### PR TITLE
Move presence cursor to relevant entities on API operations

### DIFF
--- a/src/main/presence-cursor.ts
+++ b/src/main/presence-cursor.ts
@@ -15,6 +15,7 @@ import {
   getFileEntities,
 } from './runtime/document-commands'
 import { pages } from './runtime/runtime-context'
+import { workspaceGroups } from './runtime/workspace-model'
 import {
   resolveSession,
   mcpSessions,
@@ -456,6 +457,20 @@ export function allEntityPositions(): Array<{ x: number; y: number }> {
   return positions
 }
 
+/** Look up the canvas position of any entity by id — frame, text, file, or
+ * group. Returns null if the id doesn't match anything. */
+export function findEntityPosition(id: string): { x: number; y: number } | null {
+  const page = pages.find((p) => p.id === id)
+  if (page) return { x: page.canvasX, y: page.canvasY }
+  const te = getTextEntities().find((e) => e.id === id)
+  if (te) return { x: te.canvasX, y: te.canvasY }
+  const fe = getFileEntities().find((e) => e.id === id)
+  if (fe) return { x: fe.canvasX, y: fe.canvasY }
+  const group = workspaceGroups.find((g) => g.id === id)
+  if (group) return { x: group.canvasX, y: group.canvasY }
+  return null
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
@@ -478,7 +493,7 @@ function setPresenceCursorIdle(request: IncomingMessage): void {
   notifyPresenceChanged()
 }
 
-function movePresenceCursorTo(
+export function movePresenceCursorTo(
   request: IncomingMessage,
   canvasX: number,
   canvasY: number,

--- a/src/main/presence-manager.ts
+++ b/src/main/presence-manager.ts
@@ -59,6 +59,8 @@ export {
   allEntityPositions,
   staggerOperation,
   animateCursorScan,
+  movePresenceCursorTo,
+  findEntityPosition,
 } from './presence-cursor'
 
 // Re-export for route usage

--- a/src/main/routes/annotations.ts
+++ b/src/main/routes/annotations.ts
@@ -1,5 +1,5 @@
 import type { Route } from './types'
-import type { AnnotationStatusFilter } from '../../shared/types'
+import type { AnnotationAnchor, AnnotationStatusFilter } from '../../shared/types'
 import {
   addAnnotationReply,
   createAnnotation,
@@ -12,7 +12,35 @@ import {
   fixAnnotation,
   fixPendingAnnotationsForOrigin,
 } from '../agent-fix/fix-orchestrator'
+import { findEntityPosition, movePresenceCursorTo } from '../presence-manager'
 import { writeJson } from '../app-control-server'
+import type { IncomingMessage } from 'http'
+
+/** Resolve an annotation's anchor to a canvas position. Returns null for
+ * frame/element anchors where the frame can't be found; those are rare
+ * enough that a silent miss is fine. */
+function annotationAnchorPosition(
+  anchor: AnnotationAnchor,
+): { x: number; y: number } | null {
+  if (anchor.type === 'canvas') return { x: anchor.canvasX, y: anchor.canvasY }
+  if (anchor.type === 'region') {
+    return {
+      x: anchor.canvasRect.x + anchor.canvasRect.width / 2,
+      y: anchor.canvasRect.y + anchor.canvasRect.height / 2,
+    }
+  }
+  if (anchor.type === 'frame' || anchor.type === 'element') {
+    return findEntityPosition(anchor.frameId)
+  }
+  return null
+}
+
+function moveCursorToAnnotation(request: IncomingMessage, id: string): void {
+  const annotation = getAnnotationById(id)
+  if (!annotation) return
+  const pos = annotationAnchorPosition(annotation.anchor)
+  if (pos) movePresenceCursorTo(request, pos.x, pos.y, null)
+}
 
 export const annotationRoutes: Route[] = [
   {
@@ -49,7 +77,7 @@ export const annotationRoutes: Route[] = [
   {
     method: 'POST',
     pattern: '/annotations',
-    async handler({ response, body }) {
+    async handler({ request, response, body }) {
       const payload = body as {
         anchor?: unknown
         author?: 'user' | 'agent'
@@ -62,6 +90,8 @@ export const annotationRoutes: Route[] = [
         writeJson(response, 400, { error: 'anchor and text are required' })
         return
       }
+      const pos = annotationAnchorPosition(payload.anchor as AnnotationAnchor)
+      if (pos) movePresenceCursorTo(request, pos.x, pos.y, null)
       writeJson(
         response,
         200,
@@ -81,8 +111,9 @@ export const annotationRoutes: Route[] = [
   {
     method: 'POST',
     pattern: /^\/annotations\/([^/]+)\/acknowledge$/,
-    async handler({ response, params }) {
+    async handler({ request, response, params }) {
       const id = params[0]
+      moveCursorToAnnotation(request, id)
       const result = updateAnnotationStatus(id, 'acknowledged')
       if (!result) {
         writeJson(response, 404, { error: `Annotation not found: ${id}` })
@@ -94,9 +125,10 @@ export const annotationRoutes: Route[] = [
   {
     method: 'POST',
     pattern: /^\/annotations\/([^/]+)\/dismiss$/,
-    async handler({ response, body, params }) {
+    async handler({ request, response, body, params }) {
       const id = params[0]
       const payload = body as { reason?: string }
+      moveCursorToAnnotation(request, id)
       const result = updateAnnotationStatus(id, 'dismissed', payload.reason)
       if (!result) {
         writeJson(response, 404, { error: `Annotation not found: ${id}` })
@@ -108,8 +140,9 @@ export const annotationRoutes: Route[] = [
   {
     method: 'POST',
     pattern: /^\/annotations\/([^/]+)\/resolve$/,
-    async handler({ response, params }) {
+    async handler({ request, response, params }) {
       const id = params[0]
+      moveCursorToAnnotation(request, id)
       const result = updateAnnotationStatus(id, 'resolved')
       if (!result) {
         writeJson(response, 404, { error: `Annotation not found: ${id}` })
@@ -121,13 +154,14 @@ export const annotationRoutes: Route[] = [
   {
     method: 'POST',
     pattern: /^\/annotations\/([^/]+)\/reply$/,
-    async handler({ response, body, params }) {
+    async handler({ request, response, body, params }) {
       const id = params[0]
       const payload = body as { author?: string; text?: string }
       if (!payload.text) {
         writeJson(response, 400, { error: 'text is required' })
         return
       }
+      moveCursorToAnnotation(request, id)
       const result = addAnnotationReply(id, (payload.author as 'user' | 'agent') ?? 'agent', payload.text)
       if (!result) {
         writeJson(response, 404, { error: `Annotation not found: ${id}` })
@@ -139,8 +173,9 @@ export const annotationRoutes: Route[] = [
   {
     method: 'DELETE',
     pattern: /^\/annotations\/([^/]+)$/,
-    async handler({ response, params }) {
+    async handler({ request, response, params }) {
       const id = params[0]
+      moveCursorToAnnotation(request, id)
       const deleted = deleteAnnotation(id)
       if (!deleted) {
         writeJson(response, 404, { error: `Annotation not found: ${id}` })

--- a/src/main/routes/edges-groups.ts
+++ b/src/main/routes/edges-groups.ts
@@ -4,34 +4,53 @@ import { createEdges, deleteEdges } from '../workspace-edges'
 import { createUserGroup, deleteGroups, focusTargets } from '../workspace-groups'
 import { ungroupSelectedGroup } from '../runtime/document-commands'
 import { selectGroup as selectSelectionGroup } from '../runtime/selection-controller'
-import { workspaceGroups } from '../runtime/workspace-model'
+import { workspaceEdges, workspaceGroups } from '../runtime/workspace-model'
+import { findEntityPosition, movePresenceCursorTo } from '../presence-manager'
 import { writeJson } from '../app-control-server'
 
 export const edgesGroupsRoutes: Route[] = [
   {
     method: 'POST',
     pattern: '/edges/create',
-    async handler({ response, body }) {
-      writeJson(response, 200, createEdges(body as CreateEdgesRequest))
+    async handler({ request, response, body }) {
+      const payload = body as CreateEdgesRequest
+      const firstTarget = payload.edges?.find((e) => findEntityPosition(e.toEntityId) !== null)
+      if (firstTarget) {
+        const pos = findEntityPosition(firstTarget.toEntityId)!
+        movePresenceCursorTo(request, pos.x, pos.y, null)
+      }
+      writeJson(response, 200, createEdges(payload))
     },
   },
   {
     method: 'POST',
     pattern: '/edges/delete',
-    async handler({ response, body }) {
-      writeJson(response, 200, deleteEdges(body as { edgeIds: string[] }))
+    async handler({ request, response, body }) {
+      const payload = body as { edgeIds: string[] }
+      const firstEdge = payload.edgeIds
+        ?.map((id) => workspaceEdges.find((e) => e.id === id))
+        .find((e): e is NonNullable<typeof e> => Boolean(e))
+      if (firstEdge) {
+        const pos = findEntityPosition(firstEdge.toEntityId)
+        if (pos) movePresenceCursorTo(request, pos.x, pos.y, null)
+      }
+      writeJson(response, 200, deleteEdges(payload))
     },
   },
   {
     method: 'POST',
     pattern: '/groups/create',
-    async handler({ response, body }) {
+    async handler({ request, response, body }) {
       const payload = body as { entityIds?: string[]; label?: string }
       const entityIds = payload.entityIds ?? []
       if (!entityIds.length) {
         writeJson(response, 400, { error: 'entityIds is required' })
         return
       }
+      const firstPos = entityIds
+        .map((id) => findEntityPosition(id))
+        .find((p): p is NonNullable<typeof p> => p !== null)
+      if (firstPos) movePresenceCursorTo(request, firstPos.x, firstPos.y, null)
       const group = createUserGroup(entityIds, payload.label)
       writeJson(response, 200, group)
     },
@@ -39,23 +58,30 @@ export const edgesGroupsRoutes: Route[] = [
   {
     method: 'POST',
     pattern: '/groups/delete',
-    async handler({ response, body }) {
-      writeJson(response, 200, deleteGroups(body as DeleteGroupsRequest))
+    async handler({ request, response, body }) {
+      const payload = body as DeleteGroupsRequest
+      const firstGroup = payload.groupIds
+        ?.map((id) => workspaceGroups.find((g) => g.id === id))
+        .find((g): g is NonNullable<typeof g> => Boolean(g))
+      if (firstGroup) movePresenceCursorTo(request, firstGroup.canvasX, firstGroup.canvasY, null)
+      writeJson(response, 200, deleteGroups(payload))
     },
   },
   {
     method: 'POST',
     pattern: '/groups/ungroup',
-    async handler({ response, body }) {
+    async handler({ request, response, body }) {
       const payload = body as { groupId?: string }
       if (!payload.groupId) {
         writeJson(response, 400, { error: 'groupId is required' })
         return
       }
-      if (!workspaceGroups.some((group) => group.id === payload.groupId)) {
+      const group = workspaceGroups.find((g) => g.id === payload.groupId)
+      if (!group) {
         writeJson(response, 404, { error: 'Group not found' })
         return
       }
+      movePresenceCursorTo(request, group.canvasX, group.canvasY, null)
       selectSelectionGroup(payload.groupId)
       writeJson(response, 200, { entityIds: ungroupSelectedGroup() ?? [] })
     },
@@ -63,16 +89,25 @@ export const edgesGroupsRoutes: Route[] = [
   {
     method: 'POST',
     pattern: '/camera/focus',
-    async handler({ response, body }) {
-      writeJson(
-        response,
-        200,
-        focusTargets(body as {
-          frameIds?: string[]
-          groupIds?: string[]
-          bounds?: { x: number; y: number; width: number; height: number }
-        }),
-      )
+    async handler({ request, response, body }) {
+      const payload = body as {
+        frameIds?: string[]
+        groupIds?: string[]
+        bounds?: { x: number; y: number; width: number; height: number }
+      }
+      const firstId = payload.frameIds?.[0] ?? payload.groupIds?.[0]
+      if (firstId) {
+        const pos = findEntityPosition(firstId)
+        if (pos) movePresenceCursorTo(request, pos.x, pos.y, null)
+      } else if (payload.bounds) {
+        movePresenceCursorTo(
+          request,
+          payload.bounds.x + payload.bounds.width / 2,
+          payload.bounds.y + payload.bounds.height / 2,
+          null,
+        )
+      }
+      writeJson(response, 200, focusTargets(payload))
     },
   },
 ]

--- a/src/main/routes/entities.ts
+++ b/src/main/routes/entities.ts
@@ -15,7 +15,12 @@ import { createFrames } from '../workspace-frames'
 import { deleteFrames } from '../workspace-entities'
 import { findPageById } from '../runtime/runtime-context'
 import { imageSizeFromPath, videoSizeFromPath } from '../runtime/image-sizing'
-import { animateCursorScan, allEntityPositions, staggerOperation } from '../presence-manager'
+import {
+  animateCursorScan,
+  allEntityPositions,
+  movePresenceCursorTo,
+  staggerOperation,
+} from '../presence-manager'
 import { writeJson } from '../app-control-server'
 
 export const entityRoutes: Route[] = [
@@ -49,6 +54,7 @@ export const entityRoutes: Route[] = [
           writeJson(response, 400, { error: 'canvasX and canvasY are required numbers' })
           return
         }
+        movePresenceCursorTo(request, item.canvasX, item.canvasY, null)
         writeJson(
           response,
           200,
@@ -97,7 +103,8 @@ export const entityRoutes: Route[] = [
         const entity = updateTextEntity(item.id, item.patch)
         if (entity) results.push(entity)
       }
-      if (positions.length > 1) animateCursorScan(request, positions, null)
+      if (positions.length === 1) movePresenceCursorTo(request, positions[0].x, positions[0].y, null)
+      else if (positions.length > 1) animateCursorScan(request, positions, null)
       writeJson(response, 200, items.length === 1 && !payload.items ? results[0] ?? { error: 'not found' } : { items: results })
     },
   },
@@ -111,7 +118,12 @@ export const entityRoutes: Route[] = [
       }
       const ids = payload.ids ?? [payload.id!]
       if (ids.length <= 1) {
-        const deleted = ids[0] ? deleteTextEntity(ids[0]) : false
+        const id = ids[0]
+        if (id) {
+          const existing = getTextEntities().find((e) => e.id === id)
+          if (existing) movePresenceCursorTo(request, existing.canvasX, existing.canvasY, null)
+        }
+        const deleted = id ? deleteTextEntity(id) : false
         writeJson(response, 200, !payload.ids ? { ok: deleted } : { deleted: deleted ? ids : [] })
         return
       }
@@ -160,6 +172,7 @@ export const entityRoutes: Route[] = [
         }
         const dims = resolveFileDimensions(item as { file: string; width?: number; height?: number })
         const id = item.id ?? `file_${randomUUID()}`
+        movePresenceCursorTo(request, item.canvasX, item.canvasY, null)
         createFileEntity({
           id,
           canvasX: item.canvasX,
@@ -211,7 +224,8 @@ export const entityRoutes: Route[] = [
         const entity = updateFileEntity(item.id, item.patch)
         if (entity) results.push(entity)
       }
-      if (positions.length > 1) animateCursorScan(request, positions, null)
+      if (positions.length === 1) movePresenceCursorTo(request, positions[0].x, positions[0].y, null)
+      else if (positions.length > 1) animateCursorScan(request, positions, null)
       writeJson(response, 200, items.length === 1 && !payload.items ? results[0] ?? { error: 'not found' } : { items: results })
     },
   },
@@ -225,7 +239,12 @@ export const entityRoutes: Route[] = [
       }
       const ids = payload.ids ?? [payload.id!]
       if (ids.length <= 1) {
-        const deleted = ids[0] ? deleteFileEntity(ids[0]) : false
+        const id = ids[0]
+        if (id) {
+          const existing = getFileEntities().find((e) => e.id === id)
+          if (existing) movePresenceCursorTo(request, existing.canvasX, existing.canvasY, null)
+        }
+        const deleted = id ? deleteFileEntity(id) : false
         writeJson(response, 200, !payload.ids ? { ok: deleted } : { deleted: deleted ? ids : [] })
         return
       }

--- a/src/main/routes/frames.ts
+++ b/src/main/routes/frames.ts
@@ -27,6 +27,8 @@ import {
   cdpProxyMetrics,
 } from '../cdp-proxy'
 import {
+  animateCursorScan,
+  movePresenceCursorTo,
   staggerOperation,
   normalizeAgentSnapshot,
   findPresenceTarget,
@@ -80,6 +82,8 @@ export const frameRoutes: Route[] = [
       const payload = body as CreateFramesRequest
       const frames = payload.frames ?? []
       if (frames.length <= 1) {
+        const frame = frames[0]
+        if (frame) movePresenceCursorTo(request, frame.canvasX, frame.canvasY, 'create_frame')
         writeJson(response, 200, createFrames(payload))
         return
       }
@@ -97,7 +101,7 @@ export const frameRoutes: Route[] = [
   {
     method: 'POST',
     pattern: '/frames/update',
-    async handler({ response, body }) {
+    async handler({ request, response, body }) {
       const payload = body as {
         frames: Array<{
           id: string
@@ -110,9 +114,11 @@ export const frameRoutes: Route[] = [
         }>
       }
       const updated: string[] = []
+      const positions: Array<{ x: number; y: number }> = []
       for (const f of payload.frames) {
         const page = findPageById(f.id)
         if (!page) continue
+        positions.push({ x: page.canvasX, y: page.canvasY })
         if (f.presetIndex !== undefined) setFramePreset(page.id, f.presetIndex)
         if (f.orientation !== undefined) setDeviceOrientation(page.id, f.orientation)
         if (f.showDeviceFrame !== undefined) {
@@ -128,13 +134,15 @@ export const frameRoutes: Route[] = [
         if (f.canvasY !== undefined) page.canvasY = f.canvasY
         updated.push(page.id)
       }
+      if (positions.length === 1) movePresenceCursorTo(request, positions[0].x, positions[0].y, null)
+      else if (positions.length > 1) animateCursorScan(request, positions, null)
       writeJson(response, 200, { updated })
     },
   },
   {
     method: 'POST',
     pattern: '/frames/create-at-position',
-    async handler({ response, body }) {
+    async handler({ request, response, body }) {
       const payload = body as {
         sourceFrameId?: string
         presetIndex?: number
@@ -145,6 +153,7 @@ export const frameRoutes: Route[] = [
         writeJson(response, 400, { error: 'canvasX and canvasY are required numbers' })
         return
       }
+      movePresenceCursorTo(request, payload.canvasX, payload.canvasY, 'create_frame')
       writeJson(
         response,
         200,
@@ -166,6 +175,11 @@ export const frameRoutes: Route[] = [
       const payload = body as DeleteFramesRequest
       const frameIds = payload.frameIds ?? []
       if (frameIds.length <= 1) {
+        const id = frameIds[0]
+        if (id) {
+          const page = findPageById(id)
+          if (page) movePresenceCursorTo(request, page.canvasX, page.canvasY, null)
+        }
         writeJson(response, 200, deleteFrames(payload))
         return
       }


### PR DESCRIPTION
## Summary
This PR enhances the presence cursor behavior by automatically moving it to relevant canvas positions when users perform operations through the API. This provides better visual feedback and context awareness during collaborative editing.

## Key Changes

- **Presence cursor integration across route handlers**: Updated all route handlers in `edges-groups.ts`, `annotations.ts`, `entities.ts`, and `frames.ts` to move the presence cursor to relevant entity positions after operations.

- **New utility functions in presence-cursor.ts**:
  - `findEntityPosition(id)`: Looks up the canvas position of any entity (frame, text, file, or group) by ID
  - Exported `movePresenceCursorTo()`: Previously internal function now available for route handlers

- **Annotation-specific handling**: Added `annotationAnchorPosition()` helper to resolve annotation anchors to canvas coordinates, supporting canvas, region, frame, and element anchor types.

- **Smart cursor movement logic**:
  - Single entity operations: Move cursor directly to that entity
  - Multiple entity operations: Animate cursor scan across all positions
  - Fallback handling: Gracefully handles cases where entities cannot be found

- **Updated route handlers**:
  - `/edges/create` and `/edges/delete`: Move to first valid target edge
  - `/groups/create`, `/groups/delete`, `/groups/ungroup`: Move to group position
  - `/camera/focus`: Move to focused entity or bounds center
  - `/annotations/*`: Move to annotation anchor position for all annotation operations
  - `/entities/text/*` and `/entities/file/*`: Move to created/updated/deleted entity positions
  - `/frames/*`: Move to frame positions with smart single vs. multiple handling

## Implementation Details

- The `request` parameter is now passed to all affected route handlers to enable presence cursor updates
- Presence cursor movements use `null` as the action type for most operations, with `'create_frame'` for frame creation
- Entity lookups are defensive, returning early if entities cannot be found
- Type guards are used to safely filter nullable results when mapping over entity IDs

https://claude.ai/code/session_01BZ1jhVtxrEtpzQSMWqSGnn