### PR TITLE
docs: add README, SECURITY, and development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All this stuff is designed with collaboration in mind, so it's easy to vibe out 
 - **Edges & connections** — Draw connections between entities on the canvas
 - **Undo/redo** — Full undo history backed by Yjs CRDTs
 - **Local-first storage** — No sign-in, no account. All files live on your computer
-- **Open file formats** — Canvas layout uses Obsidian's `.canvas` spec; text and media are plain `.md`, `.png`, and `.webm` files that live on your computer in a folder.
+- **Open file formats** — Canvas layout uses the [JSON Canvas](https://jsoncanvas.org) spec (also used by Obsidian); text and media are plain `.md`, `.png`, and `.webm` files that live on your computer in a folder.
 
 ## Inspiration and related products
 - [Paper](https://paper.design): best full-featured design tool with agent collaboration

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Part web browser and part canvas, telescope is a hybrid design tool for thinking through ideas spatially and iterating on software. 
 
-Code is the source of truth for making ideas real, but long chat threads and single browser tabs aren't ideal for the exploratory, divergent, and visual thinking thats often required to design something great. A canvas is a much more familiar place for this type of work, but there's a gap between what you see on the canvas and what is built. There's lots of products and tools that bridge this gap in variety of ways, but there's always some level of friction moving back and fourth between canvas and code.
+Code is the source of truth for making ideas real, but long chat threads and single browser tabs aren't ideal for the exploratory, divergent, and visual thinking that's often required to design something great. A canvas is a much more familiar place for this type of work, but there's a gap between what you see on the canvas and what is built. There's lots of products and tools that bridge this gap in a variety of ways, but there's always some level of friction moving back and forth between canvas and code.
 
-Telescope sidesteps this disconnect with a different approach: full featured browser tabs on a canvas. The actual website, product, or prototype lives spatially alongside notes, images, and drawings making it easy to build and explore in one place.
+Telescope sidesteps this disconnect with a different approach: full-featured browser tabs on a canvas. The actual website, product, or prototype lives spatially alongside notes, images, and drawings making it easy to build and explore in one place.
 
-All this stuff is designed with collaboration in mind, so its easy to vibe out designs, research, and more as you work with teams of people and agents.
+All this stuff is designed with collaboration in mind, so it's easy to vibe out designs, research, and more as you work with teams of people and agents.
 
 <!-- TODO: Add screenshot or GIF demo here -->
 
@@ -20,7 +20,7 @@ All this stuff is designed with collaboration in mind, so its easy to vibe out d
 
 ## Key features
 
-- **Canvas** — Arrange real browser windows on an infinite, zoomable canvas
+- **Canvas** — Arrange real browser windows on an infinite, zoomable canvas.
 - **Agent-friendly** — Agents drive the canvas through a `telescope` CLI (primary) or an MCP server (fallback) — creating frames, navigating, inspecting the DOM, clicking, typing, and taking screenshots
 - **Agent presence** — See an agent's live cursor and task status as it works alongside you
 - **Commenting & annotations** — Create annotations on any frame, usable by people and agents
@@ -32,10 +32,10 @@ All this stuff is designed with collaboration in mind, so its easy to vibe out d
 - **Open file formats** — Canvas layout uses Obsidian's `.canvas` spec; text and media are plain `.md`, `.png`, and `.webm` files that live on your computer in a folder.
 
 ## Inspiration and related products
-- [Paper](https://paper.design): best full featured design tool with agent collaboration
-- [Agentation](https://agentation.com): for visual edits and commenting
+- [Paper](https://paper.design): best full-featured design tool with agent collaboration
+- [Agentation](https://agentation.com): inspiration for visual edits and commenting
 - [Polypane](https://polypane.app): for viewing a webpage across multiple breakpoints in one place
-- [Obsidian](https://obsidian.md): inspiration from local storage format and their light weight canvas
+- [Obsidian](https://obsidian.md): inspiration from local storage format and its lightweight canvas
 - [agent-browser](https://agent-browser.dev): inspiration for cli based web automation
 
 ## System requirements
@@ -47,7 +47,7 @@ All this stuff is designed with collaboration in mind, so its easy to vibe out d
 
 Download the latest release from the [GitHub Releases](https://github.com/lklyne/telescope/releases) page.
 
-Updates are delivered automatically via `electron-updater`. You'll be prompted to restart when a new version is ready.
+Updates are delivered automatically via `update-electron-app`. You'll be prompted to restart when a new version is ready.
 
 ## Using with AI agents
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# Telescope
+
+Part web browser and part canvas, telescope is a hybrid design tool for thinking through ideas spatially and iterating on software. 
+
+Code is the source of truth for making ideas real, but long chat threads and single browser tabs aren't ideal for the exploratory, divergent, and visual thinking thats often required to design something great. A canvas is a much more familiar place for this type of work, but there's a gap between what you see on the canvas and what is built. There's lots of products and tools that bridge this gap in variety of ways, but there's always some level of friction moving back and fourth between canvas and code.
+
+Telescope sidesteps this disconnect with a different approach: full featured browser tabs on a canvas. The actual website, product, or prototype lives spatially alongside notes, images, and drawings making it easy to build and explore in one place.
+
+All this stuff is designed with collaboration in mind, so its easy to vibe out designs, research, and more as you work with teams of people and agents.
+
+<!-- TODO: Add screenshot or GIF demo here -->
+
+## Some ways you can use this
+1. Explore different directions and see them all side-by-side
+2. Annotate live websites with feedback and pass that directly back to an agent
+3. Create layouts with different device breakpoints to check responsiveness
+4. Ask an agent to share its thinking visually
+5. Add a repo and ingest its design system
+6. Switch to browser mode for a more classic tab-based browser
+
+## Key features
+
+- **Canvas** — Arrange real browser windows on an infinite, zoomable canvas
+- **Agent-friendly** — Agents drive the canvas through a `telescope` CLI (primary) or an MCP server (fallback) — creating frames, navigating, inspecting the DOM, clicking, typing, and taking screenshots
+- **Agent presence** — See an agent's live cursor and task status as it works alongside you
+- **Commenting & annotations** — Create annotations on any frame, usable by people and agents
+- **Device frames** — Preview sites at preset device sizes (iPhone, iPad, Laptop, etc.) with visual device shells
+- **Groups & layout** — Organize frames into groups with freeform, row, or grid layout modes
+- **Edges & connections** — Draw connections between entities on the canvas
+- **Undo/redo** — Full undo history backed by Yjs CRDTs
+- **Local-first storage** — No sign-in, no account. All files live on your computer
+- **Open file formats** — Canvas layout uses Obsidian's `.canvas` spec; text and media are plain `.md`, `.png`, and `.webm` files that live on your computer in a folder.
+
+## Inspiration and related products
+- [Paper](https://paper.design): best full featured design tool with agent collaboration
+- [Agentation](https://agentation.com): for visual edits and commenting
+- [Polypane](https://polypane.app): for viewing a webpage across multiple breakpoints in one place
+- [Obsidian](https://obsidian.md): inspiration from local storage format and their light weight canvas
+- [agent-browser](https://agent-browser.dev): inspiration for cli based web automation
+
+## System requirements
+
+- macOS 12+ (Apple Silicon or Intel)
+- Windows and Linux builds aren't currently planned
+
+## Installation
+
+Download the latest release from the [GitHub Releases](https://github.com/lklyne/telescope/releases) page.
+
+Updates are delivered automatically via `electron-updater`. You'll be prompted to restart when a new version is ready.
+
+## Using with AI agents
+
+Telescope is designed to be driven by agents as a first-class collaborator. There are two ways in:
+
+### CLI (primary)
+
+The `telescope` CLI is the main interface for agents. It exposes the full canvas surface — creating and arranging frames, snapshotting the DOM, clicking and filling fields, leaving annotations, and more — as composable commands that fit naturally into an agent's working loop.
+
+```bash
+telescope workspace                       # inspect the current canvas
+telescope create frame <url>              # pull a live page onto the canvas
+telescope snapshot -i                     # get element refs for the selected frame
+telescope annotate "<feedback>"           # leave a comment for a human or agent
+```
+
+A Claude Code skill ships with the app so agents know how to use it. See [`resources/skills/telescope/SKILL.md`](resources/skills/telescope/SKILL.md) for the full command surface.
+
+### MCP server (fallback)
+
+An MCP server is also available for clients that prefer the Model Context Protocol. It covers the same core operations as the CLI. See the [MCP tools source](src/main/mcp-tools.ts) for the tool list.
+
+## Security
+
+To report a security vulnerability, see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,5 +36,5 @@ Only the latest release is actively supported with security fixes.
 
 | Version | Supported |
 |---|---|
-| Latest alpha | Yes |
+| Latest release | Yes |
 | Older releases | No |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Telescope embeds full Chromium browser processes, so security issues are taken seriously.
+
+If you discover a security vulnerability, **please do not open a public issue.** Instead, report it privately:
+
+1. Email the maintainer directly (see GitHub profile for contact info)
+2. Or use [GitHub's private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) on this repository
+
+Please include:
+- A description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested fix (if you have one)
+
+## Response timeline
+
+- **Acknowledgment** within 72 hours
+- **Assessment and plan** within 1 week
+- **Fix or mitigation** as soon as practical, depending on severity
+
+## Scope
+
+The following are in scope:
+- The Telescope Electron application
+- The MCP server and its tools
+- The CDP proxy
+- IPC and preload scripts
+- Any data exposure or privilege escalation
+
+## Supported versions
+
+Only the latest release is actively supported with security fixes.
+
+| Version | Supported |
+|---|---|
+| Latest alpha | Yes |
+| Older releases | No |

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,53 @@
+# Development
+
+## Prerequisites
+
+- Node.js >= 22
+- [pnpm](https://pnpm.io/)
+
+## Getting started
+
+```bash
+pnpm install
+pnpm dev                     # start the Electron app
+pnpm typecheck               # type-check both node and web tsconfigs
+pnpm test:unit               # fast unit tests (no Electron)
+pnpm test:smoke              # integration tests (spawns Electron, uses HTTP API)
+pnpm build                   # package for distribution
+```
+
+## Environment variables
+
+See [`.env.example`](../.env.example) for all available configuration options.
+
+## Releasing
+
+Releases are built, signed, notarized, and published automatically via GitHub Actions when a version tag is pushed.
+
+### Setup (one-time)
+
+Add these secrets to the GitHub repo settings (**Settings > Secrets > Actions**):
+
+| Secret | Value |
+|---|---|
+| `APPLE_ID` | Apple Developer account email |
+| `APPLE_PASSWORD` | An [app-specific password](https://support.apple.com/en-us/102654) for the Apple ID |
+| `APPLE_TEAM_ID` | Apple Developer Team ID |
+| `CSC_LINK` | Base64-encoded `.p12` certificate |
+| `CSC_KEY_PASSWORD` | Password used when exporting the `.p12` |
+
+### Publishing a release
+
+```bash
+# Patch release (e.g. 0.2.2 -> 0.2.3)
+pnpm release:patch
+
+# Minor release (e.g. 0.2.2 -> 0.3.0)
+pnpm release:minor
+```
+
+Must be run from a clean `main`. These run `npm version` (which commits and tags) then `git push --follow-tags`. The `release.yml` workflow picks up the `v*` tag, builds a signed+notarized macOS DMG, and publishes it as a GitHub Release. Users with the app installed receive the update automatically via [`update.electronjs.org`](https://update.electronjs.org) (powered by `update-electron-app`).
+
+> **Do not use SemVer prerelease suffixes** (e.g. `0.2.1-alpha.3`). `update.electronjs.org` filters them out, so alpha/beta tags will never reach installed clients. Just increment patch/minor versions.
+>
+> Patch numbers can grow arbitrarily (`0.2.31`, `0.2.147`) — that's expected during active development. Bump the minor version when you want a "grouping" signal, not because the patch number got big.


### PR DESCRIPTION
## Summary

- Add a public `README.md` introducing Telescope, its use cases, key features, inspiration, system requirements, install, and agent integration
- Add `SECURITY.md` with private vulnerability reporting instructions, response SLA, in-scope surface (app, MCP server, CDP proxy, IPC/preload), and supported-versions table
- Add `docs/development.md` covering prerequisites, common pnpm scripts, env vars pointer, and the release-publishing flow (Apple secrets, `release:patch` / `release:minor`, auto-update caveats)

## Test plan

- [ ] Links in README resolve (GitHub Releases, `resources/skills/telescope/SKILL.md`, `src/main/mcp-tools.ts`, SECURITY.md)
- [ ] Skill path `resources/skills/telescope/SKILL.md` still exists at that location
- [ ] MCP tools path `src/main/mcp-tools.ts` still exists
- [ ] `update-electron-app` is the actual updater mechanism (confirmed in `package.json` and `src/main/auto-updater.ts`)
- [ ] Release secrets list in `docs/development.md` matches what `.github/workflows/release.yml` consumes
- [ ] `pnpm release:patch` and `pnpm release:minor` scripts exist in `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)