### PR TITLE
fix: frame crash guard and region-select over frames

### DIFF
--- a/src/main/ipc/register-canvas-ipc.ts
+++ b/src/main/ipc/register-canvas-ipc.ts
@@ -6,7 +6,7 @@ import { pages } from '../runtime/page-runtime'
 import { aboveView } from '../runtime/view-refs'
 import { setCommentOverlayActive } from '../runtime/runtime-core'
 import { setHoverEntity, setHoveredFrame } from '../runtime/runtime-core'
-import { selectedCanvasTargets as uiSelectedCanvasTargets } from '../ui-state'
+import { annotationMode as uiAnnotationMode, selectedCanvasTargets as uiSelectedCanvasTargets } from '../ui-state'
 import {
   canvasOrigin,
   layoutAllViews,
@@ -138,6 +138,7 @@ export function registerCanvasIpc(): void {
 
   ipcMain.on('canvas-hover-frame', (_event, { frameId }: { frameId: string | null }) => {
     if (interactionBlocksPageHover()) return
+    if (uiAnnotationMode() === 'region_select') return
     setHoveredFrame(frameId)
   })
 

--- a/src/main/ipc/register-page-chrome-ipc.ts
+++ b/src/main/ipc/register-page-chrome-ipc.ts
@@ -29,6 +29,7 @@ import {
   interactionBlocksPageHover,
   interactionBlocksPageSelection,
 } from '../runtime/interaction-state'
+import { annotationMode as uiAnnotationMode } from '../ui-state'
 import { tryEnter, commitActive, cancelActive } from '../runtime/interaction-controller'
 import {
   findPageByPageView,
@@ -82,6 +83,7 @@ export function registerPageChromeIpc(): void {
 
   ipcMain.on('frame-hover', (event, hovered: boolean) => {
     if (interactionBlocksPageHover()) return
+    if (uiAnnotationMode() === 'region_select') return
     const page = pages.find((candidate) => candidate.pageView.webContents === event.sender)
     setHoverEntity(hovered && page ? { id: page.id, kind: 'frame' } : null)
   })

--- a/src/main/runtime/page-factory.ts
+++ b/src/main/runtime/page-factory.ts
@@ -151,7 +151,23 @@ export function createPage(config: PageConfig): Page {
   })
   page.pageView.webContents.on('did-start-loading', () => {
     selectionDebug('page:did-start-loading', { pageId: page.id, url: page.pageView.webContents.getURL() })
+    page.crashedAt = undefined
+    page.crashReason = undefined
     requestLayout()
+  })
+  page.pageView.webContents.on('render-process-gone', (_event, details) => {
+    page.crashedAt = Date.now()
+    page.crashReason = details.reason
+    breadcrumb('page', 'render-process-gone', {
+      host: hostOf(page.url),
+      reason: details.reason,
+      exitCode: details.exitCode,
+    })
+    selectionDebug('page:render-process-gone', { pageId: page.id, ...details })
+  })
+  page.pageView.webContents.on('unresponsive', () => {
+    breadcrumb('page', 'unresponsive', { host: hostOf(page.url) })
+    selectionDebug('page:unresponsive', { pageId: page.id })
   })
   page.pageView.webContents.on('did-stop-loading', () => {
     selectionDebug('page:did-stop-loading', { pageId: page.id, url: page.pageView.webContents.getURL() })

--- a/src/main/runtime/runtime-entities.ts
+++ b/src/main/runtime/runtime-entities.ts
@@ -44,6 +44,8 @@ export interface Page {
   lastSelected?: boolean
   lastSafeAreaCssKey?: string
   lastSafeAreaCssId?: string
+  crashedAt?: number
+  crashReason?: string
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main/runtime/runtime-entities.ts
+++ b/src/main/runtime/runtime-entities.ts
@@ -45,7 +45,7 @@ export interface Page {
   lastSafeAreaCssKey?: string
   lastSafeAreaCssId?: string
   crashedAt?: number
-  crashReason?: string
+  crashReason?: Electron.RenderProcessGoneDetails['reason']
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main/runtime/safe-send.ts
+++ b/src/main/runtime/safe-send.ts
@@ -1,7 +1,7 @@
 import type { WebContents } from 'electron'
 
 export function safeSend(wc: WebContents, channel: string, ...args: unknown[]): void {
-  if (wc.isDestroyed()) return
+  if (wc.isDestroyed() || wc.isCrashed()) return
   try {
     wc.send(channel, ...args)
   } catch {

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -296,7 +296,8 @@ export default function App({
   // hover forwarding. When above-view intercepts events (gate open), canvas-bg
   // never sees mouseenter/leave, so we dedupe and forward via api.hoverFrame.
   const lastHoverIdRef = useRef<string | null>(null)
-  const hoverForwardingEnabled = layoutData.annotationMode !== 'draw'
+  const hoverForwardingEnabled =
+    layoutData.annotationMode !== 'draw' && layoutData.annotationMode !== 'region_select'
   useEffect(() => {
     const clearHover = () => {
       if (lastHoverIdRef.current === null) return
@@ -407,9 +408,14 @@ export default function App({
           : canvasClickAtFromAboveView,
       onDragMove: activeDragMove,
       onDragEnd: activeDragEnd,
-      hitTestFrame: overlayInteractive || pendingPlacement ? undefined : hitTestFrame,
+      hitTestFrame:
+        overlayInteractive || pendingPlacement || dragMode === 'region_select'
+          ? undefined
+          : hitTestFrame,
       onFramePointerDown:
-        overlayInteractive || pendingPlacement ? undefined : onFramePointerDown,
+        overlayInteractive || pendingPlacement || dragMode === 'region_select'
+          ? undefined
+          : onFramePointerDown,
     }),
     [
       api,
@@ -419,6 +425,7 @@ export default function App({
       canvasClickAtFromAboveView,
       activeDragMove,
       activeDragEnd,
+      dragMode,
       hitTestFrame,
       onFramePointerDown,
     ],


### PR DESCRIPTION
## Summary

- **Frame crash containment**: `safeSend` now checks `wc.isCrashed()` to suppress the stderr spam cascade after a renderer OOM/crash. Per-page `render-process-gone` and `unresponsive` listeners add frame-level Sentry breadcrumbs and mark `page.crashedAt`/`crashReason` for future UI surfacing. Flags clear on `did-start-loading` so manual reload recovers cleanly.
- **Region-select drag over frames**: `useViewportForwarding` was hit-testing frames on mousedown and routing to `onFramePointerDown` (frame-move), preempting the region-select rect drag when starting inside a frame. Now skips hit-test and hover forwarding in `region_select` mode, and gates both `frame-hover` IPC handlers so hover state doesn't leak during area annotation.

## Test plan

- [ ] Open a frame, enter area annotation mode, mousedown inside the frame — should start region rect drag
- [ ] Drag the rect over a frame — no hover outline should appear
- [ ] Exit area annotation mode — frame should be interactive again (click links, scroll)
- [ ] Trigger a renderer crash (e.g. OOM page) — no stderr cascade, `errors.log` has frame-level detail
- [ ] After crash, reload the frame via chrome header URL bar — should recover cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)