### PR TITLE
Per-frame agent-browser sessions + CLI/presence fixes

### DIFF
--- a/src/main/cli-commands.ts
+++ b/src/main/cli-commands.ts
@@ -187,6 +187,20 @@ const focus: VerbHandler = async (args) => {
 }
 
 const link: VerbHandler = async (args) => {
+  if (args.positional.length >= 2) {
+    const [fromEntityId, toEntityId] = args.positional
+    const edge: Record<string, unknown> = { fromEntityId, toEntityId, kind: 'connection' }
+    if (args.flags.label) edge.label = args.flags.label
+    printJson(await callApp('/edges/create', {
+      method: 'POST',
+      body: JSON.stringify({ edges: [edge] }),
+    }))
+    return 0
+  }
+  if (args.positional.length === 1 || (args.positional.length === 0 && process.stdin.isTTY)) {
+    printError('usage: telescope link <fromId> <toId> [--label <text>]  (or pipe a JSON edges array on stdin)')
+    return 1
+  }
   const input = await readStdin()
   printJson(await callApp('/edges/create', {
     method: 'POST',

--- a/src/main/presence-session.ts
+++ b/src/main/presence-session.ts
@@ -25,44 +25,37 @@ export function activeSessions(now = Date.now()): McpClientSession[] {
   return sessions
 }
 
+function upsertSession(
+  id: string,
+  clientName: string | undefined,
+): { sessionId: string; session: McpClientSession } {
+  const existing = mcpSessions.get(id)
+  if (existing) {
+    existing.lastSeenAt = Date.now()
+    if (clientName) existing.clientName = clientName
+    return { sessionId: id, session: existing }
+  }
+  const next: McpClientSession = {
+    id,
+    clientName: clientName ?? id,
+    lastSeenAt: Date.now(),
+  }
+  mcpSessions.set(id, next)
+  return { sessionId: id, session: next }
+}
+
 export function resolveSession(
   request: IncomingMessage,
   body?: Record<string, unknown>,
 ): { sessionId: string; session: McpClientSession } | null {
   const headerId = request.headers['x-telescope-session-id'] as string | undefined
   const headerClientName = request.headers['x-telescope-client-name'] as string | undefined
-  if (headerId) {
-    const existing = mcpSessions.get(headerId)
-    if (existing) {
-      existing.lastSeenAt = Date.now()
-      if (headerClientName) existing.clientName = headerClientName
-      return { sessionId: headerId, session: existing }
-    }
-    const nextSession = {
-      id: headerId,
-      clientName: headerClientName ?? headerId,
-      lastSeenAt: Date.now(),
-    }
-    mcpSessions.set(headerId, nextSession)
-    return { sessionId: headerId, session: nextSession }
-  }
+  if (headerId) return upsertSession(headerId, headerClientName)
+
   const bodySessionId = typeof body?.sessionId === 'string' ? body.sessionId : undefined
   const bodyClientName = typeof body?.clientName === 'string' ? body.clientName : undefined
-  if (bodySessionId) {
-    const existing = mcpSessions.get(bodySessionId)
-    if (existing) {
-      existing.lastSeenAt = Date.now()
-      if (bodyClientName) existing.clientName = bodyClientName
-      return { sessionId: bodySessionId, session: existing }
-    }
-    const nextSession = {
-      id: bodySessionId,
-      clientName: bodyClientName ?? bodySessionId,
-      lastSeenAt: Date.now(),
-    }
-    mcpSessions.set(bodySessionId, nextSession)
-    return { sessionId: bodySessionId, session: nextSession }
-  }
+  if (bodySessionId) return upsertSession(bodySessionId, bodyClientName)
+
   const active = activeSessions()
   if (active.length === 0) return null
   const session = active.reduce((a, b) => (a.lastSeenAt >= b.lastSeenAt ? a : b))

--- a/src/main/presence-session.ts
+++ b/src/main/presence-session.ts
@@ -32,8 +32,12 @@ export function resolveSession(
   const headerId = request.headers['x-telescope-session-id'] as string | undefined
   const headerClientName = request.headers['x-telescope-client-name'] as string | undefined
   if (headerId) {
-    const session = mcpSessions.get(headerId)
-    if (session) return { sessionId: headerId, session }
+    const existing = mcpSessions.get(headerId)
+    if (existing) {
+      existing.lastSeenAt = Date.now()
+      if (headerClientName) existing.clientName = headerClientName
+      return { sessionId: headerId, session: existing }
+    }
     const nextSession = {
       id: headerId,
       clientName: headerClientName ?? headerId,
@@ -45,6 +49,12 @@ export function resolveSession(
   const bodySessionId = typeof body?.sessionId === 'string' ? body.sessionId : undefined
   const bodyClientName = typeof body?.clientName === 'string' ? body.clientName : undefined
   if (bodySessionId) {
+    const existing = mcpSessions.get(bodySessionId)
+    if (existing) {
+      existing.lastSeenAt = Date.now()
+      if (bodyClientName) existing.clientName = bodyClientName
+      return { sessionId: bodySessionId, session: existing }
+    }
     const nextSession = {
       id: bodySessionId,
       clientName: bodyClientName ?? bodySessionId,

--- a/src/main/routes/session.ts
+++ b/src/main/routes/session.ts
@@ -201,12 +201,15 @@ export const sessionRoutes: Route[] = [
 
       const targetRect = resolvePresenceTargetRect(frameId, targetRef, targetRefSource, null)
       const observationCommands = new Set(['snapshot', 'wait', 'get'])
-      const fallbackFrameY = observationCommands.has(command) ? 20 : undefined
+      const isObservation = observationCommands.has(command)
+      // For mutation commands with an agent-browser ref we can't resolve to
+      // bounds, skip the center fallback and let CDP mouseMoved drive the
+      // cursor — otherwise it lands at frame center then snaps to the target.
       const framePosition =
-        frameId
+        frameId && (targetRect || isObservation)
           ? resolveCanvasPointForFrame(frameId, {
               frameX: undefined,
-              frameY: fallbackFrameY,
+              frameY: isObservation ? 20 : undefined,
               targetRect,
             })
           : null
@@ -216,8 +219,8 @@ export const sessionRoutes: Route[] = [
         taskLabel,
         surface: frameId ? 'frame' : 'canvas',
         frameId,
-        canvasX: framePosition?.canvasX ?? null,
-        canvasY: framePosition?.canvasY ?? null,
+        canvasX: framePosition?.canvasX,
+        canvasY: framePosition?.canvasY,
         targetName,
         targetRect,
         labelHint,

--- a/src/main/shared/browse-handler.ts
+++ b/src/main/shared/browse-handler.ts
@@ -217,7 +217,14 @@ export function spawnAsync(
     const child = spawn(cmd, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: opts.cwd,
-      env: { ...process.env, NO_COLOR: '1' },
+      // Auto-shutdown per-frame daemons after 60s of inactivity. We spin one
+      // daemon per frame (via --session <frameId>) so without an idle timeout
+      // they'd accumulate for the app's lifetime. User override still wins.
+      env: {
+        AGENT_BROWSER_IDLE_TIMEOUT_MS: '60000',
+        ...process.env,
+        NO_COLOR: '1',
+      },
     })
     const maxBuf = opts.maxBuffer ?? 10 * 1024 * 1024
     const stdoutChunks: Buffer[] = []
@@ -295,6 +302,12 @@ export async function handleBrowse(args: Record<string, unknown>): Promise<{
   return withFrameLock(frameId, async () => {
     const { wsUrl: cdpUrl, pageUrl: expectedPageUrl } = await resolveCdpUrl(frameId)
     const abPath = resolveAgentBrowserPath()
+    // One agent-browser daemon per frame. Without --session, a single daemon
+    // pins the first --cdp URL it saw and silently ignores subsequent --cdp
+    // values — upstream bug in agent-browser (CLI skips `launch` when daemon
+    // is already running; daemon's relaunch check doesn't compare cdp_url).
+    // Keying by frameId sidesteps both gates.
+    const sessionFlags = ['--session', frameId]
 
     // Fire presence intent (non-blocking)
     if (labelKey) {
@@ -340,7 +353,7 @@ export async function handleBrowse(args: Record<string, unknown>): Promise<{
 
       const { stdout } = await spawnAsync(
         abPath,
-        [...GLOBAL_AB_FLAGS, '--cdp', cdpUrl, 'batch', '--json', '--bail'],
+        [...GLOBAL_AB_FLAGS, ...sessionFlags, '--cdp', cdpUrl, 'batch', '--json', '--bail'],
         { timeout: timeoutMs, input: batchInput },
       )
 
@@ -412,7 +425,7 @@ export async function handleBrowse(args: Record<string, unknown>): Promise<{
     if (verb && MUTATION_VERBS.has(verb) && ref) {
       await spawnAsync(
         abPath,
-        [...GLOBAL_AB_FLAGS, '--cdp', cdpUrl, 'scrollintoview', ref],
+        [...GLOBAL_AB_FLAGS, ...sessionFlags, '--cdp', cdpUrl, 'scrollintoview', ref],
         { timeout: 5_000 },
       ).catch(() => {}) // Best-effort — don't fail the click if scroll fails
     }
@@ -423,7 +436,7 @@ export async function handleBrowse(args: Record<string, unknown>): Promise<{
 
     const { stdout, stderr } = await spawnAsync(
       abPath,
-      [...GLOBAL_AB_FLAGS, '--cdp', cdpUrl, ...extraFlags, ...argv],
+      [...GLOBAL_AB_FLAGS, ...sessionFlags, '--cdp', cdpUrl, ...extraFlags, ...argv],
       { timeout: timeoutMs },
     )
 
@@ -458,7 +471,7 @@ export async function handleBrowse(args: Record<string, unknown>): Promise<{
       try {
         const { stdout: urlOut } = await spawnAsync(
           abPath,
-          [...GLOBAL_AB_FLAGS, '--cdp', cdpUrl, 'get', 'url'],
+          [...GLOBAL_AB_FLAGS, ...sessionFlags, '--cdp', cdpUrl, 'get', 'url'],
           { timeout: 5_000 },
         )
         output += `\nurl: ${urlOut.trim()}`

--- a/src/main/shared/browse-handler.ts
+++ b/src/main/shared/browse-handler.ts
@@ -309,7 +309,10 @@ export async function handleBrowse(args: Record<string, unknown>): Promise<{
     // Keying by frameId sidesteps both gates.
     const sessionFlags = ['--session', frameId]
 
-    // Fire presence intent (non-blocking)
+    // Fire presence intent (non-blocking). Include frameId so the cursor
+    // follows the frame we're actually driving — otherwise the server-side
+    // fallback picks the first CDP proxy registration for this session and
+    // the cursor sticks to whichever frame was driven first.
     if (labelKey) {
       callApp('/session/presence/intent', {
         method: 'POST',
@@ -318,6 +321,7 @@ export async function handleBrowse(args: Record<string, unknown>): Promise<{
           clientName,
           command: verb,
           labelKey,
+          frameId,
           labelHint: verb === 'fill' || verb === 'type' ? 'editing control' : null,
           targetRef: ref,
           targetRefSource: ref ? 'agent-browser' : null,


### PR DESCRIPTION
## Summary
Fixes a cross-frame routing bug in agent-browser and tightens up CLI + presence behavior around multi-frame sessions.

- **Per-frame daemon isolation** — pass `--session <frameId>` on every agent-browser invocation. Upstream agent-browser pins the first `--cdp` URL its daemon sees and silently ignores later ones; keying by `frameId` spawns one daemon per frame and sidesteps the bug.
- **Idle shutdown** — default `AGENT_BROWSER_IDLE_TIMEOUT_MS=60000` so the per-frame daemons don't accumulate for the app's lifetime. User env still overrides.
- **Cursor follows the driven frame** — include `frameId` in the presence intent payload so the server-side fallback doesn't stick the cursor to whichever frame was driven first.
- **No more center bounce** — when a click/fill intent arrives with an agent-browser ref we can't resolve to bounds, skip the frame-center fallback and let CDP mouseMoved drive the cursor directly to the target.
- **Session keep-alive** — `resolveSession` now refreshes `lastSeenAt` and `clientName` on every header/body lookup, so long-running workflows don't let the MCP session expire mid-stream.
- **`telescope link` positional args** — `telescope link <fromId> <toId> [--label <text>]` now works directly; stdin JSON fallback preserved.
- **Refactor** — `resolveSession` extracted an `upsertSession` helper to remove duplication between the header-id and body-id branches.

## Test plan

### Cross-frame routing (verified)
- [x] Two frames at different URLs; snapshot each returns the correct `origin=`
- [x] Click on each lands on the intended frame (URL updates match)
- [x] Rapid alternation (A → B → A snapshots) routes correctly

### Cursor follows driven frame (verified visually)
- [x] Drive frame A then frame B; cursor hops to B rather than sticking on A

### Cursor moves directly to target (verified visually)
- [x] Clicks across 3 rounds of A→B navigation land directly on the target link without a visible center bounce
- [x] Observation commands (`snapshot`/`wait`/`get`) still anchor at frame top

### Idle daemon cleanup (verified)
- [x] Driving a frame spawns one daemon; reaped ~56s after inactivity (60s configured)
- [x] Respawns cleanly on next drive

### \`telescope link\` CLI (verified)
- [x] \`telescope link <a> <b>\` creates an edge
- [x] \`telescope link <a> <b> --label \"x\"\` accepts the flag (note: server-side \`createEdges\` drops the label — pre-existing, not in this PR's scope)
- [x] \`telescope link <solo>\` prints usage, exit 1
- [x] Stdin JSON fallback still works

### Session keep-alive (verified)
- [x] 5 calls at 18s intervals over ~75s — presence session stays live without mid-stream expiry

### Automated
- [x] \`pnpm typecheck\`
- [x] \`pnpm test:unit\` (189 tests pass)