### PR TITLE
chore: move telescope skill into repo

### DIFF
--- a/.claude/skills/telescope/SKILL.md
+++ b/.claude/skills/telescope/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: telescope
+description: Drive Telescope — a spatial canvas for iterating on web UI — from Claude Code. Use this skill whenever you need to pull a live website into a shared canvas, arrange frames at breakpoints, annotate pages, or inspect snapshots.
+---
+
+# Telescope
+
+Telescope is a spatial canvas that lets you pull live web pages (frames) onto a
+freeform surface, view them at different breakpoints, and annotate them. All
+canvas and frame operations go through the `telescope` command.
+
+## Core workflow
+
+1. `telescope workspace` — list the current canvas: frames, groups, edges, annotations.
+2. `telescope create frame <url>` — pull a live site onto the canvas as a frame.
+3. `telescope snapshot -i` — get element refs for the selected frame (or `-f <frameId>`).
+4. `telescope click @<ref>` / `telescope fill @<ref> "<text>"` — interact.
+5. `telescope snapshot -i` — re-snapshot after DOM mutations (refs go stale).
+
+## Common commands
+
+| Command | Purpose |
+|---|---|
+| `telescope workspace` | Print the current canvas state as JSON |
+| `telescope selection` | Print the currently selected entities |
+| `telescope create frame <url>` | Add a live page to the canvas |
+| `telescope create note <text>` | Add a text note to the canvas |
+| `telescope upsert --json < items.json` | Batch create/update entities (frames, notes, files) |
+| `telescope update <id> …` | Update properties on an existing entity |
+| `telescope delete <id>` | Remove an entity |
+| `telescope focus <id>` | Scroll the viewport so the entity is centered |
+| `telescope find-placement` | Find open canvas space for new entities |
+| `telescope link <a> <b>` | Connect two frames with an edge |
+| `telescope group <id…>` | Group entities together |
+| `telescope breakpoints <id>` | Cycle through device breakpoints for a frame |
+| `telescope annotate "<text>"` | Leave an annotation on the canvas |
+| `telescope annotations` | List unresolved annotations (pending + acknowledged) |
+| `telescope annotations --status <s>` | Filter by specific status (`pending`, `acknowledged`, `resolved`, `dismissed`) |
+| `telescope annotations --all` | Include resolved + dismissed too |
+| `telescope annotation <id>` | Get full detail for one annotation (elements, screenshot, replies) |
+| `telescope ack <id>` / `telescope resolve <id>` | Respond to an annotation |
+| `telescope snapshot -i` | Capture an accessibility snapshot with refs |
+| `telescope click @<ref>` | Click an element by ref |
+| `telescope fill @<ref> "<text>"` | Fill a form field |
+| `telescope screenshot -f <id>` | Screenshot a frame |
+
+## Entity types
+
+| Kind | Created via | Description |
+|---|---|---|
+| frame | `telescope create frame <url>` | Live web page rendered in a webview |
+| text | `telescope create note <text>` | Short text note (sticky-note style) |
+| file | `telescope upsert --json` | File entity — markdown (`.md`) or wireframe (`.wireframe.json`) |
+
+### Upsert tips
+
+`upsert --json` is the fastest way to create many entities at once. For
+**frames**, it honors `canvasX`, `canvasY`, `presetIndex`, and
+`orientation: "landscape" | "portrait"` — use it to drop a batch of frames
+at exact positions with the right device preset in one call:
+
+```bash
+cat << 'EOF' | telescope upsert --json
+[
+  {"kind":"frame","url":"https://example.com","presetIndex":6,"orientation":"landscape","canvasX":200,"canvasY":200},
+  {"kind":"frame","url":"https://example.com","presetIndex":0,"canvasX":1520,"canvasY":200}
+]
+EOF
+```
+
+For **files** (markdown, wireframe, image) upsert ignores `canvasX/canvasY` —
+the layout engine always places them. Images additionally ignore `width`.
+
+### Wireframes
+
+Files ending in `.wireframe.json` render as interactive wireframe editors on the
+canvas. Use them to sketch UI layouts, explore design variants, and iterate
+spatially alongside live frames. Write the JSON file to disk, then upsert it:
+
+```bash
+cat << 'EOF' | telescope upsert --json
+[{ "kind": "file", "file": "/tmp/my-layout.wireframe.json", "width": 300 }]
+EOF
+```
+
+See [references/wireframes.md](references/wireframes.md) for the full node schema, layout patterns, and examples.
+
+## Passing URLs
+
+Always pass full URLs (including scheme and host) to `telescope create frame`.
+The canvas can contain frames from different origins, so bare paths like
+`/garden` are ambiguous. Use `http://localhost:4321/garden`, not `/garden`.
+
+## Chaining
+
+Commands can be chained with `&&` for atomic sequences:
+
+```
+telescope create frame http://localhost:3000 && telescope snapshot -i
+```
+
+## Switching the active frame
+
+Browse verbs (`snapshot`, `click`, `fill`, `scroll`, `screenshot`) need a target
+frame. There is no persistent "active frame" binding — pass `-f <frameId>` on
+every browse call:
+
+```
+telescope snapshot -i -f <frameId>
+telescope click @e3 -f <frameId>
+```
+
+`telescope focus <id>` only scrolls the canvas viewport — it does not set the
+active frame.
+
+## Useful verbs
+
+> **Assumed — verify when you first use each.** `telescope back` has been
+> confirmed once; `forward` and `reload` are inferred from the CLI help and
+> have not been directly tested.
+
+- `telescope back` / `telescope forward` / `telescope reload` — browser history
+  navigation inside the active frame. Handy after `click` navigates you away
+  and you want to return.
+
+## Known CLI limitations
+
+> **Treat this list as known assumptions, not ground truth.** Entries reflect
+> behavior observed at the time they were added. Codepaths change, and some
+> items here may already be fixed or may present differently in your session.
+> If something behaves unexpectedly, re-test before trusting the list — and
+> update it (remove the entry, or tighten its wording) when you confirm a
+> change. A stale warning is worse than no warning.
+
+When you encounter new gaps, append them to the tracking issue (see below).
+
+- **`telescope breakpoints <id>` creates sibling frames with malformed URLs** — the new frames get `https://<sourceFrameId>/` instead of the source frame's real URL, so they load an invalid host instead of mirroring the page. Unusable as a multi-breakpoint primitive until fixed.
+- **`telescope update <id> --url` is a silent no-op** — the command returns `updated: [id]` but neither the webview nor the workspace URL field changes. Use `telescope click` on a link, or delete + recreate the frame, to navigate.
+- **`telescope update` silently ignores unsupported flags** — `--width`, `--label`, `--url` all return `updated: [id]` while applying nothing. Only `--preset / --at / --text / --color / --landscape / --portrait` actually take effect. Re-read workspace to verify.
+- **`telescope link` does not validate entity ids** — self-edges and edges to nonexistent ids are accepted and stored. Confirm both endpoints exist before calling `link`.
+- **`telescope delete <annotation_id>` silently lies** — the generic `delete` verb accepts annotation ids and returns `{"items":[{"kind":"file","id":"ann_...","deleted":true}]}` but does NOT call the annotation DELETE route. The annotation stays. Call `DELETE /annotations/:id` via raw HTTP, or wait for a dedicated verb.
+- **`telescope delete --json` requires `[{"id":"..."}]`, not `["..."]`** — the natural string-array shape crashes with `Cannot read properties of undefined (reading 'startsWith')`. Wrap each id in an object.
+- **`upsert --json` ignores `x`/`y`/`width` for `file` entities** — text entities honor explicit coordinates; file entities (markdown, wireframe, image) are always placed by layout. Images additionally ignore `width` and land at 128×128.
+- **Search box `fill` + `click` may not trigger navigation** — `fill` may not fire input events. If a click on Search fails, re-fill and retry, or click an autocomplete option ref instead.
+
+## Tracking issue (localhost sessions)
+
+When running against a local Telescope app (`http://localhost:*`), you are working in a development context. If you hit a new CLI gap not listed above:
+
+1. Add it to the list above in this skill file.
+2. Append it as a comment to **[lklyne/telescope#7](https://github.com/lklyne/telescope/issues/7)** using:
+   ```bash
+   gh issue comment 7 --repo lklyne/telescope --body "..."
+   ```
+
+Keep entries terse: one-line description, observed behavior, expected behavior. No need to comment for known issues already tracked.
+
+When a limitation is fixed (confirmed by testing, not just by a closed issue), **remove it from the "Known CLI limitations" list above** and close or note it on the GitHub issue. A stale warning is worse than no warning.
+
+## See also
+
+- `agent-browser` skill — deeper browser-automation reference (invoked via
+  `telescope snapshot`, `telescope click`, etc. under the hood).

--- a/.claude/skills/telescope/references/wireframes.md
+++ b/.claude/skills/telescope/references/wireframes.md
@@ -1,0 +1,200 @@
+# Wireframes
+
+Telescope renders `.wireframe.json` files as interactive wireframe editors on the
+canvas. Use them to sketch UI layouts, explore variants, and iterate spatially
+alongside live frames.
+
+## Creating wireframes
+
+Wireframes are file entities. Create them with `telescope upsert --json`:
+
+```bash
+cat << 'EOF' | telescope upsert --json
+[{
+  "kind": "file",
+  "file": "/tmp/my-layout.wireframe.json",
+  "canvasX": 500,
+  "canvasY": 200,
+  "width": 300
+}]
+EOF
+```
+
+The file must exist on disk and end in `.wireframe.json`. Write the JSON first,
+then upsert it as a file entity.
+
+## Batch placement
+
+Place multiple wireframes side-by-side in one call:
+
+```bash
+cat << 'EOF' | telescope upsert --json
+[
+  { "kind": "file", "file": "/tmp/v1.wireframe.json", "canvasX": 100, "canvasY": 100, "width": 280 },
+  { "kind": "file", "file": "/tmp/v2.wireframe.json", "canvasX": 430, "canvasY": 100, "width": 280 },
+  { "kind": "file", "file": "/tmp/v3.wireframe.json", "canvasX": 760, "canvasY": 100, "width": 280 }
+]
+EOF
+```
+
+Use `telescope find-placement` to find open canvas space before placing.
+
+## File format
+
+```json
+{
+  "version": "1.0",
+  "theme": "light",
+  "root": { "id": "root", "type": "frame", ... }
+}
+```
+
+- **version** — always `"1.0"`
+- **theme** — `"light"`, `"dark"`, or `"blueprint"`
+- **root** — a single `frame` node containing the layout tree
+
+## Node types
+
+### frame (layout container)
+
+The primary layout primitive. Arranges children in a row or column.
+
+```json
+{
+  "id": "sidebar",
+  "type": "frame",
+  "direction": "vertical",
+  "gap": 8,
+  "padding": 16,
+  "width": 200,
+  "height": "fill",
+  "children": [...]
+}
+```
+
+- **direction** — `"horizontal"` or `"vertical"` (default vertical)
+- **gap** — pixel spacing between children
+- **padding** — single number, `[vertical, horizontal]`, or `[top, right, bottom, left]`
+- **width/height** — pixel number, `"fill"` (stretch), or `"hug"` (shrink to content)
+
+### text
+
+```json
+{ "id": "title", "type": "text", "text": "Welcome", "level": "h1" }
+```
+
+Levels: `"h1"`, `"h2"`, `"h3"`, `"body"`, `"caption"`
+
+### button
+
+```json
+{ "id": "save", "type": "button", "text": "Save", "variant": "primary" }
+```
+
+Variants: `"primary"`, `"secondary"`, `"ghost"`
+
+### input
+
+```json
+{ "id": "email", "type": "input", "label": "Email", "placeholder": "you@example.com" }
+```
+
+### dropdown
+
+```json
+{ "id": "lang", "type": "dropdown", "label": "Language", "placeholder": "Select...", "options": ["English", "Spanish"] }
+```
+
+### checkbox
+
+```json
+{ "id": "agree", "type": "checkbox", "label": "I agree", "checked": true }
+```
+
+### toggle
+
+```json
+{ "id": "notify", "type": "toggle", "label": "Notifications", "on": true }
+```
+
+### image (placeholder)
+
+```json
+{ "id": "hero", "type": "image", "width": 400, "height": 200, "alt": "Hero image" }
+```
+
+Renders as a gray placeholder rectangle with the alt text.
+
+### divider
+
+```json
+{ "id": "sep", "type": "divider" }
+```
+
+Horizontal rule spanning the parent width.
+
+### spacer
+
+```json
+{ "id": "gap", "type": "spacer" }
+```
+
+Flexible space — pushes siblings apart (like CSS `flex: 1`).
+
+## Layout patterns
+
+**Header with right-aligned actions:**
+
+```json
+{
+  "id": "header", "type": "frame", "direction": "horizontal", "padding": [12, 16], "gap": 12, "width": "fill",
+  "children": [
+    { "id": "logo", "type": "text", "text": "App", "level": "h3" },
+    { "id": "s", "type": "spacer" },
+    { "id": "login", "type": "button", "text": "Log In", "variant": "primary" }
+  ]
+}
+```
+
+**Form section:**
+
+```json
+{
+  "id": "form", "type": "frame", "direction": "vertical", "padding": 16, "gap": 12, "width": "fill",
+  "children": [
+    { "id": "name", "type": "input", "label": "Name", "placeholder": "Jane Doe" },
+    { "id": "role", "type": "dropdown", "label": "Role", "options": ["Admin", "Editor", "Viewer"] },
+    { "id": "submit", "type": "button", "text": "Save", "variant": "primary" }
+  ]
+}
+```
+
+**Two-column layout:**
+
+```json
+{
+  "id": "body", "type": "frame", "direction": "horizontal", "gap": 0, "width": "fill", "height": "fill",
+  "children": [
+    { "id": "sidebar", "type": "frame", "direction": "vertical", "width": 200, "padding": 16, "gap": 8, "children": [...] },
+    { "id": "content", "type": "frame", "direction": "vertical", "width": "fill", "padding": 24, "gap": 16, "children": [...] }
+  ]
+}
+```
+
+## Interactive features
+
+Wireframes on the canvas are interactive:
+
+- **Text** — click to edit inline
+- **Checkboxes/Toggles** — click to toggle state
+- **Nodes** — drag to reorder within their parent frame
+
+Changes persist back to the `.wireframe.json` file on disk.
+
+## Tips
+
+- Every node needs a unique `id` within the file.
+- Use `"width": "fill"` on the root frame and section frames so they stretch to the entity width on the canvas.
+- Write wireframe files to `/tmp/` for throwaway explorations; write to the project directory if they should persist.
+- Create a title label as a text note alongside wireframes for context:
+  `{ "kind": "text", "text": "V1: Stacked list", "canvasX": 100, "canvasY": 80 }`


### PR DESCRIPTION
## Summary
The telescope skill has been living at `~/.claude/skills/telescope/` (user scope), which meant edits from exploratory branches persisted globally even when those branches never landed. Findings from one branch contaminated the skill across all work.

## What this does
- Copies the skill into `.claude/skills/telescope/` at the repo root so it's versioned with the code it documents.
- Branch-specific edits are now isolated by git — they only surface to collaborators once merged to `main`.

## Followup
After this merges, remove the user-scope copy:

```bash
rm -rf ~/.claude/skills/telescope
```

## Test plan
- [ ] After merge, in a fresh session inside this repo, `/telescope` loads the project-scoped skill (check `SKILL.md` path in the skill header).
- [ ] Outside this repo, `/telescope` no longer appears (expected — it's project-specific now).