### PR TITLE
polish: drawings persistence + above-view interactions

### DIFF
--- a/src/main/runtime/gate-predicate.ts
+++ b/src/main/runtime/gate-predicate.ts
@@ -60,11 +60,22 @@ function hasFloatingMenu(inputs: GateInputs): boolean {
 }
 
 /**
- * Saved drawings render above frames unless a frame is selected (then we
- * yield so the user can interact with the frame's webContents natively).
+ * Saved drawings render above frames. We only yield the gate when a SINGLE
+ * frame is selected — that's the case where the user wants to interact with
+ * the frame's webContents natively (scroll, click links, etc.). Multi-select
+ * with a frame is a canvas-level gesture (drag, resize a group), not a frame
+ * interaction, so drawings should stay visible.
+ *
+ * We also yield when the user is in a tool mode that needs the frame's
+ * webContents to receive events (comment hover, inspect eyedropper).
+ * Pending-placement keeps the gate open so drawings stay visible while
+ * placing — above-view handles the placement preview and commit itself.
  */
 function hasVisibleSavedDrawings(inputs: GateInputs): boolean {
   if (!inputs.hasSavedDrawings) return false
-  const frameSelected = inputs.selectedEntityKinds.some((k) => k === 'frame')
-  return !frameSelected
+  if (inputs.toolMode !== 'select') return false
+  const singleFrameSelected =
+    inputs.selectedEntityIds.length === 1 &&
+    inputs.selectedEntityKinds[0] === 'frame'
+  return !singleFrameSelected
 }

--- a/src/main/runtime/json-canvas-serializer.ts
+++ b/src/main/runtime/json-canvas-serializer.ts
@@ -10,6 +10,7 @@ import type {
   BrowserTabMode,
   DevtoolsPanelTab,
   PersistedCanvasEntity,
+  PersistedDrawingEntity,
   PersistedFileEntity,
   PersistedFrameEntity,
   PersistedGroupEntity,
@@ -20,6 +21,7 @@ import type {
 } from '../../shared/types'
 import type {
   JsonCanvasDocument,
+  JsonCanvasDrawingNode,
   JsonCanvasEdge,
   JsonCanvasFileNode,
   JsonCanvasGroupNode,
@@ -80,6 +82,8 @@ export function serializeToJsonCanvas(
       nodes.push(serializeFileToFileNode(entity))
     } else if (entity.kind === 'group') {
       nodes.push(serializeGroupEntityToGroupNode(entity))
+    } else if (entity.kind === 'drawing') {
+      nodes.push(serializeDrawingToDrawingNode(entity))
     }
   }
 
@@ -148,6 +152,20 @@ function serializeFileToFileNode(entity: PersistedFileEntity): JsonCanvasFileNod
     height: entity.height,
     file: entity.file,
     subpath: entity.subpath,
+  }
+}
+
+function serializeDrawingToDrawingNode(entity: PersistedDrawingEntity): JsonCanvasDrawingNode {
+  return {
+    id: entity.id,
+    type: 'drawing',
+    x: entity.canvasX,
+    y: entity.canvasY,
+    width: entity.width,
+    height: entity.height,
+    strokes: entity.strokes,
+    label: entity.label,
+    parentGroupId: entity.parentGroupId,
   }
 }
 
@@ -227,6 +245,10 @@ export function deserializeFromJsonCanvas(doc: JsonCanvasDocument): {
       const entity = deserializeGroupNodeToGroup(node)
       entities[entity.id] = entity
       entityOrder.push(entity.id)
+    } else if (node.type === 'drawing') {
+      const entity = deserializeDrawingNodeToDrawing(node)
+      entities[entity.id] = entity
+      entityOrder.push(entity.id)
     }
   }
 
@@ -295,6 +317,20 @@ function deserializeFileNodeToFile(node: JsonCanvasFileNode): PersistedFileEntit
     canvasY: node.y,
     width: node.width,
     height: node.height,
+  }
+}
+
+function deserializeDrawingNodeToDrawing(node: JsonCanvasDrawingNode): PersistedDrawingEntity {
+  return {
+    kind: 'drawing',
+    id: node.id,
+    canvasX: node.x,
+    canvasY: node.y,
+    width: node.width,
+    height: node.height,
+    strokes: node.strokes,
+    label: node.label,
+    parentGroupId: node.parentGroupId,
   }
 }
 

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -6,11 +6,16 @@ import type {
   ThemeData,
 } from '../../shared/types'
 import {
+  isOverlayUiTarget,
   normalizeRect,
+  screenPointToCanvasPoint,
   screenRectToCanvasRect,
+  snapToGrid,
 } from '../../shared/gesture-utils'
 import { TOOLBAR_HEIGHT } from '../../shared/constants'
 import { DRAW_CURSOR } from '../canvas-bg/canvasBgConstants'
+import { PlacementPreviewLayer } from '../canvas-bg/CanvasGridSurface'
+import { buildPendingPlacementPreview } from '../canvas-bg/canvasBgSelectors'
 import { DrawingLayer, SavedDrawingEntities } from './DrawingsLayer'
 import { RegionSelectAnnotations } from './AnnotationsLayer'
 import {
@@ -120,6 +125,49 @@ export default function App({
   )
   const hasSavedDrawings =
     !hasSelectedFrame && layoutData.entities.some((e) => e.kind === 'drawing')
+
+  // Above-view owns placement preview whenever its gate is open (saved
+  // drawings force us to cover the canvas, so canvas-bg can't see the
+  // pointer). Tracks cursor from window pointermove and commits on click.
+  // Above-view's pointer events are relative to its origin at canvasOrigin.y,
+  // so we add that offset to get the window-relative coords that
+  // buildPendingPlacementPreview expects.
+  const pendingPlacement = layoutData.pendingPlacement
+  const [placementCursor, setPlacementCursor] = useState<{
+    clientX: number
+    clientY: number
+  } | null>(null)
+  useEffect(() => {
+    if (!pendingPlacement) {
+      setPlacementCursor(null)
+      return
+    }
+    if (
+      pendingPlacement.initialClientX !== null &&
+      pendingPlacement.initialClientY !== null
+    ) {
+      setPlacementCursor({
+        clientX: pendingPlacement.initialClientX,
+        clientY: pendingPlacement.initialClientY,
+      })
+    }
+  }, [pendingPlacement])
+  useEffect(() => {
+    if (!pendingPlacement) return
+    const handlePointerMove = (event: PointerEvent) => {
+      if (isOverlayUiTarget(event.target)) return
+      setPlacementCursor({
+        clientX: event.clientX,
+        clientY: event.clientY + layoutRef.current.canvasOrigin.y,
+      })
+    }
+    window.addEventListener('pointermove', handlePointerMove)
+    return () => window.removeEventListener('pointermove', handlePointerMove)
+  }, [pendingPlacement])
+  const placementPreview = useMemo(
+    () => buildPendingPlacementPreview(layoutData, placementCursor),
+    [layoutData, placementCursor],
+  )
 
   const {
     consumeSuppressedAnnotationClick,
@@ -244,6 +292,63 @@ export default function App({
     [layoutRef],
   )
 
+  // Hover hit-test over any interactive entity kind. Above-view intercepts
+  // pointer events whenever the gate is open (e.g. saved drawings present),
+  // so canvas-bg's chrome-level mouseenter/leave never fires — we forward
+  // hover changes through api.hoverFrame.
+  const hitTestHoverTarget = useCallback(
+    (clientX: number, clientY: number): string | null => {
+      const layout = layoutRef.current
+      const windowY = clientY + layout.canvasOrigin.y
+      const FRAME_CHROME = 44
+      for (let i = layout.entities.length - 1; i >= 0; i--) {
+        const e = layout.entities[i]
+        if (e.kind === 'group' || e.kind === 'drawing') continue
+        const top = e.kind === 'frame' ? e.screenY - FRAME_CHROME : e.screenY
+        const bottom = e.screenY + e.screenHeight
+        if (
+          clientX >= e.screenX &&
+          clientX <= e.screenX + e.screenWidth &&
+          windowY >= top &&
+          windowY <= bottom
+        ) {
+          return e.id
+        }
+      }
+      return null
+    },
+    [layoutRef],
+  )
+  const lastHoverIdRef = useRef<string | null>(null)
+  const hoverForwardingEnabled = layoutData.annotationMode !== 'draw'
+  useEffect(() => {
+    const clearHover = () => {
+      if (lastHoverIdRef.current === null) return
+      lastHoverIdRef.current = null
+      api.hoverFrame(null)
+    }
+    if (!hoverForwardingEnabled) {
+      clearHover()
+      return
+    }
+    const handleMove = (event: PointerEvent) => {
+      if (isOverlayUiTarget(event.target)) return
+      const nextId = hitTestHoverTarget(event.clientX, event.clientY)
+      if (nextId === lastHoverIdRef.current) return
+      lastHoverIdRef.current = nextId
+      api.hoverFrame(nextId)
+    }
+    window.addEventListener('pointermove', handleMove)
+    window.addEventListener('pointerleave', clearHover)
+    window.addEventListener('blur', clearHover)
+    return () => {
+      window.removeEventListener('pointermove', handleMove)
+      window.removeEventListener('pointerleave', clearHover)
+      window.removeEventListener('blur', clearHover)
+      clearHover()
+    }
+  }, [hitTestHoverTarget, hoverForwardingEnabled])
+
   const onFramePointerDown = useCallback(
     (frameId: string, event: MouseEvent) => {
       api.selectFrame(frameId)
@@ -270,13 +375,37 @@ export default function App({
     [],
   )
 
-  const dragMode: 'region_select' | 'marquee' | null = !overlayInteractive
-    ? layoutData.annotationMode === 'region_select'
-      ? 'region_select'
-      : hasSavedDrawings
-        ? 'marquee'
-        : null
-    : null
+  const placementClickAt = useCallback(
+    (screenX: number, screenY: number) => {
+      const layout = layoutRef.current
+      const point = screenPointToCanvasPoint(
+        screenX,
+        screenY + layout.canvasOrigin.y,
+        layout,
+      )
+      api.placePendingEntity(snapToGrid(point.x), snapToGrid(point.y))
+    },
+    [],
+  )
+
+  // Above-view's pointer events are relative to its origin (canvasOrigin.y
+  // below the toolbar), but main's canvas-click-at expects window-relative
+  // coords — adjust Y before forwarding.
+  const canvasClickAtFromAboveView = useCallback(
+    (screenX: number, screenY: number) => {
+      api.canvasClickAt(screenX, screenY + layoutRef.current.canvasOrigin.y)
+    },
+    [],
+  )
+
+  const dragMode: 'region_select' | 'marquee' | null =
+    !overlayInteractive && !pendingPlacement
+      ? layoutData.annotationMode === 'region_select'
+        ? 'region_select'
+        : hasSavedDrawings
+          ? 'marquee'
+          : null
+      : null
   const activeDragMove =
     dragMode === 'region_select' ? onDragMove : dragMode === 'marquee' ? onMarqueeMove : undefined
   const activeDragEnd =
@@ -285,14 +414,29 @@ export default function App({
     () => ({
       canvasZoom: api.canvasZoom,
       canvasPan: api.canvasPan,
-      canvasDeselect: overlayInteractive ? undefined : api.canvasDeselect,
-      canvasClickAt: overlayInteractive || activeDragMove ? undefined : api.canvasClickAt,
+      canvasDeselect: overlayInteractive || pendingPlacement ? undefined : api.canvasDeselect,
+      canvasClickAt: overlayInteractive
+        ? undefined
+        : pendingPlacement
+          ? placementClickAt
+          : canvasClickAtFromAboveView,
       onDragMove: activeDragMove,
       onDragEnd: activeDragEnd,
-      hitTestFrame: overlayInteractive ? undefined : hitTestFrame,
-      onFramePointerDown: overlayInteractive ? undefined : onFramePointerDown,
+      hitTestFrame: overlayInteractive || pendingPlacement ? undefined : hitTestFrame,
+      onFramePointerDown:
+        overlayInteractive || pendingPlacement ? undefined : onFramePointerDown,
     }),
-    [api, overlayInteractive, activeDragMove, activeDragEnd, hitTestFrame, onFramePointerDown],
+    [
+      api,
+      overlayInteractive,
+      pendingPlacement,
+      placementClickAt,
+      canvasClickAtFromAboveView,
+      activeDragMove,
+      activeDragEnd,
+      hitTestFrame,
+      onFramePointerDown,
+    ],
   )
   // Always enabled: when the overlay has zero bounds (main's gate closed),
   // the renderer DOM receives no events, so listener attachment is a no-op.
@@ -340,11 +484,21 @@ export default function App({
         layoutData={layoutData}
         selectedEntityIds={layoutData.selectedEntityIds}
         onSelect={
-          layoutData.annotationMode === 'off'
+          layoutData.annotationMode === 'off' && layoutData.pendingPlacement === null
             ? (id) => api.selectEntity(id, 'drawing')
             : undefined
         }
       />
+
+      {placementPreview ? (
+        <PlacementPreviewLayer
+          isDark={isDark}
+          preview={{
+            ...placementPreview,
+            top: placementPreview.top - layoutData.canvasOrigin.y,
+          }}
+        />
+      ) : null}
 
       {!captureMode ? (
         <>

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -126,12 +126,10 @@ export default function App({
   const hasSavedDrawings =
     !hasSelectedFrame && layoutData.entities.some((e) => e.kind === 'drawing')
 
-  // Above-view owns placement preview whenever its gate is open (saved
-  // drawings force us to cover the canvas, so canvas-bg can't see the
-  // pointer). Tracks cursor from window pointermove and commits on click.
-  // Above-view's pointer events are relative to its origin at canvasOrigin.y,
-  // so we add that offset to get the window-relative coords that
-  // buildPendingPlacementPreview expects.
+  // Above-view covers the canvas when saved drawings are present, so canvas-bg
+  // can't see pointermove — above-view owns placement preview here. Seed from
+  // the toolbar click that started placement; merged pointer handler below
+  // keeps it updated.
   const pendingPlacement = layoutData.pendingPlacement
   const [placementCursor, setPlacementCursor] = useState<{
     clientX: number
@@ -151,18 +149,6 @@ export default function App({
         clientY: pendingPlacement.initialClientY,
       })
     }
-  }, [pendingPlacement])
-  useEffect(() => {
-    if (!pendingPlacement) return
-    const handlePointerMove = (event: PointerEvent) => {
-      if (isOverlayUiTarget(event.target)) return
-      setPlacementCursor({
-        clientX: event.clientX,
-        clientY: event.clientY + layoutRef.current.canvasOrigin.y,
-      })
-    }
-    window.addEventListener('pointermove', handlePointerMove)
-    return () => window.removeEventListener('pointermove', handlePointerMove)
   }, [pendingPlacement])
   const placementPreview = useMemo(
     () => buildPendingPlacementPreview(layoutData, placementCursor),
@@ -266,44 +252,20 @@ export default function App({
     [api, layoutRef],
   )
 
-  const hitTestFrame = useCallback(
-    (clientX: number, clientY: number): string | null => {
-      const layout = layoutRef.current
-      // Above-view WCV origin is at canvasOrigin.y; scene entities use
-      // screenY in window coords, so add canvasOrigin.y to clientY.
-      const windowY = clientY + layout.canvasOrigin.y
-      const FRAME_CHROME = 44
-      for (let i = layout.entities.length - 1; i >= 0; i--) {
-        const e = layout.entities[i]
-        if (e.kind !== 'frame') continue
-        const top = e.screenY - FRAME_CHROME
-        const bottom = e.screenY + e.screenHeight
-        if (
-          clientX >= e.screenX &&
-          clientX <= e.screenX + e.screenWidth &&
-          windowY >= top &&
-          windowY <= bottom
-        ) {
-          return e.id
-        }
-      }
-      return null
-    },
-    [layoutRef],
-  )
-
-  // Hover hit-test over any interactive entity kind. Above-view intercepts
-  // pointer events whenever the gate is open (e.g. saved drawings present),
-  // so canvas-bg's chrome-level mouseenter/leave never fires — we forward
-  // hover changes through api.hoverFrame.
-  const hitTestHoverTarget = useCallback(
-    (clientX: number, clientY: number): string | null => {
+  // Above-view WCV origin sits at canvasOrigin.y; scene entities use screenY
+  // in window coords, so we add canvasOrigin.y to clientY before bounds checks.
+  const hitTestEntity = useCallback(
+    (
+      clientX: number,
+      clientY: number,
+      accept: (kind: string) => boolean,
+    ): string | null => {
       const layout = layoutRef.current
       const windowY = clientY + layout.canvasOrigin.y
       const FRAME_CHROME = 44
       for (let i = layout.entities.length - 1; i >= 0; i--) {
         const e = layout.entities[i]
-        if (e.kind === 'group' || e.kind === 'drawing') continue
+        if (!accept(e.kind)) continue
         const top = e.kind === 'frame' ? e.screenY - FRAME_CHROME : e.screenY
         const bottom = e.screenY + e.screenHeight
         if (
@@ -319,6 +281,20 @@ export default function App({
     },
     [layoutRef],
   )
+  const hitTestFrame = useCallback(
+    (clientX: number, clientY: number) =>
+      hitTestEntity(clientX, clientY, (k) => k === 'frame'),
+    [hitTestEntity],
+  )
+  const hitTestHoverTarget = useCallback(
+    (clientX: number, clientY: number) =>
+      hitTestEntity(clientX, clientY, (k) => k !== 'group' && k !== 'drawing'),
+    [hitTestEntity],
+  )
+
+  // One window pointermove handler drives both placement-preview cursor and
+  // hover forwarding. When above-view intercepts events (gate open), canvas-bg
+  // never sees mouseenter/leave, so we dedupe and forward via api.hoverFrame.
   const lastHoverIdRef = useRef<string | null>(null)
   const hoverForwardingEnabled = layoutData.annotationMode !== 'draw'
   useEffect(() => {
@@ -327,16 +303,25 @@ export default function App({
       lastHoverIdRef.current = null
       api.hoverFrame(null)
     }
-    if (!hoverForwardingEnabled) {
+    if (!pendingPlacement && !hoverForwardingEnabled) {
       clearHover()
       return
     }
     const handleMove = (event: PointerEvent) => {
       if (isOverlayUiTarget(event.target)) return
-      const nextId = hitTestHoverTarget(event.clientX, event.clientY)
-      if (nextId === lastHoverIdRef.current) return
-      lastHoverIdRef.current = nextId
-      api.hoverFrame(nextId)
+      if (pendingPlacement) {
+        setPlacementCursor({
+          clientX: event.clientX,
+          clientY: event.clientY + layoutRef.current.canvasOrigin.y,
+        })
+      }
+      if (hoverForwardingEnabled) {
+        const nextId = hitTestHoverTarget(event.clientX, event.clientY)
+        if (nextId !== lastHoverIdRef.current) {
+          lastHoverIdRef.current = nextId
+          api.hoverFrame(nextId)
+        }
+      }
     }
     window.addEventListener('pointermove', handleMove)
     window.addEventListener('pointerleave', clearHover)
@@ -347,7 +332,7 @@ export default function App({
       window.removeEventListener('blur', clearHover)
       clearHover()
     }
-  }, [hitTestHoverTarget, hoverForwardingEnabled])
+  }, [api, hitTestHoverTarget, hoverForwardingEnabled, layoutRef, pendingPlacement])
 
   const onFramePointerDown = useCallback(
     (frameId: string, event: MouseEvent) => {

--- a/src/renderer/canvas-bg/App.tsx
+++ b/src/renderer/canvas-bg/App.tsx
@@ -308,6 +308,7 @@ export default function App({
             zoom={layoutData.zoom}
             selectedIdSet={selectedEntityIdSet}
             marqueePreviewIds={marqueePreviewIds}
+            hoveredEntityId={hoveredEntityId}
             onFrameMouseDown={handleChromeMouseDown}
             onResizeFrame={(id, patch) => api.updateFrameBounds(id, patch)}
             onResizeTextEntity={(id, patch) => api.updateTextEntity(id, patch)}

--- a/src/renderer/canvas-bg/CanvasSelectionLayers.tsx
+++ b/src/renderer/canvas-bg/CanvasSelectionLayers.tsx
@@ -270,6 +270,7 @@ export function CanvasSelectionOutlineLayer({
   zoom,
   selectedIdSet,
   marqueePreviewIds,
+  hoveredEntityId,
   onFrameMouseDown,
   onResizeFrame,
   onResizeTextEntity,
@@ -287,6 +288,10 @@ export function CanvasSelectionOutlineLayer({
   zoom: number
   selectedIdSet: Set<string>
   marqueePreviewIds: Set<string> | null
+  /** Main-authoritative hover id from layoutData.hover. Used as a fallback
+   *  when SelectableEntityShell's mouseenter/leave can't fire (e.g. when
+   *  above-view is covering the canvas because saved drawings are visible). */
+  hoveredEntityId: string | null
   onFrameMouseDown: (frameId: string, event: React.MouseEvent) => void
   onResizeFrame: (id: string, patch: EntityResizePatch) => void
   onResizeTextEntity: (id: string, patch: EntityResizePatch) => void
@@ -295,7 +300,8 @@ export function CanvasSelectionOutlineLayer({
   onResizeMulti: (entries: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing'; width: number; height: number; canvasX: number; canvasY: number }>) => void
   onDrawingMouseDown: (drawingId: string, event: React.MouseEvent) => void
 }) {
-  const entityHoverId = useContext(EntityHoverValueContext)
+  const localHoverId = useContext(EntityHoverValueContext)
+  const entityHoverId = localHoverId ?? hoveredEntityId
   const isMultiSelect = selectedIdSet.size > 1
   const entities = useMemo(
     () => [...allTextEntities, ...allFileEntities, ...allDrawingEntities].filter(

--- a/src/shared/json-canvas-types.ts
+++ b/src/shared/json-canvas-types.ts
@@ -13,7 +13,7 @@ export type CanvasColor = '1' | '2' | '3' | '4' | '5' | '6' | (string & {})
 
 export interface JsonCanvasNodeBase {
   id: string
-  type: 'text' | 'link' | 'file' | 'group'
+  type: 'text' | 'link' | 'file' | 'group' | 'drawing'
   x: number
   y: number
   width: number
@@ -62,15 +62,27 @@ export interface JsonCanvasGroupNode extends JsonCanvasNodeBase {
   groupMetadata?: Record<string, unknown>
 }
 
+/**
+ * Drawing node (Telescope extension). Other JSON Canvas tools ignore
+ * unknown `type` values per the spec's extensibility model.
+ */
+export interface JsonCanvasDrawingNode extends JsonCanvasNodeBase {
+  type: 'drawing'
+  strokes: AnnotationDrawingStroke[]
+  label?: string
+  parentGroupId?: string
+}
+
 export type JsonCanvasNode =
   | JsonCanvasTextNode
   | JsonCanvasLinkNode
   | JsonCanvasFileNode
   | JsonCanvasGroupNode
+  | JsonCanvasDrawingNode
 
 // --- Edges ---
 
-import type { EdgeSide, EdgeEnd } from './types'
+import type { AnnotationDrawingStroke, EdgeSide, EdgeEnd } from './types'
 export type { EdgeSide, EdgeEnd }
 
 export interface JsonCanvasEdge {

--- a/tests/unit/gate-predicate.test.ts
+++ b/tests/unit/gate-predicate.test.ts
@@ -117,7 +117,7 @@ describe('shouldGateBeOpen', () => {
     expect(shouldGateBeOpen({ ...base(), hasSavedDrawings: true })).toBe(true)
   })
 
-  it('closed when saved drawings exist but a frame is selected', () => {
+  it('closed when saved drawings exist but a single frame is selected', () => {
     expect(
       shouldGateBeOpen({
         ...base(),
@@ -127,4 +127,28 @@ describe('shouldGateBeOpen', () => {
       }),
     ).toBe(false)
   })
+
+  it('open when saved drawings exist and multi-selection includes a frame', () => {
+    expect(
+      shouldGateBeOpen({
+        ...base(),
+        hasSavedDrawings: true,
+        selectedEntityIds: ['f1', 't1'],
+        selectedEntityKinds: ['frame', 'text'],
+      }),
+    ).toBe(true)
+  })
+
+  it.each(['inspect', 'annotate-comment'] as const)(
+    'closed when saved drawings exist but toolMode is %s',
+    (toolMode) => {
+      expect(
+        shouldGateBeOpen({
+          ...base(),
+          toolMode,
+          hasSavedDrawings: true,
+        }),
+      ).toBe(false)
+    },
+  )
 })

--- a/tests/unit/json-canvas-serializer.test.ts
+++ b/tests/unit/json-canvas-serializer.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import {
+  serializeToJsonCanvas,
+  deserializeFromJsonCanvas,
+} from '../../src/main/runtime/json-canvas-serializer'
+import type {
+  PersistedDrawingEntity,
+  WorkspaceSnapshot,
+} from '../../src/shared/types'
+
+function emptySnapshot(): WorkspaceSnapshot {
+  return {
+    zoom: 1,
+    pan: { x: 0, y: 0 },
+    pages: [],
+    entities: {},
+    entityOrder: [],
+    selectedPageIndex: null,
+    devtoolsOpen: false,
+    devtoolsWidth: 400,
+  }
+}
+
+describe('json-canvas-serializer drawings', () => {
+  const drawing: PersistedDrawingEntity = {
+    kind: 'drawing',
+    id: 'd1',
+    canvasX: 100,
+    canvasY: 200,
+    width: 300,
+    height: 150,
+    label: 'sketch',
+    strokes: [
+      {
+        id: 's1',
+        color: '#ff0000',
+        width: 2,
+        points: [
+          { x: 0, y: 0 },
+          { x: 10, y: 10 },
+        ],
+      },
+    ],
+  }
+
+  it('round-trips drawing entities through JSON Canvas', () => {
+    const snapshot = emptySnapshot()
+    snapshot.entities!['d1'] = drawing
+    snapshot.entityOrder = ['d1']
+
+    const doc = serializeToJsonCanvas(snapshot)
+    expect(doc.nodes).toHaveLength(1)
+    expect(doc.nodes[0]).toMatchObject({ type: 'drawing', id: 'd1' })
+
+    const { snapshot: restored } = deserializeFromJsonCanvas(doc)
+    expect(restored.entities?.['d1']).toEqual(drawing)
+    expect(restored.entityOrder).toEqual(['d1'])
+  })
+
+  it('preserves drawing z-order among other entities', () => {
+    const snapshot = emptySnapshot()
+    snapshot.entities!['t1'] = {
+      kind: 'text',
+      id: 't1',
+      text: 'hello',
+      color: '3',
+      canvasX: 0,
+      canvasY: 0,
+      width: 100,
+      height: 50,
+    }
+    snapshot.entities!['d1'] = drawing
+    snapshot.entityOrder = ['t1', 'd1']
+
+    const doc = serializeToJsonCanvas(snapshot)
+    expect(doc.nodes.map((n) => n.id)).toEqual(['t1', 'd1'])
+
+    const { snapshot: restored } = deserializeFromJsonCanvas(doc)
+    expect(restored.entityOrder).toEqual(['t1', 'd1'])
+  })
+})


### PR DESCRIPTION
## Summary

- **Fix drawing persistence**: the JSON Canvas serializer skipped `kind === 'drawing'`, so strokes were silently dropped on every `.canvas` write and canvases came back empty after reboot. Added a `type: 'drawing'` node (Telescope extension) with serialize/deserialize branches and a round-trip unit test.
- **Tighten drawing gate**: only yield the gate for a single selected frame (multi-select is a canvas gesture) and keep the gate closed whenever a non-select tool mode is active.
- **Above-view drawing interactions**: when saved drawings force above-view to cover the canvas, it now owns placement preview, hover forwarding, and click forwarding. Canvas-bg falls back to main's authoritative `hoveredEntityId` when its own mouseenter/leave can't fire.
- **Simplify pass**: merged the two window `pointermove` listeners (placement + hover) into one shared handler and unified `hitTestFrame` / `hitTestHoverTarget` via a shared `hitTestEntity` helper.

## Test plan

- [ ] Create drawings, quit the app, relaunch — drawings should load from the `.canvas` file
- [ ] Hover frames, text, and file entities while saved drawings are present — hover outline should follow the cursor
- [ ] Multi-select a frame + another entity — drawings should remain visible/interactive
- [ ] Switch to inspect / annotate-comment tool modes while drawings are present — gate should stay closed (frames receive events natively)
- [ ] Place a new text/file entity from the toolbar while saved drawings are present — placement preview tracks cursor and commit lands at the clicked point
- [ ] `pnpm typecheck` + `pnpm test:unit` both clean (151 passing locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)