### PR TITLE
Spline cursor motion + debug window

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: release
+description: Cut a new Telescope release. Bumps the version, updates CHANGELOG.md, tags, and pushes — CI builds and publishes. Use when the user says "cut a release", "ship a release", "release v0.2.6", "bump the version", or wants to update the changelog and tag.
+allowed-tools: Bash(git *), Bash(pnpm *), Bash(npm version*), Edit, Write, Read, AskUserQuestion
+---
+
+# Release Skill
+
+Cuts a new release of Telescope. Updates the changelog, bumps the version, tags, and pushes. The `release.yml` GitHub Action handles build and publish.
+
+## Guiding principles
+
+- **The changelog is user-facing.** Commits are developer-facing. Translate, group, and trim — don't dump commit messages.
+- **Ask before writing.** Version bump and changelog wording are the two decisions that matter. Never guess silently.
+- **One commit per release.** The version bump commit includes the staged CHANGELOG. `npm version` handles this for us.
+- **No prereleases.** SemVer prerelease suffixes (`-alpha.N`, `-beta.N`) are a footgun with `update.electronjs.org`. Patch/minor/major only.
+
+## Workflow
+
+### Step 1: Preflight
+
+Stop and report to the user if any of these fail:
+
+- Working tree is clean (`git status --porcelain` empty)
+- On `main` (or user explicitly said to release from another branch)
+- Up to date with `origin/main` (`git fetch` then compare)
+
+If any check fails, explain what's off and stop — don't try to fix it silently.
+
+### Step 2: Gather context
+
+Collect in parallel:
+
+- Current version: `node -p "require('./package.json').version"`
+- Last tag: `git describe --tags --abbrev=0`
+- Commits since last tag: `git log <last-tag>..HEAD --oneline`
+- Full commit bodies for those commits: `git log <last-tag>..HEAD --format="%h%n%s%n%b%n---"`
+- Existing `## [Unreleased]` section from `changelog.md`
+
+If there are zero commits since the last tag, stop — nothing to release.
+
+### Step 3: Infer version bump, ask user to confirm
+
+Infer the bump from commits — don't present it as an open question. Read the actual changes, not just prefixes:
+
+- Breaking change to data model, file format, IPC surface, CLI, or HTTP API → **major**
+- New feature, new entity type, new surface, or meaningful capability → **minor**
+- Fixes, polish, internal changes, docs → **patch**
+
+Prefixes (`feat:`, `fix:`, `BREAKING CHANGE:`, `!`) are hints, not rules — weight them against what the diffs actually do.
+
+Use **AskUserQuestion** framed as confirmation of your inference, not as a menu. State the bump you inferred, the one-line reason, and offer options: `confirm <inferred>`, `<other bump>`, `<other bump>`. The inferred option is the default.
+
+### Step 4: Draft the changelog entry
+
+Every release gets a **title** — a short headline that captures what's in this release. Follow Conductor's pattern: descriptive, title-cased, comma-separated when multiple themes.
+
+- Feature release: name the features. `Big Terminal Mode`, `File Previews, Codex Personalities`
+- Fix-heavy release: say so. `Bug Fixes`, `Stability Fixes and Polish`
+- Milestone/holiday: let personality in. `Conductor Wrapped`, `Happy Valentine's Day`
+- Mixed: list the top 1–3 themes. `Bug Fixes, Instant Archiving, @terminal`
+
+Then build the body — combine:
+
+1. Everything already under `## [Unreleased]` in `changelog.md`
+2. User-facing summaries of commits since the last tag (deduped against the Unreleased items — many will already be covered)
+
+The target voice is **Conductor's changelog** (`conductor.build/changelog`): punchy, conversational, user-facing, light on ceremony. Not strict Keep a Changelog — warmer than that.
+
+Style rules:
+
+- **Voice**: write to the user like you're telling a friend what changed. Active, concrete, a little personality. Follow the user's UI copy voice memory — lowercase gerunds, no corporate stiffness.
+- **Grouping**: use informal headings that fit the release. Common ones: `Improvements`, `Fixes`, `Misc`. Use `New` for headline features. Don't force strict `Added/Changed/Fixed` if the release doesn't fit that shape. Omit empty sections.
+- **Length**: most bullets are one short sentence. Headline features can get a 1–2 sentence lede before a bullet list.
+- **Merge related commits**: multiple commits around one thing become one bullet.
+- **Describe the outcome**, not the diff. "Agent cursors fade out gracefully when retired" beats "refactor retirement animation timing."
+- **Drop internal-only noise**: `chore`, dep bumps without user impact, pure refactors, test-only changes, internal docs. If the user wouldn't notice it, it doesn't belong.
+- **Personality is welcome** when a release genuinely calls for it (holidays, milestones). Don't force it — a terse release should stay terse.
+
+### Step 5: Confirm the draft
+
+Show the user the full drafted section — title + body, formatted as it will appear in `changelog.md`. Use **AskUserQuestion** with options:
+
+- `approve` — write it as shown
+- `edit title` — user wants to change the title; iterate
+- `edit body` — user wants to change entries; iterate
+- `cancel` — stop, make no changes
+
+Iterate until the user approves. Respect their wording exactly — don't "improve" it.
+
+### Step 6: Write changelog
+
+Compute the new version: apply the chosen bump to the current version (e.g., `0.2.5` + patch → `0.2.6`).
+
+Edit `changelog.md`:
+
+- Replace the `## [Unreleased]` heading (and its contents) with:
+  ```
+  ## [Unreleased]
+
+  ## [X.Y.Z] - YYYY-MM-DD — <Title>
+
+  <approved content>
+  ```
+- Use today's date from the environment (`currentDate`).
+- Leave the rest of the file untouched.
+
+### Step 7: Bump, commit, tag
+
+- `git add changelog.md`
+- Run the matching script:
+  - patch → `pnpm release:patch`
+  - minor → `pnpm release:minor`
+  - major → no script exists; run `npm version major && git push --follow-tags` directly, and tell the user you're adding a `release:major` script next time they're in `package.json` (don't modify it now)
+
+`npm version` will:
+- Bump `package.json`
+- Include the staged `changelog.md` in the bump commit
+- Create an annotated tag `vX.Y.Z`
+- (The `release:*` scripts then push with `--follow-tags`)
+
+If the tree has unexpected staged changes at this point, stop — something went wrong.
+
+### Step 8: Report
+
+Tell the user:
+
+- New version and tag (e.g., `v0.2.6`)
+- Tag has been pushed; the `release.yml` workflow will build and publish
+- Link to the Actions tab: `https://github.com/lklyne/telescope/actions`
+- Reminder to check the GitHub Release draft and flip "prerelease" off if needed before publishing
+
+## Notes
+
+- Never use `--no-verify` or `-f` on `npm version`. If it fails, the tree is dirty for a reason — investigate.
+- The `update.electronjs.org` caveat is in `changelog.md` line 5. If a user asks for an alpha release, point them there and confirm they really want to do it before proceeding.
+- `changelog.md` and `CHANGELOG.md` resolve to the same file on macOS (case-insensitive FS). Use `changelog.md` — that's what exists on disk.
+- If the user invokes this skill mid-session with uncommitted work, offer to stash it before preflight fails, but don't auto-stash.

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -48,6 +48,11 @@ const config: ForgeConfig = {
           target: 'main',
         },
         {
+          entry: 'src/preload/debug.ts',
+          config: 'vite.preload.config.ts',
+          target: 'preload',
+        },
+        {
           entry: 'src/preload/toolbar.ts',
           config: 'vite.preload.config.ts',
           target: 'preload',

--- a/src/main/debug-window.ts
+++ b/src/main/debug-window.ts
@@ -1,0 +1,64 @@
+import { BrowserWindow } from 'electron'
+import type { WebContents } from 'electron'
+import { loadRenderer, preloadPath } from './runtime/load-renderer'
+import { isDark } from './runtime/preferences'
+
+let debugWindow: BrowserWindow | null = null
+
+const WINDOW_WIDTH = 1024
+const WINDOW_HEIGHT = 720
+
+export function isDebugWindowOpen(): boolean {
+  return debugWindow !== null && !debugWindow.isDestroyed()
+}
+
+export function focusDebugWindow(): void {
+  if (isDebugWindowOpen()) debugWindow!.focus()
+}
+
+function createDebugWindow(): BrowserWindow {
+  const win = new BrowserWindow({
+    width: WINDOW_WIDTH,
+    height: WINDOW_HEIGHT,
+    resizable: true,
+    minimizable: true,
+    maximizable: true,
+    fullscreenable: true,
+    title: 'Telescope Debug',
+    titleBarStyle: 'hiddenInset',
+    show: false,
+    backgroundColor: isDark() ? '#18181b' : '#fafafa',
+    ...(process.platform === 'darwin'
+      ? { trafficLightPosition: { x: 14, y: 13 } }
+      : {}),
+    webPreferences: {
+      preload: preloadPath('debug'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  })
+
+  loadRenderer(win, 'debug')
+  win.once('ready-to-show', () => win.show())
+  win.on('closed', () => {
+    debugWindow = null
+  })
+  return win
+}
+
+export function showDebugWindow(): void {
+  if (isDebugWindowOpen()) {
+    debugWindow!.focus()
+    return
+  }
+  debugWindow = createDebugWindow()
+}
+
+export function getDebugWebContents(): WebContents | null {
+  if (!isDebugWindowOpen()) return null
+  return debugWindow!.webContents
+}
+
+export function closeDebugWindow(): void {
+  if (isDebugWindowOpen()) debugWindow!.close()
+}

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -5,9 +5,11 @@ import { registerOnboardingIpc } from './ipc/register-onboarding-ipc'
 import { registerPageChromeIpc } from './ipc/register-page-chrome-ipc'
 import { registerRightDetailsPanelIpc } from './ipc/register-right-details-panel-ipc'
 import { registerToolbarIpc } from './ipc/register-toolbar-ipc'
+import { registerDebugIpc } from './ipc/register-debug-ipc'
 
 export function registerIpcHandlers(): void {
   registerAppIpc()
+  registerDebugIpc()
   registerToolbarIpc()
   registerCanvasIpc()
   registerRightDetailsPanelIpc()

--- a/src/main/ipc/register-debug-ipc.ts
+++ b/src/main/ipc/register-debug-ipc.ts
@@ -1,0 +1,51 @@
+import { ipcMain } from 'electron'
+import { DEFAULT_CURSOR_MOTION, normalizeCursorMotion } from '../../shared/cursor-motion'
+import {
+  DEFAULT_CURSOR_TUNING,
+  normalizeCursorTuning,
+} from '../../shared/cursor-tuning'
+import type { DebugBootstrapData } from '../../shared/types'
+import {
+  broadcastCursorMotion,
+  broadcastCursorSplineViz,
+  getCursorMotion,
+  getCursorSplineViz,
+  getCursorTuning,
+  isDark,
+  saveCursorMotion,
+  saveCursorSplineViz,
+  saveCursorTuning,
+} from '../runtime/preferences'
+
+export function registerDebugIpc(): void {
+  ipcMain.handle('debug:get-initial-data', async (): Promise<DebugBootstrapData> => ({
+    theme: { isDark: isDark() },
+    cursorMotion: getCursorMotion(),
+    cursorSplineViz: getCursorSplineViz(),
+    cursorTuning: getCursorTuning(),
+    presenceTimeline: [],
+  }))
+
+  ipcMain.on('debug:update-cursor-motion', (_event, raw: unknown) => {
+    saveCursorMotion(normalizeCursorMotion(raw))
+    broadcastCursorMotion()
+  })
+
+  ipcMain.on('debug:reset-cursor-motion', () => {
+    saveCursorMotion(DEFAULT_CURSOR_MOTION)
+    broadcastCursorMotion()
+  })
+
+  ipcMain.on('debug:update-cursor-spline-viz', (_event, on: unknown) => {
+    saveCursorSplineViz(on === true)
+    broadcastCursorSplineViz()
+  })
+
+  ipcMain.on('debug:update-cursor-tuning', (_event, raw: unknown) => {
+    saveCursorTuning(normalizeCursorTuning(raw))
+  })
+
+  ipcMain.on('debug:reset-cursor-tuning', () => {
+    saveCursorTuning(DEFAULT_CURSOR_TUNING)
+  })
+}

--- a/src/main/presence-cursor.ts
+++ b/src/main/presence-cursor.ts
@@ -75,6 +75,9 @@ export const PRESENCE_CURSOR_STEP_DELAY_MS = PRESENCE_STEP_DELAY_MS
 const PRESENCE_CURSOR_THINKING_DELAY_MS = PRESENCE_THINKING_DELAY_MS
 const PRESENCE_DEPARTURE_GRACE_MS = 1500
 const PRESENCE_IDLE_RETIRE_MS = 10_000
+const PRESENCE_MOVE_LOGGING_ENABLED =
+  process.env.NODE_ENV !== 'production' ||
+  Boolean(process.env.MAIN_WINDOW_VITE_DEV_SERVER_URL)
 
 // --- Coercion validation sets ---
 
@@ -246,6 +249,107 @@ export function coercePresenceTargetRefSource(value: unknown): PresenceTargetRef
     : null
 }
 
+function formatCoord(value: number | null | undefined): string {
+  return typeof value === 'number' ? value.toFixed(1) : '-'
+}
+
+function formatTargetRect(rect: PresenceTargetRect | null | undefined): string {
+  if (!rect) return '-'
+  return `${rect.x.toFixed(1)},${rect.y.toFixed(1)},${rect.width.toFixed(1)},${rect.height.toFixed(1)}`
+}
+
+function coordSourceForLog(
+  existing: PresenceCursorEntry | undefined,
+  patch: {
+    surface?: PresenceSurface
+    frameX?: number | null
+    frameY?: number | null
+    targetRect?: PresenceTargetRect | null
+    canvasX?: number
+    canvasY?: number
+  },
+): string {
+  const surface = patch.surface ?? existing?.surface ?? 'canvas'
+  if (surface !== 'frame') return 'canvas'
+  if (typeof patch.frameX === 'number' && typeof patch.frameY === 'number') {
+    return 'frame-point'
+  }
+  if (patch.targetRect) return 'target-rect'
+  if (typeof patch.canvasX === 'number' && typeof patch.canvasY === 'number') {
+    return 'canvas-only'
+  }
+  return 'existing'
+}
+
+function logPresenceMove(
+  request: IncomingMessage,
+  source: 'upsertPresenceCursor' | 'movePresenceCursorTo',
+  sessionId: string,
+  clientName: string,
+  existing: PresenceCursorEntry | undefined,
+  next: PresenceCursorEntry,
+  patch: {
+    body?: Record<string, unknown>
+    canvasX?: number
+    canvasY?: number
+    frameX?: number | null
+    frameY?: number | null
+    targetRect?: PresenceTargetRect | null
+  },
+): void {
+  if (!PRESENCE_MOVE_LOGGING_ENABLED) return
+  const changed =
+    !existing ||
+    existing.canvasX !== next.canvasX ||
+    existing.canvasY !== next.canvasY
+  if (!changed) return
+  if (!existing && patch.canvasX === undefined && patch.canvasY === undefined) return
+
+  const body = patch.body ?? {}
+  const route = `${request.method ?? 'GET'} ${request.url ?? ''}`.trim()
+  const eventType =
+    typeof body.eventType === 'string' ? body.eventType : null
+  const command = typeof body.command === 'string' ? body.command : null
+  const coordSource = coordSourceForLog(existing, patch)
+  const suspiciousCenterFallback =
+    next.surface === 'frame' &&
+    coordSource === 'canvas-only' &&
+    typeof next.frameX !== 'number' &&
+    typeof next.frameY !== 'number' &&
+    !next.targetRect
+  const prevX = existing?.canvasX
+  const prevY = existing?.canvasY
+  const dx =
+    typeof prevX === 'number' ? (next.canvasX - prevX).toFixed(1) : 'n/a'
+  const dy =
+    typeof prevY === 'number' ? (next.canvasY - prevY).toFixed(1) : 'n/a'
+
+  const parts = [
+    '[presence-move]',
+    `source=${source}`,
+    `route=${JSON.stringify(route)}`,
+    `session=${sessionId.slice(0, 8)}`,
+    `client=${JSON.stringify(clientName)}`,
+    `from=(${formatCoord(prevX)},${formatCoord(prevY)})`,
+    `to=(${formatCoord(next.canvasX)},${formatCoord(next.canvasY)})`,
+    `delta=(${dx},${dy})`,
+    `surface=${next.surface}`,
+    `activity=${next.activity}`,
+    `label=${next.labelKey ?? '-'}`,
+    `coordSource=${coordSource}`,
+    `frame=${next.frameId ?? '-'}`,
+    `framePoint=(${formatCoord(next.frameX)},${formatCoord(next.frameY)})`,
+    `targetRect=${formatTargetRect(next.targetRect)}`,
+    `targetRef=${next.targetRef ?? '-'}`,
+    `targetName=${JSON.stringify(next.targetName ?? '-')}`,
+  ]
+  if (eventType) parts.push(`event=${eventType}`)
+  if (command) parts.push(`command=${command}`)
+  if (suspiciousCenterFallback) parts.push('suspect=center-fallback')
+
+  console.log(parts.join(' '))
+}
+
 // --- Cursor mutation functions ---
 
 export function upsertPresenceCursor(
@@ -280,7 +384,7 @@ export function upsertPresenceCursor(
   }
 
   const existing = presenceCursors.get(sessionId)
-  presenceCursors.set(sessionId, {
+  const next: PresenceCursorEntry = {
     sessionId,
     clientName: session.clientName,
     color: existing?.color ?? deriveColor(sessionId),
@@ -333,7 +437,18 @@ export function upsertPresenceCursor(
         ? existing?.targetRect ?? null
         : patch.targetRect,
     updatedAt: Date.now(),
-  })
+  }
+
+  presenceCursors.set(sessionId, next)
+  logPresenceMove(
+    request,
+    'upsertPresenceCursor',
+    sessionId,
+    session.clientName,
+    existing,
+    next,
+    patch,
+  )
 
   schedulePresenceExpiry()
   notifyPresenceChanged()
@@ -507,7 +622,7 @@ export function movePresenceCursorTo(
   if (existing.canvasX === canvasX && existing.canvasY === canvasY && existing.labelKey === labelKey) {
     return
   }
-  presenceCursors.set(resolved.sessionId, {
+  const next: PresenceCursorEntry = {
     ...existing,
     canvasX,
     canvasY,
@@ -515,7 +630,17 @@ export function movePresenceCursorTo(
     activity: 'traveling',
     labelKey,
     updatedAt: Date.now(),
-  })
+  }
+  presenceCursors.set(resolved.sessionId, next)
+  logPresenceMove(
+    request,
+    'movePresenceCursorTo',
+    resolved.sessionId,
+    resolved.session.clientName,
+    existing,
+    next,
+    { canvasX, canvasY },
+  )
   notifyPresenceChanged()
 }
 

--- a/src/main/presence-cursor.ts
+++ b/src/main/presence-cursor.ts
@@ -124,7 +124,7 @@ export function notifyPresenceChanged(): void {
 }
 
 function schedulePresenceExpiry(): void {
-  if (presenceExpiryTimer) clearTimeout(presenceExpiryTimer)
+  if (presenceExpiryTimer) return
   presenceExpiryTimer = setTimeout(() => {
     presenceExpiryTimer = null
     const before = presenceCursors.size + activePresenceTasks.size

--- a/src/main/presence-manager.ts
+++ b/src/main/presence-manager.ts
@@ -162,9 +162,11 @@ export function resolveCanvasPointForFrame(
     fallbackX: width / 2,
     fallbackY: height / 2,
   })
+  // `page.canvasY` is the top of the frame's chrome band; the DOM point lives
+  // in content coordinates, so shift down by chromeHeight to land on the page.
   return {
     canvasX: page.canvasX + clamp(point.x, 0, width),
-    canvasY: page.canvasY + clamp(point.y, 0, height),
+    canvasY: page.canvasY + page.chromeHeight + clamp(point.y, 0, height),
   }
 }
 

--- a/src/main/presence-manager.ts
+++ b/src/main/presence-manager.ts
@@ -71,6 +71,7 @@ import { resolveSession } from './presence-session'
 import {
   activePresenceTasks,
   bumpActiveScanId,
+  presenceCursors,
   upsertPresenceCursor,
   upsertActivePresenceTask,
   scheduleThinkingState,
@@ -486,16 +487,27 @@ export function updatePresenceCursor(
   body: Record<string, unknown>,
 ): void {
   if (url === '/session/presence') return
+  if (url === '/session/presence/intent') return
   if (url.startsWith('/mcp/session/')) return
   bumpActiveScanId()
 
+  const resolved = resolveSession(request, body)
   const frameId = deriveFrameId(url, body)
-  const position = normalizeCanvasPosition(
-    extractCanvasPosition(url, body) ??
-    (frameId
-      ? resolveCanvasPointForFrame(frameId)
-      : null),
-  )
+  const labelKey = deriveLabelKey(url, method)
+  const existingCursor = resolved ? presenceCursors.get(resolved.sessionId) : null
+  const isAttachFrame = labelKey === 'attach_frame'
+  const preserveSameFramePosition =
+    isAttachFrame &&
+    frameId !== null &&
+    existingCursor?.surface === 'frame' &&
+    existingCursor.frameId === frameId
+
+  const position = preserveSameFramePosition
+    ? { x: existingCursor.canvasX, y: existingCursor.canvasY }
+    : normalizeCanvasPosition(
+        extractCanvasPosition(url, body) ??
+          (frameId ? resolveCanvasPointForFrame(frameId) : null),
+      )
 
   upsertPresenceCursor(request, {
     body,
@@ -504,10 +516,10 @@ export function updatePresenceCursor(
     surface: frameId ? 'frame' : 'canvas',
     activity: 'acting',
     frameId,
-    labelKey: deriveLabelKey(url, method),
+    labelKey,
   })
 
-  if (activePresenceTasks.has(resolveSession(request, body)?.sessionId ?? '')) {
+  if (resolved && activePresenceTasks.has(resolved.sessionId)) {
     upsertActivePresenceTask(request, {
       body,
       surface: frameId ? 'frame' : 'canvas',

--- a/src/main/routes/session.ts
+++ b/src/main/routes/session.ts
@@ -202,16 +202,27 @@ export const sessionRoutes: Route[] = [
       const targetRect = resolvePresenceTargetRect(frameId, targetRef, targetRefSource, null)
       const observationCommands = new Set(['snapshot', 'wait', 'get'])
       const isObservation = observationCommands.has(command)
-      // For mutation commands with an agent-browser ref we can't resolve to
-      // bounds, skip the center fallback and let CDP mouseMoved drive the
-      // cursor — otherwise it lands at frame center then snaps to the target.
-      const framePosition =
-        frameId && (targetRect || isObservation)
-          ? resolveCanvasPointForFrame(frameId, {
-              frameX: undefined,
-              frameY: isObservation ? 20 : undefined,
-              targetRect,
-            })
+      const currentCursor = getPresenceCursors().find(
+        (cursor) => cursor.sessionId === resolved.sessionId,
+      )
+      // When we're issuing an intent for the same frame the cursor is already
+      // in and can't resolve a targetRect (e.g. mutation intents whose ref is
+      // agent-browser-opaque, or observations like snapshot/wait/get), preserve
+      // the cursor's existing position. Nulling frameX/frameY here causes
+      // buildCanvasLayoutData to fall back to frame center and the renderer
+      // visibly hops between real interactions in the same frame.
+      const preserveSameFramePosition =
+        frameId !== null &&
+        !targetRect &&
+        currentCursor?.surface === 'frame' &&
+        currentCursor.frameId === frameId
+      const framePosition = preserveSameFramePosition
+        ? {
+            canvasX: currentCursor.canvasX,
+            canvasY: currentCursor.canvasY,
+          }
+        : frameId && (targetRect || isObservation)
+          ? resolveCanvasPointForFrame(frameId, { targetRect })
           : null
 
       upsertActivePresenceTask(request, {
@@ -233,8 +244,8 @@ export const sessionRoutes: Route[] = [
         surface: frameId ? 'frame' : 'canvas',
         activity: 'traveling',
         frameId,
-        frameX: null,
-        frameY: null,
+        frameX: preserveSameFramePosition ? undefined : null,
+        frameY: preserveSameFramePosition ? undefined : null,
         labelKey,
         taskLabel,
         labelHint,

--- a/src/main/runtime/app-menu.ts
+++ b/src/main/runtime/app-menu.ts
@@ -5,6 +5,7 @@ import { workspaceViewMode } from '../ui-state'
 import { selectBrowserTab } from './runtime-core'
 import { checkForUpdatesManually } from '../auto-updater'
 import { showOnboardingWindow } from '../onboarding-window'
+import { showDebugWindow } from '../debug-window'
 import {
   bundledSkillHash,
   installedSkillHash,
@@ -125,6 +126,11 @@ function buildTemplate(): Electron.MenuItemConstructorOptions[] {
       label: 'View',
       submenu: [
         { role: 'toggleDevTools' },
+        {
+          label: 'Open Motion Debug Window',
+          accelerator: 'CmdOrCtrl+Shift+D',
+          click: () => showDebugWindow(),
+        },
         { type: 'separator' },
         { role: 'togglefullscreen' },
       ],

--- a/src/main/runtime/canvas-layout-data.ts
+++ b/src/main/runtime/canvas-layout-data.ts
@@ -388,9 +388,11 @@ export function buildCanvasLayoutData(
             // render outside the frame when targeting off-screen elements.
             const clampedX = Math.max(0, Math.min(point.x, frame.width))
             const clampedY = Math.max(0, Math.min(point.y, frame.height))
+            const page = findPageById(frame.id)
+            const chromeHeight = page?.chromeHeight ?? 0
             return {
               canvasX: frame.canvasX + clampedX,
-              canvasY: frame.canvasY + clampedY,
+              canvasY: frame.canvasY + chromeHeight + clampedY,
             }
           }
         }

--- a/src/main/runtime/preferences.ts
+++ b/src/main/runtime/preferences.ts
@@ -4,7 +4,7 @@
 
 import { app, nativeTheme } from 'electron'
 import { join } from 'path'
-import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { readFileSync, writeFileSync } from 'fs'
 import type {
   CursorMotionParams,
   DevtoolsPanelTab,
@@ -76,10 +76,9 @@ let currentCursorTuning: CursorTuningParams = { ...DEFAULT_CURSOR_TUNING }
 
 function readPreferencesFile(): PreferencesFile {
   try {
-    const file = preferencesPath()
-    if (!existsSync(file)) return {}
-    return JSON.parse(readFileSync(file, 'utf8')) as PreferencesFile
+    return JSON.parse(readFileSync(preferencesPath(), 'utf8')) as PreferencesFile
   } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return {}
     console.error('Failed to read preferences:', error)
     return {}
   }
@@ -271,30 +270,21 @@ export function broadcastTheme(): void {
   }
 }
 
-export function broadcastCursorMotion(): void {
-  const params = currentCursorMotion
-  if (bgView && !bgView.webContents.isDestroyed()) {
-    bgView.webContents.send('cursor-motion-changed', params)
-  }
-  if (aboveView && !aboveView.webContents.isDestroyed()) {
-    aboveView.webContents.send('cursor-motion-changed', params)
-  }
-  const debugWebContents = getDebugWebContents()
-  if (debugWebContents && !debugWebContents.isDestroyed()) {
-    debugWebContents.send('cursor-motion-changed', params)
+function broadcastToDebugTargets(channel: string, payload: unknown): void {
+  const targets = [
+    bgView?.webContents,
+    aboveView?.webContents,
+    getDebugWebContents(),
+  ]
+  for (const wc of targets) {
+    if (wc && !wc.isDestroyed()) wc.send(channel, payload)
   }
 }
 
+export function broadcastCursorMotion(): void {
+  broadcastToDebugTargets('cursor-motion-changed', currentCursorMotion)
+}
+
 export function broadcastCursorSplineViz(): void {
-  const on = currentCursorSplineViz
-  if (bgView && !bgView.webContents.isDestroyed()) {
-    bgView.webContents.send('cursor-spline-viz-changed', on)
-  }
-  if (aboveView && !aboveView.webContents.isDestroyed()) {
-    aboveView.webContents.send('cursor-spline-viz-changed', on)
-  }
-  const debugWebContents = getDebugWebContents()
-  if (debugWebContents && !debugWebContents.isDestroyed()) {
-    debugWebContents.send('cursor-spline-viz-changed', on)
-  }
+  broadcastToDebugTargets('cursor-spline-viz-changed', currentCursorSplineViz)
 }

--- a/src/main/runtime/preferences.ts
+++ b/src/main/runtime/preferences.ts
@@ -6,12 +6,23 @@ import { app, nativeTheme } from 'electron'
 import { join } from 'path'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import type {
+  CursorMotionParams,
   DevtoolsPanelTab,
   FixConfig,
   OnboardingState,
   OriginBinding,
   OriginBindings,
 } from '../../shared/types'
+import {
+  DEFAULT_CURSOR_MOTION,
+  normalizeCursorMotion,
+} from '../../shared/cursor-motion'
+import {
+  DEFAULT_CURSOR_TUNING,
+  normalizeCursorTuning,
+  type CursorTuningParams,
+} from '../../shared/cursor-tuning'
+import { getDebugWebContents } from '../debug-window'
 import {
   bgView,
   aboveView,
@@ -52,7 +63,16 @@ type PreferencesFile = {
   onboarding?: OnboardingState
   originBindings?: OriginBindings
   fixConfig?: Omit<FixConfig, 'configured'>
+  debug?: {
+    cursorMotion?: CursorMotionParams
+    cursorSplineViz?: boolean
+    cursorTuning?: CursorTuningParams
+  }
 }
+
+let currentCursorMotion: CursorMotionParams = DEFAULT_CURSOR_MOTION
+let currentCursorSplineViz = false
+let currentCursorTuning: CursorTuningParams = { ...DEFAULT_CURSOR_TUNING }
 
 function readPreferencesFile(): PreferencesFile {
   try {
@@ -129,6 +149,48 @@ export function loadPreferences(): void {
   if (parsed.fixConfig && typeof parsed.fixConfig === 'object') {
     fixConfig = { ...DEFAULT_FIX_CONFIG, ...parsed.fixConfig, configured: true }
   }
+  currentCursorMotion = normalizeCursorMotion(parsed.debug?.cursorMotion)
+  currentCursorSplineViz = parsed.debug?.cursorSplineViz === true
+  currentCursorTuning = normalizeCursorTuning(parsed.debug?.cursorTuning)
+}
+
+export function getCursorMotion(): CursorMotionParams {
+  return currentCursorMotion
+}
+
+export function getCursorSplineViz(): boolean {
+  return currentCursorSplineViz
+}
+
+export function saveCursorSplineViz(next: boolean): void {
+  currentCursorSplineViz = next === true
+  const parsed = readPreferencesFile()
+  writePreferencesFile({
+    ...parsed,
+    debug: { ...parsed.debug, cursorSplineViz: currentCursorSplineViz },
+  })
+}
+
+export function saveCursorMotion(next: CursorMotionParams): void {
+  currentCursorMotion = normalizeCursorMotion(next)
+  const parsed = readPreferencesFile()
+  writePreferencesFile({
+    ...parsed,
+    debug: { ...parsed.debug, cursorMotion: currentCursorMotion },
+  })
+}
+
+export function getCursorTuning(): CursorTuningParams {
+  return currentCursorTuning
+}
+
+export function saveCursorTuning(next: CursorTuningParams): void {
+  currentCursorTuning = normalizeCursorTuning(next)
+  const parsed = readPreferencesFile()
+  writePreferencesFile({
+    ...parsed,
+    debug: { ...parsed.debug, cursorTuning: currentCursorTuning },
+  })
 }
 
 export function savePreferences(): void {
@@ -198,9 +260,41 @@ export function broadcastTheme(): void {
   if (devtoolsResizeHandleView && !devtoolsResizeHandleView.webContents.isDestroyed()) {
     devtoolsResizeHandleView.webContents.send('theme-changed', data)
   }
+  const debugWebContents = getDebugWebContents()
+  if (debugWebContents && !debugWebContents.isDestroyed()) {
+    debugWebContents.send('theme-changed', data)
+  }
   for (let i = 0; i < pages.length; i++) {
     const page = pages[i]
     page.frameView.setBackgroundColor(frameColor())
     page.chromeView.webContents.send('theme-changed', data)
+  }
+}
+
+export function broadcastCursorMotion(): void {
+  const params = currentCursorMotion
+  if (bgView && !bgView.webContents.isDestroyed()) {
+    bgView.webContents.send('cursor-motion-changed', params)
+  }
+  if (aboveView && !aboveView.webContents.isDestroyed()) {
+    aboveView.webContents.send('cursor-motion-changed', params)
+  }
+  const debugWebContents = getDebugWebContents()
+  if (debugWebContents && !debugWebContents.isDestroyed()) {
+    debugWebContents.send('cursor-motion-changed', params)
+  }
+}
+
+export function broadcastCursorSplineViz(): void {
+  const on = currentCursorSplineViz
+  if (bgView && !bgView.webContents.isDestroyed()) {
+    bgView.webContents.send('cursor-spline-viz-changed', on)
+  }
+  if (aboveView && !aboveView.webContents.isDestroyed()) {
+    aboveView.webContents.send('cursor-spline-viz-changed', on)
+  }
+  const debugWebContents = getDebugWebContents()
+  if (debugWebContents && !debugWebContents.isDestroyed()) {
+    debugWebContents.send('cursor-spline-viz-changed', on)
   }
 }

--- a/src/preload/debug.ts
+++ b/src/preload/debug.ts
@@ -1,0 +1,49 @@
+import { contextBridge, ipcRenderer } from 'electron'
+import type {
+  CursorMotionParams,
+  DebugElectronAPI,
+  PresenceDebugEntry,
+  ThemeData,
+} from '../shared/types'
+
+const api: DebugElectronAPI = {
+  getInitialData: () => ipcRenderer.invoke('debug:get-initial-data'),
+  updateCursorMotion: (params) =>
+    ipcRenderer.send('debug:update-cursor-motion', params),
+  resetCursorMotion: () => ipcRenderer.send('debug:reset-cursor-motion'),
+  onCursorMotionChanged: (callback) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      params: CursorMotionParams,
+    ) => callback(params)
+    ipcRenderer.on('cursor-motion-changed', handler)
+    return () => ipcRenderer.removeListener('cursor-motion-changed', handler)
+  },
+  updateCursorSplineViz: (on) =>
+    ipcRenderer.send('debug:update-cursor-spline-viz', on),
+  onCursorSplineVizChanged: (callback) => {
+    const handler = (_event: Electron.IpcRendererEvent, on: boolean) =>
+      callback(on)
+    ipcRenderer.on('cursor-spline-viz-changed', handler)
+    return () => ipcRenderer.removeListener('cursor-spline-viz-changed', handler)
+  },
+  updateCursorTuning: (params) =>
+    ipcRenderer.send('debug:update-cursor-tuning', params),
+  resetCursorTuning: () => ipcRenderer.send('debug:reset-cursor-tuning'),
+  onPresenceTimelineAppend: (callback) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      entry: PresenceDebugEntry,
+    ) => callback(entry)
+    ipcRenderer.on('presence-timeline-append', handler)
+    return () => ipcRenderer.removeListener('presence-timeline-append', handler)
+  },
+  onThemeChanged: (callback) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: ThemeData) =>
+      callback(data)
+    ipcRenderer.on('theme-changed', handler)
+    return () => ipcRenderer.removeListener('theme-changed', handler)
+  },
+}
+
+contextBridge.exposeInMainWorld('electronAPI', api)

--- a/src/renderer/canvas-bg/AgentCursorLayer.tsx
+++ b/src/renderer/canvas-bg/AgentCursorLayer.tsx
@@ -12,6 +12,7 @@ import {
   PRESENCE_TRAVEL_MS,
   PRESENCE_STEP_DELAY_MS,
 } from '../../shared/presence-timing'
+import { FilledCursorIcon } from '../shared/FilledCursorIcon'
 
 const ANIMATE_DURATION_MS = PRESENCE_TRAVEL_MS
 const PRODUCTION_CURSOR_MOTION = {
@@ -20,30 +21,6 @@ const PRODUCTION_CURSOR_MOTION = {
   distanceScaling: 0,
 }
 const POSITION_EPSILON = 0.5
-
-export function FilledCursorIcon({
-  color,
-  size = 16,
-}: {
-  color: string
-  size?: number
-}) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill={color}
-      stroke="rgba(255,255,255,0.9)"
-      strokeWidth={1.5}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      style={{ filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.3))' }}
-    >
-      <path d="M4.037 4.688a.495.495 0 0 1 .651-.651l16 6.5a.5.5 0 0 1-.063.947l-6.124 1.58a2 2 0 0 0-1.438 1.435l-1.579 6.126a.5.5 0 0 1-.947.063z" />
-    </svg>
-  )
-}
 
 function activityStyle(activity: PresenceActivity): CSSProperties {
   switch (activity) {

--- a/src/renderer/canvas-bg/AgentCursorLayer.tsx
+++ b/src/renderer/canvas-bg/AgentCursorLayer.tsx
@@ -5,6 +5,8 @@ import type {
   PresenceActivity,
 } from '../../shared/types'
 import { labelForPresenceCursor } from '../../shared/agent-presence'
+import { DEFAULT_CURSOR_MOTION, easeAt } from '../../shared/cursor-motion'
+import { foldSpline } from '../../shared/cursor-spline'
 import { framePointMatchesTargetRect } from '../../shared/presence-targeting'
 import {
   PRESENCE_TRAVEL_MS,
@@ -12,8 +14,14 @@ import {
 } from '../../shared/presence-timing'
 
 const ANIMATE_DURATION_MS = PRESENCE_TRAVEL_MS
+const PRODUCTION_CURSOR_MOTION = {
+  ...DEFAULT_CURSOR_MOTION,
+  durationMs: ANIMATE_DURATION_MS,
+  distanceScaling: 0,
+}
+const POSITION_EPSILON = 0.5
 
-function FilledCursorIcon({
+export function FilledCursorIcon({
   color,
   size = 16,
 }: {
@@ -128,8 +136,15 @@ function AgentCursor({
 }) {
   const label = labelForPresenceCursor(cursor)
   const [rippleKey, setRippleKey] = useState<number | null>(null)
+  const [displayPoint, setDisplayPoint] = useState(() => ({
+    x: cursor.canvasX,
+    y: cursor.canvasY,
+  }))
   const rippleCounterRef = useRef(0)
   const prevActivity = useRef(cursor.activity)
+  const animationFrameRef = useRef<number | null>(null)
+  const pointRef = useRef(displayPoint)
+  const tangentRef = useRef({ x: 1, y: 0 })
 
   useEffect(() => {
     const wasClick =
@@ -142,18 +157,72 @@ function AgentCursor({
     }
   }, [cursor.activity, cursor.labelKey])
 
-  // Position is in canvas units — the parent wrapper applies the canvas
-  // transform, so pan/zoom move this with the canvas atomically. Only
-  // director-driven motion triggers the CSS transition.
+  useEffect(() => {
+    pointRef.current = displayPoint
+  }, [displayPoint])
+
+  useEffect(() => {
+    return () => {
+      if (animationFrameRef.current !== null) {
+        cancelAnimationFrame(animationFrameRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    const target = { x: cursor.canvasX, y: cursor.canvasY }
+    const current = pointRef.current
+
+    if (
+      Math.abs(target.x - current.x) < POSITION_EPSILON &&
+      Math.abs(target.y - current.y) < POSITION_EPSILON
+    ) {
+      pointRef.current = target
+      setDisplayPoint(target)
+      return
+    }
+
+    if (animationFrameRef.current !== null) {
+      cancelAnimationFrame(animationFrameRef.current)
+    }
+
+    const spline = foldSpline(current, tangentRef.current, [target])
+    let startedAt = 0
+
+    const tick = (now: number) => {
+      if (startedAt === 0) startedAt = now
+      const progress = Math.min(1, (now - startedAt) / PRODUCTION_CURSOR_MOTION.durationMs)
+      const sample = spline.sampleT(easeAt(PRODUCTION_CURSOR_MOTION.easing, progress))
+      pointRef.current = sample.position
+      tangentRef.current = sample.tangent
+      setDisplayPoint(sample.position)
+
+      if (progress < 1) {
+        animationFrameRef.current = requestAnimationFrame(tick)
+      } else {
+        animationFrameRef.current = null
+        pointRef.current = target
+        setDisplayPoint(target)
+      }
+    }
+
+    animationFrameRef.current = requestAnimationFrame(tick)
+    return () => {
+      if (animationFrameRef.current !== null) {
+        cancelAnimationFrame(animationFrameRef.current)
+        animationFrameRef.current = null
+      }
+    }
+  }, [cursor.canvasX, cursor.canvasY])
+
   const positionStyle: CSSProperties = useMemo(
     () => ({
       left: 0,
       top: 0,
-      transform: `translate3d(${cursor.canvasX}px, ${cursor.canvasY}px, 0)`,
-      transition: `transform ${ANIMATE_DURATION_MS}ms cubic-bezier(0.4, 0, 0.2, 1)`,
+      transform: `translate3d(${displayPoint.x}px, ${displayPoint.y}px, 0)`,
       willChange: 'transform',
     }),
-    [cursor.canvasX, cursor.canvasY],
+    [displayPoint.x, displayPoint.y],
   )
 
   // Counter-scale keeps icon, label, and ripple at constant screen size

--- a/src/renderer/debug/App.tsx
+++ b/src/renderer/debug/App.tsx
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useState } from 'react'
+import type {
+  CursorMotionParams,
+  CursorTuningParams,
+  DebugBootstrapData,
+  DebugElectronAPI,
+  PresenceDebugEntry,
+} from '../../shared/types'
+import { DEFAULT_CURSOR_TUNING } from '../../shared/cursor-tuning'
+import { useTheme } from '../shared/hooks/useTheme'
+import { CursorMotionSection } from './CursorMotionSection'
+import { PresenceSection } from './PresenceSection'
+
+type SectionId = 'cursor-motion' | 'presence'
+
+const SECTIONS: Array<{ id: SectionId; label: string }> = [
+  { id: 'cursor-motion', label: 'Cursor motion (legacy)' },
+  { id: 'presence', label: 'Presence' },
+]
+
+export default function App({
+  api,
+  initialData,
+}: {
+  api: DebugElectronAPI
+  initialData: DebugBootstrapData
+}) {
+  useTheme(initialData.theme, api.onThemeChanged)
+  const [activeSection, setActiveSection] = useState<SectionId>('presence')
+  const [cursorMotion, setCursorMotion] = useState<CursorMotionParams>(
+    initialData.cursorMotion,
+  )
+  const [splineViz, setSplineViz] = useState<boolean>(initialData.cursorSplineViz)
+  const [cursorTuning, setCursorTuning] = useState<CursorTuningParams>(
+    initialData.cursorTuning,
+  )
+
+  useEffect(() => api.onCursorMotionChanged(setCursorMotion), [api])
+  useEffect(() => api.onCursorSplineVizChanged(setSplineViz), [api])
+
+  const subscribeTimeline = useCallback(
+    (cb: (entry: PresenceDebugEntry) => void) =>
+      api.onPresenceTimelineAppend(cb),
+    [api],
+  )
+
+  const commitCursorMotion = (next: CursorMotionParams) => {
+    setCursorMotion(next)
+    api.updateCursorMotion(next)
+  }
+
+  const commitSplineViz = (next: boolean) => {
+    setSplineViz(next)
+    api.updateCursorSplineViz(next)
+  }
+
+  const commitCursorTuning = (next: CursorTuningParams) => {
+    setCursorTuning(next)
+    api.updateCursorTuning(next)
+  }
+
+  const resetCursorTuning = () => {
+    api.resetCursorTuning()
+    setCursorTuning(DEFAULT_CURSOR_TUNING)
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="titlebar-drag h-[34px] w-full shrink-0" />
+      <div className="flex min-h-0 flex-1">
+        <nav className="flex w-44 shrink-0 flex-col border-r border-[var(--surface-popover-border)] px-2 py-3">
+          <div className="mb-2 px-2 text-[10px] font-semibold uppercase tracking-wider opacity-50">
+            Debug
+          </div>
+          {SECTIONS.map((section) => {
+            const active = section.id === activeSection
+            return (
+              <button
+                key={section.id}
+                type="button"
+                onClick={() => setActiveSection(section.id)}
+                className={`rounded px-2 py-1 text-left text-[12px] ${
+                  active
+                    ? 'bg-zinc-200 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100'
+                    : 'text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900'
+                }`}
+              >
+                {section.label}
+              </button>
+            )
+          })}
+        </nav>
+        <main className="flex min-h-0 min-w-0 flex-1">
+          {activeSection === 'cursor-motion' ? (
+            <CursorMotionSection
+              params={cursorMotion}
+              onChange={commitCursorMotion}
+              onReset={api.resetCursorMotion}
+            />
+          ) : activeSection === 'presence' ? (
+            <PresenceSection
+              splineViz={splineViz}
+              onSplineVizChange={commitSplineViz}
+              tuning={cursorTuning}
+              onTuningChange={commitCursorTuning}
+              onTuningReset={resetCursorTuning}
+              initialTimeline={initialData.presenceTimeline}
+              subscribeTimeline={subscribeTimeline}
+            />
+          ) : null}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/debug/ControlsPanel.tsx
+++ b/src/renderer/debug/ControlsPanel.tsx
@@ -1,0 +1,222 @@
+import type { ReactNode } from 'react'
+import type {
+  CursorMotionParams,
+  CurveDirection,
+  EasingPreset,
+  EasingSpec,
+} from '../../shared/types'
+
+const EASING_PRESETS: EasingPreset[] = [
+  'linear',
+  'easeInOutCubic',
+  'easeOutExpo',
+  'easeInOutQuart',
+  'easeOutBack',
+  'easeInOutSine',
+]
+
+const DIRECTIONS: CurveDirection[] = ['auto', 'left', 'right', 'alternating']
+
+export function ControlsPanel({
+  params,
+  onChange,
+  onReset,
+}: {
+  params: CursorMotionParams
+  onChange: (next: CursorMotionParams) => void
+  onReset: () => void
+}) {
+  const patch = (p: Partial<CursorMotionParams>) => onChange({ ...params, ...p })
+
+  const easingSelectValue: EasingPreset | 'custom' =
+    params.easing.kind === 'custom' ? 'custom' : params.easing.name
+
+  const onEasingChange = (value: string) => {
+    if (value === 'custom') {
+      patch({
+        easing: { kind: 'custom', x1: 0.4, y1: 0, x2: 0.2, y2: 1 },
+      })
+    } else {
+      patch({ easing: { kind: 'preset', name: value as EasingPreset } })
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4 text-[12px]">
+      <Header title="Motion" onReset={onReset} />
+
+      <Field label="Duration" value={`${params.durationMs} ms`}>
+        <input
+          type="range"
+          min={50}
+          max={2000}
+          step={10}
+          value={params.durationMs}
+          onChange={(e) => patch({ durationMs: Number(e.target.value) })}
+          className="w-full accent-blue-600"
+        />
+      </Field>
+
+      <Field label="Distance scaling" value={params.distanceScaling.toFixed(2)}>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={params.distanceScaling}
+          onChange={(e) => patch({ distanceScaling: Number(e.target.value) })}
+          className="w-full accent-blue-600"
+        />
+      </Field>
+
+      <Field label="Curve strength" value={params.curveStrength.toFixed(2)}>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={params.curveStrength}
+          onChange={(e) => patch({ curveStrength: Number(e.target.value) })}
+          className="w-full accent-blue-600"
+        />
+      </Field>
+
+      <Field label="Curve asymmetry" value={params.curveAsymmetry.toFixed(2)}>
+        <input
+          type="range"
+          min={-1}
+          max={1}
+          step={0.01}
+          value={params.curveAsymmetry}
+          onChange={(e) => patch({ curveAsymmetry: Number(e.target.value) })}
+          className="w-full accent-blue-600"
+        />
+      </Field>
+
+      <Field label="Jitter" value={params.curveJitter.toFixed(2)}>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={params.curveJitter}
+          onChange={(e) => patch({ curveJitter: Number(e.target.value) })}
+          className="w-full accent-blue-600"
+        />
+      </Field>
+
+      <Field label="Curve direction">
+        <div className="mt-1 flex gap-1">
+          {DIRECTIONS.map((dir) => {
+            const active = params.curveDirection === dir
+            return (
+              <button
+                key={dir}
+                type="button"
+                onClick={() => patch({ curveDirection: dir })}
+                className={`flex-1 rounded border px-2 py-1 text-[11px] capitalize ${
+                  active
+                    ? 'border-blue-500 bg-blue-500/10 text-blue-600 dark:text-blue-300'
+                    : 'border-zinc-300 hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800'
+                }`}
+              >
+                {dir}
+              </button>
+            )
+          })}
+        </div>
+      </Field>
+
+      <Field label="Easing">
+        <select
+          value={easingSelectValue}
+          onChange={(e) => onEasingChange(e.target.value)}
+          className="mt-1 w-full rounded border border-zinc-300 bg-white px-2 py-1 text-[12px] dark:border-zinc-700 dark:bg-zinc-900"
+        >
+          {EASING_PRESETS.map((preset) => (
+            <option key={preset} value={preset}>
+              {preset}
+            </option>
+          ))}
+          <option value="custom">custom cubic-bezier</option>
+        </select>
+      </Field>
+
+      {params.easing.kind === 'custom' ? (
+        <CustomBezierInputs
+          easing={params.easing}
+          onChange={(next) => patch({ easing: next })}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function Header({ title, onReset }: { title: string; onReset: () => void }) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="text-[11px] font-semibold uppercase tracking-wider opacity-60">
+        {title}
+      </div>
+      <button
+        type="button"
+        onClick={onReset}
+        className="rounded border border-zinc-300 px-2 py-0.5 text-[11px] hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+      >
+        Reset
+      </button>
+    </div>
+  )
+}
+
+function Field({
+  label,
+  value,
+  children,
+}: {
+  label: string
+  value?: string
+  children: ReactNode
+}) {
+  return (
+    <div>
+      <div className="flex items-baseline justify-between">
+        <label className="text-[11px] font-medium opacity-70">{label}</label>
+        {value !== undefined ? (
+          <span className="text-[11px] tabular-nums opacity-60">{value}</span>
+        ) : null}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function CustomBezierInputs({
+  easing,
+  onChange,
+}: {
+  easing: Extract<EasingSpec, { kind: 'custom' }>
+  onChange: (next: EasingSpec) => void
+}) {
+  const set = (key: 'x1' | 'y1' | 'x2' | 'y2', value: number) =>
+    onChange({ ...easing, [key]: value })
+
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {(['x1', 'y1', 'x2', 'y2'] as const).map((key) => (
+        <div key={key}>
+          <label className="text-[10px] uppercase tracking-wider opacity-60">
+            {key}
+          </label>
+          <input
+            type="number"
+            step={0.05}
+            value={easing[key]}
+            onChange={(e) => set(key, Number(e.target.value))}
+            className="mt-0.5 w-full rounded border border-zinc-300 bg-white px-1 py-0.5 text-[12px] tabular-nums dark:border-zinc-700 dark:bg-zinc-900"
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/debug/CursorMotionSection.tsx
+++ b/src/renderer/debug/CursorMotionSection.tsx
@@ -1,0 +1,24 @@
+import type { CursorMotionParams } from '../../shared/types'
+import { PlaygroundCanvas } from './PlaygroundCanvas'
+import { ControlsPanel } from './ControlsPanel'
+
+export function CursorMotionSection({
+  params,
+  onChange,
+  onReset,
+}: {
+  params: CursorMotionParams
+  onChange: (next: CursorMotionParams) => void
+  onReset: () => void
+}) {
+  return (
+    <div className="flex h-full w-full min-w-0">
+      <div className="relative min-w-0 flex-1 overflow-hidden">
+        <PlaygroundCanvas params={params} />
+      </div>
+      <div className="w-80 shrink-0 overflow-y-auto border-l border-[var(--surface-popover-border)]">
+        <ControlsPanel params={params} onChange={onChange} onReset={onReset} />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/debug/PlaygroundCanvas.tsx
+++ b/src/renderer/debug/PlaygroundCanvas.tsx
@@ -8,7 +8,7 @@ import {
   pickCandidateIndex,
   type MotionCandidate,
 } from '../../shared/cursor-motion'
-import { FilledCursorIcon } from '../canvas-bg/AgentCursorLayer'
+import { FilledCursorIcon } from '../shared/FilledCursorIcon'
 
 const TRAIL_LIMIT = 6
 const CURSOR_COLOR = '#2563eb'

--- a/src/renderer/debug/PlaygroundCanvas.tsx
+++ b/src/renderer/debug/PlaygroundCanvas.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useRef, useState } from 'react'
+import type { CursorMotionParams, Vec2 } from '../../shared/types'
+import {
+  cubicBezierPoint,
+  deriveCandidatePaths,
+  easeAt,
+  effectiveDurationMs,
+  pickCandidateIndex,
+  type MotionCandidate,
+} from '../../shared/cursor-motion'
+import { FilledCursorIcon } from '../canvas-bg/AgentCursorLayer'
+
+const TRAIL_LIMIT = 6
+const CURSOR_COLOR = '#2563eb'
+const ACTIVE_TRAIL_COLOR = '#16a34a'
+const GHOST_TRAIL_COLOR = '#64748b'
+
+type Trail = {
+  id: number
+  p0: Vec2
+  p3: Vec2
+  candidates: MotionCandidate[]
+  pickedIndex: number
+}
+
+type Animation = {
+  id: number
+  start: number
+  durationMs: number
+  p0: Vec2
+  p1: Vec2
+  p2: Vec2
+  p3: Vec2
+  params: CursorMotionParams
+}
+
+export function PlaygroundCanvas({ params }: { params: CursorMotionParams }) {
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const cursorRef = useRef<HTMLDivElement | null>(null)
+  const posRef = useRef<Vec2>({ x: 120, y: 120 })
+  const sequenceRef = useRef(0)
+  const animRef = useRef<Animation | null>(null)
+  const rafRef = useRef<number | null>(null)
+  const paramsRef = useRef<CursorMotionParams>(params)
+
+  const [trails, setTrails] = useState<Trail[]>([])
+  const [activeTrailId, setActiveTrailId] = useState<number | null>(null)
+  const [targetDot, setTargetDot] = useState<Vec2 | null>(null)
+
+  useEffect(() => {
+    paramsRef.current = params
+  }, [params])
+
+  useEffect(() => {
+    if (cursorRef.current) {
+      const p = posRef.current
+      cursorRef.current.style.transform = `translate3d(${p.x}px, ${p.y}px, 0)`
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current)
+    }
+  }, [])
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    const host = hostRef.current
+    if (!host) return
+    const rect = host.getBoundingClientRect()
+    const target: Vec2 = {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    }
+    setTargetDot(target)
+
+    const p0 = posRef.current
+    if (Math.hypot(target.x - p0.x, target.y - p0.y) < 1) return
+
+    const activeParams = paramsRef.current
+    const seq = ++sequenceRef.current
+    const candidates = deriveCandidatePaths(p0, target, activeParams, seq)
+    const pickedIndex = pickCandidateIndex(seq, candidates.length)
+    const picked = candidates[pickedIndex]
+    const id = seq
+
+    setTrails((prev) => {
+      const next = [...prev, { id, p0, p3: target, candidates, pickedIndex }]
+      return next.length > TRAIL_LIMIT ? next.slice(next.length - TRAIL_LIMIT) : next
+    })
+    setActiveTrailId(id)
+
+    const distance = Math.hypot(target.x - p0.x, target.y - p0.y)
+    animRef.current = {
+      id,
+      start: performance.now(),
+      durationMs: effectiveDurationMs(activeParams, distance),
+      p0,
+      p1: picked.p1,
+      p2: picked.p2,
+      p3: target,
+      params: activeParams,
+    }
+
+    const tick = (now: number) => {
+      const a = animRef.current
+      if (!a || !cursorRef.current) {
+        rafRef.current = null
+        return
+      }
+      const t = Math.min(1, (now - a.start) / Math.max(1, a.durationMs))
+      const easedT = easeAt(a.params.easing, t)
+      const pos = cubicBezierPoint(a.p0, a.p1, a.p2, a.p3, easedT)
+      posRef.current = pos
+      cursorRef.current.style.transform = `translate3d(${pos.x}px, ${pos.y}px, 0)`
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick)
+      } else {
+        animRef.current = null
+        rafRef.current = null
+      }
+    }
+    if (rafRef.current !== null) cancelAnimationFrame(rafRef.current)
+    rafRef.current = requestAnimationFrame(tick)
+  }
+
+  return (
+    <div
+      ref={hostRef}
+      onClick={handleClick}
+      className="relative h-full w-full cursor-crosshair select-none"
+      style={{
+        backgroundImage:
+          'linear-gradient(to right, rgba(120,120,120,0.08) 1px, transparent 1px), linear-gradient(to bottom, rgba(120,120,120,0.08) 1px, transparent 1px)',
+        backgroundSize: '32px 32px',
+      }}
+    >
+      <TrailsSvg trails={trails} activeId={activeTrailId} />
+      {targetDot ? (
+        <div
+          className="pointer-events-none absolute h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full"
+          style={{
+            left: targetDot.x,
+            top: targetDot.y,
+            background: ACTIVE_TRAIL_COLOR,
+            opacity: 0.65,
+          }}
+        />
+      ) : null}
+      <div
+        ref={cursorRef}
+        className="pointer-events-none absolute"
+        style={{ left: 0, top: 0, willChange: 'transform' }}
+      >
+        <FilledCursorIcon color={CURSOR_COLOR} size={24} />
+      </div>
+      <InstructionHint />
+    </div>
+  )
+}
+
+function TrailsSvg({
+  trails,
+  activeId,
+}: {
+  trails: Trail[]
+  activeId: number | null
+}) {
+  if (trails.length === 0) return null
+  const total = trails.length
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0"
+      width="100%"
+      height="100%"
+    >
+      {trails.map((trail, index) => {
+        const isActive = trail.id === activeId
+        const ageFromNewest = total - 1 - index
+        const fade = Math.max(0.05, 0.55 - ageFromNewest * 0.09)
+        const pickedHue = isActive ? ACTIVE_TRAIL_COLOR : hueFor(trail.id)
+        return (
+          <g key={trail.id}>
+            {trail.candidates.map((cand, i) => {
+              if (i === trail.pickedIndex) return null
+              const d = pathD(trail.p0, cand.p1, cand.p2, trail.p3)
+              return (
+                <path
+                  key={i}
+                  d={d}
+                  fill="none"
+                  stroke={GHOST_TRAIL_COLOR}
+                  strokeOpacity={isActive ? 0.35 : fade * 0.45}
+                  strokeWidth={1}
+                  strokeDasharray="3 3"
+                  strokeLinecap="round"
+                />
+              )
+            })}
+            {(() => {
+              const picked = trail.candidates[trail.pickedIndex]
+              if (!picked) return null
+              const d = pathD(trail.p0, picked.p1, picked.p2, trail.p3)
+              return (
+                <path
+                  d={d}
+                  fill="none"
+                  stroke={pickedHue}
+                  strokeOpacity={isActive ? 0.95 : Math.max(0.12, fade)}
+                  strokeWidth={isActive ? 2.25 : 1.5}
+                  strokeLinecap="round"
+                />
+              )
+            })()}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+function pathD(p0: Vec2, p1: Vec2, p2: Vec2, p3: Vec2): string {
+  return `M ${p0.x} ${p0.y} C ${p1.x} ${p1.y}, ${p2.x} ${p2.y}, ${p3.x} ${p3.y}`
+}
+
+function hueFor(id: number): string {
+  const hue = (id * 47) % 360
+  return `hsl(${hue} 60% 60%)`
+}
+
+function InstructionHint() {
+  return (
+    <div
+      className="pointer-events-none absolute left-4 top-4 rounded px-2 py-1 text-[11px] opacity-60"
+      style={{ background: 'color-mix(in srgb, var(--surface-panel) 88%, transparent)' }}
+    >
+      Click anywhere to retarget the cursor
+    </div>
+  )
+}

--- a/src/renderer/debug/PresencePlayground.tsx
+++ b/src/renderer/debug/PresencePlayground.tsx
@@ -19,7 +19,7 @@ import {
   CURSOR_DISTANCE_REFERENCE_PX,
   distanceSpeedScale,
 } from '../../shared/cursor-tuning'
-import { FilledCursorIcon } from '../canvas-bg/AgentCursorLayer'
+import { FilledCursorIcon } from '../shared/FilledCursorIcon'
 
 const TRAIL_LIMIT = 6
 const CURSOR_COLOR = '#2563eb'

--- a/src/renderer/debug/PresencePlayground.tsx
+++ b/src/renderer/debug/PresencePlayground.tsx
@@ -1,0 +1,314 @@
+/**
+ * Presence playground — a local mirror of the director's advance loop, run
+ * entirely in the renderer against the current tuning. Click anywhere to set
+ * a new waypoint; the cursor folds onto a fresh spline from its current
+ * (position, tangent), then advances at the director's speed model:
+ *
+ *   speed = baseSpeedPxS * distanceSpeedScale(length)
+ *
+ * If this playground feels snappy but the real agent cursor feels slow, the
+ * gap is somewhere outside the director's math — likely HTTP verb latency
+ * or a waypoint rect that's farther from the cursor than expected.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import type { CursorTuningParams } from '../../shared/types'
+import { easeAt, type Vec2 } from '../../shared/cursor-motion'
+import { foldSpline, type CatmullRomSpline } from '../../shared/cursor-spline'
+import {
+  CURSOR_DISTANCE_REFERENCE_PX,
+  distanceSpeedScale,
+} from '../../shared/cursor-tuning'
+import { FilledCursorIcon } from '../canvas-bg/AgentCursorLayer'
+
+const TRAIL_LIMIT = 6
+const CURSOR_COLOR = '#2563eb'
+const ACTIVE_STROKE = '#16a34a'
+const GHOST_STROKE = '#64748b'
+const SPLINE_SAMPLES = 48
+const SPLINE_ALPHA = 0.5
+
+type Trail = {
+  id: number
+  polyline: Vec2[]
+  target: Vec2
+}
+
+interface ActiveRun {
+  id: number
+  spline: CatmullRomSpline
+  splineSpeedScale: number
+  durationMs: number
+  elapsedMs: number
+  target: Vec2
+}
+
+export function PresencePlayground({
+  tuning,
+}: {
+  tuning: CursorTuningParams
+}) {
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const cursorRef = useRef<HTMLDivElement | null>(null)
+  const positionRef = useRef<Vec2>({ x: 160, y: 160 })
+  const tangentRef = useRef<Vec2>({ x: 1, y: 0 })
+  const activeRef = useRef<ActiveRun | null>(null)
+  const tuningRef = useRef(tuning)
+  const rafRef = useRef<number | null>(null)
+  const lastTickRef = useRef<number>(0)
+  const seqRef = useRef(0)
+
+  const [trails, setTrails] = useState<Trail[]>([])
+  const [activeSplinePolyline, setActiveSplinePolyline] = useState<Vec2[] | null>(
+    null,
+  )
+  const [stats, setStats] = useState<{
+    length: number
+    speedPxS: number
+    durationMs: number
+  } | null>(null)
+
+  useEffect(() => {
+    tuningRef.current = tuning
+  }, [tuning])
+
+  useEffect(() => {
+    applyCursorTransform(cursorRef.current, positionRef.current)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current)
+    }
+  }, [])
+
+  const ensureRaf = () => {
+    if (rafRef.current !== null) return
+    lastTickRef.current = performance.now()
+    const tick = (now: number) => {
+      rafRef.current = null
+      const run = activeRef.current
+      if (!run) return
+
+      const dtMs = Math.min(now - lastTickRef.current, 1000 / 30)
+      lastTickRef.current = now
+
+      const t = tuningRef.current
+      if (Number.isFinite(run.durationMs) && run.durationMs > 0) {
+        run.elapsedMs = Math.min(run.durationMs, run.elapsedMs + dtMs)
+      }
+      const progressT = run.durationMs > 0 ? run.elapsedMs / run.durationMs : 1
+      const easedT = easeAt(t.easing, progressT)
+      const arc = easedT * run.spline.totalLength
+      const sample = run.spline.sample(arc)
+      positionRef.current = sample.position
+      tangentRef.current = sample.tangent
+      applyCursorTransform(cursorRef.current, sample.position)
+
+      if (progressT >= 1) {
+        // Arrived. Retire the active spline; subsequent clicks re-fold from
+        // this settled (position, tangent).
+        activeRef.current = null
+        setActiveSplinePolyline(null)
+        return
+      }
+      rafRef.current = requestAnimationFrame(tick)
+    }
+    rafRef.current = requestAnimationFrame(tick)
+  }
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    const host = hostRef.current
+    if (!host) return
+    const rect = host.getBoundingClientRect()
+    const target: Vec2 = {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    }
+    const from = positionRef.current
+    const distance = Math.hypot(target.x - from.x, target.y - from.y)
+    if (distance < 1) return
+
+    const t = tuningRef.current
+    const spline = foldSpline(from, tangentRef.current, [target], SPLINE_ALPHA)
+    const splineSpeedScale = distanceSpeedScale(t, spline.totalLength)
+    const effectiveSpeed = t.baseSpeedPxS * splineSpeedScale
+    const durationMs =
+      effectiveSpeed > 0 ? (spline.totalLength / effectiveSpeed) * 1000 : Infinity
+
+    const id = ++seqRef.current
+    const polyline = spline.polyline(SPLINE_SAMPLES)
+    setActiveSplinePolyline(polyline)
+    setTrails((prev) => {
+      const next = [...prev, { id, polyline, target }]
+      return next.length > TRAIL_LIMIT ? next.slice(next.length - TRAIL_LIMIT) : next
+    })
+    setStats({
+      length: spline.totalLength,
+      speedPxS: effectiveSpeed,
+      durationMs,
+    })
+
+    activeRef.current = {
+      id,
+      spline,
+      splineSpeedScale,
+      durationMs,
+      elapsedMs: 0,
+      target,
+    }
+    ensureRaf()
+  }
+
+  return (
+    <div className="relative flex h-full w-full min-w-0 flex-col">
+      <div
+        ref={hostRef}
+        onClick={handleClick}
+        className="relative min-h-0 flex-1 cursor-crosshair select-none overflow-hidden"
+        style={{
+          backgroundImage:
+            'linear-gradient(to right, rgba(120,120,120,0.08) 1px, transparent 1px), linear-gradient(to bottom, rgba(120,120,120,0.08) 1px, transparent 1px)',
+          backgroundSize: '32px 32px',
+        }}
+      >
+        <TrailsSvg trails={trails} activeId={activeRef.current?.id ?? null} />
+        <ActiveSpline polyline={activeSplinePolyline} />
+        <div
+          ref={cursorRef}
+          className="pointer-events-none absolute"
+          style={{ left: 0, top: 0, willChange: 'transform' }}
+        >
+          <FilledCursorIcon color={CURSOR_COLOR} size={24} />
+        </div>
+        <InstructionHint />
+        <StatsOverlay tuning={tuning} stats={stats} />
+      </div>
+    </div>
+  )
+}
+
+function applyCursorTransform(el: HTMLDivElement | null, p: Vec2) {
+  if (!el) return
+  el.style.transform = `translate3d(${p.x}px, ${p.y}px, 0)`
+}
+
+function polylineToPath(points: Vec2[]): string {
+  if (points.length === 0) return ''
+  const [head, ...rest] = points
+  return `M ${head.x} ${head.y} ${rest.map((p) => `L ${p.x} ${p.y}`).join(' ')}`
+}
+
+function TrailsSvg({
+  trails,
+  activeId,
+}: {
+  trails: Trail[]
+  activeId: number | null
+}) {
+  if (trails.length === 0) return null
+  const total = trails.length
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0"
+      width="100%"
+      height="100%"
+    >
+      {trails.map((trail, index) => {
+        const isActive = trail.id === activeId
+        const ageFromNewest = total - 1 - index
+        const fade = Math.max(0.05, 0.55 - ageFromNewest * 0.09)
+        const d = polylineToPath(trail.polyline)
+        return (
+          <g key={trail.id}>
+            <path
+              d={d}
+              fill="none"
+              stroke={isActive ? ACTIVE_STROKE : GHOST_STROKE}
+              strokeOpacity={isActive ? 0.95 : Math.max(0.12, fade)}
+              strokeWidth={isActive ? 2.25 : 1.25}
+              strokeLinecap="round"
+            />
+            <circle
+              cx={trail.target.x}
+              cy={trail.target.y}
+              r={3}
+              fill={isActive ? ACTIVE_STROKE : GHOST_STROKE}
+              fillOpacity={isActive ? 0.75 : Math.max(0.12, fade)}
+            />
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+function ActiveSpline({ polyline }: { polyline: Vec2[] | null }) {
+  if (!polyline || polyline.length === 0) return null
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0"
+      width="100%"
+      height="100%"
+    >
+      <path
+        d={polylineToPath(polyline)}
+        fill="none"
+        stroke={ACTIVE_STROKE}
+        strokeOpacity={0.35}
+        strokeWidth={4}
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+function InstructionHint() {
+  return (
+    <div
+      className="pointer-events-none absolute left-4 top-4 rounded px-2 py-1 text-[11px] opacity-60"
+      style={{
+        background: 'color-mix(in srgb, var(--surface-panel) 88%, transparent)',
+      }}
+    >
+      Click anywhere to retarget the cursor
+    </div>
+  )
+}
+
+function StatsOverlay({
+  tuning,
+  stats,
+}: {
+  tuning: CursorTuningParams
+  stats: { length: number; speedPxS: number; durationMs: number } | null
+}) {
+  return (
+    <div
+      className="pointer-events-none absolute right-4 top-4 rounded px-2 py-1 text-[11px] tabular-nums opacity-80"
+      style={{
+        background: 'color-mix(in srgb, var(--surface-panel) 88%, transparent)',
+      }}
+    >
+      <div>
+        base {tuning.baseSpeedPxS} px/s · scale {tuning.distanceScaling.toFixed(2)}
+      </div>
+      <div>ref {CURSOR_DISTANCE_REFERENCE_PX} px</div>
+      {stats ? (
+        <div className="mt-1 border-t border-black/10 pt-1 dark:border-white/10">
+          <div>length {stats.length.toFixed(0)} px</div>
+          <div>
+            speed{' '}
+            {Number.isFinite(stats.speedPxS) ? stats.speedPxS.toFixed(0) : '0'} px/s
+          </div>
+          <div>
+            duration{' '}
+            {Number.isFinite(stats.durationMs)
+              ? `${stats.durationMs.toFixed(0)} ms`
+              : '∞'}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/debug/PresenceSection.tsx
+++ b/src/renderer/debug/PresenceSection.tsx
@@ -1,0 +1,303 @@
+/**
+ * Presence debug panel — playground on the left, tuning controls on the right.
+ *
+ * The playground mirrors the director's advance loop locally so the user can
+ * retarget the cursor with a click and watch the speed model react to tuning
+ * changes in real time. If the playground feels snappy but the real agent
+ * cursor feels slow, the problem is somewhere outside the director.
+ */
+
+import type { ReactNode } from 'react'
+import type {
+  CursorTuningParams,
+  EasingPreset,
+  EasingSpec,
+  PresenceDebugEntry,
+} from '../../shared/types'
+import { PresencePlayground } from './PresencePlayground'
+import { PresenceTimelinePanel } from './PresenceTimelinePanel'
+
+const EASING_PRESETS: EasingPreset[] = [
+  'linear',
+  'easeInOutCubic',
+  'easeOutExpo',
+  'easeInOutQuart',
+  'easeOutBack',
+  'easeInOutSine',
+]
+
+export function PresenceSection({
+  splineViz,
+  onSplineVizChange,
+  tuning,
+  onTuningChange,
+  onTuningReset,
+  initialTimeline,
+  subscribeTimeline,
+}: {
+  splineViz: boolean
+  onSplineVizChange: (on: boolean) => void
+  tuning: CursorTuningParams
+  onTuningChange: (next: CursorTuningParams) => void
+  onTuningReset: () => void
+  initialTimeline: PresenceDebugEntry[]
+  subscribeTimeline: (cb: (entry: PresenceDebugEntry) => void) => () => void
+}) {
+  return (
+    <div className="flex h-full w-full min-w-0">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="relative min-h-0 flex-1 overflow-hidden">
+          <PresencePlayground tuning={tuning} />
+        </div>
+        <div className="flex h-[45%] min-h-[160px] shrink-0 flex-col">
+          <PresenceTimelinePanel
+            initialEntries={initialTimeline}
+            subscribe={subscribeTimeline}
+          />
+        </div>
+      </div>
+      <div className="w-80 shrink-0 overflow-y-auto border-l border-[var(--surface-popover-border)]">
+        <TuningControls
+          splineViz={splineViz}
+          onSplineVizChange={onSplineVizChange}
+          tuning={tuning}
+          onTuningChange={onTuningChange}
+          onTuningReset={onTuningReset}
+        />
+      </div>
+    </div>
+  )
+}
+
+function TuningControls({
+  splineViz,
+  onSplineVizChange,
+  tuning,
+  onTuningChange,
+  onTuningReset,
+}: {
+  splineViz: boolean
+  onSplineVizChange: (on: boolean) => void
+  tuning: CursorTuningParams
+  onTuningChange: (next: CursorTuningParams) => void
+  onTuningReset: () => void
+}) {
+  const patch = (p: Partial<CursorTuningParams>) =>
+    onTuningChange({ ...tuning, ...p })
+
+  return (
+    <div className="flex flex-col gap-4 p-4 text-[12px]">
+      <Header title="Director tuning" onReset={onTuningReset} />
+
+      <Field
+        label="Base speed"
+        value={`${tuning.baseSpeedPxS} px/s`}
+        help="Arc-length travel rate before distance scaling."
+      >
+        <input
+          type="range"
+          min={50}
+          max={2000}
+          step={10}
+          value={tuning.baseSpeedPxS}
+          onChange={(e) => patch({ baseSpeedPxS: Number(e.target.value) })}
+          className="w-full accent-blue-600"
+        />
+      </Field>
+
+      <Field
+        label="Distance scaling"
+        value={tuning.distanceScaling.toFixed(2)}
+        help="1 = constant speed (travel time grows with distance). 0 = constant duration regardless of distance, so short hops no longer teleport."
+      >
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={tuning.distanceScaling}
+          onChange={(e) => patch({ distanceScaling: Number(e.target.value) })}
+          className="w-full accent-blue-600"
+        />
+      </Field>
+
+      <Field
+        label="Easing"
+        help="Time-axis curve applied across each spline. Legacy default was easeInOutCubic; linear reproduces the constant-speed behavior."
+      >
+        <EasingPicker
+          value={tuning.easing}
+          onChange={(next) => patch({ easing: next })}
+        />
+      </Field>
+
+      <Field
+        label="Sync cap"
+        value={`${tuning.syncCapMs} ms`}
+        help="Upper bound for move-then-act. If the cursor arrives sooner, the mutation fires immediately; otherwise it fires at this cap."
+      >
+        <input
+          type="range"
+          min={0}
+          max={1000}
+          step={10}
+          value={tuning.syncCapMs}
+          onChange={(e) => patch({ syncCapMs: Number(e.target.value) })}
+          className="w-full accent-blue-600"
+        />
+      </Field>
+
+      <Field
+        label="Commit hold"
+        value={`${tuning.commitHoldMs} ms`}
+        help="Duration of the 'committing' phase (ripple hold) at commit waypoints."
+      >
+        <input
+          type="range"
+          min={0}
+          max={1000}
+          step={10}
+          value={tuning.commitHoldMs}
+          onChange={(e) => patch({ commitHoldMs: Number(e.target.value) })}
+          className="w-full accent-blue-600"
+        />
+      </Field>
+
+      <Field
+        label="Dwell"
+        value={`${tuning.commitDwellMs} ms`}
+        help="Pause at non-commit waypoints that request a dwell."
+      >
+        <input
+          type="range"
+          min={0}
+          max={1000}
+          step={10}
+          value={tuning.commitDwellMs}
+          onChange={(e) => patch({ commitDwellMs: Number(e.target.value) })}
+          className="w-full accent-blue-600"
+        />
+      </Field>
+
+      <hr className="border-[var(--surface-popover-border)]" />
+
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="font-semibold">Visualize cursor splines</div>
+          <div className="mt-0.5 text-[11px] opacity-60">
+            Overlays the active spline on the real canvas behind each agent
+            cursor (separate from the playground above).
+          </div>
+        </div>
+        <label className="flex shrink-0 items-center gap-2">
+          <input
+            type="checkbox"
+            checked={splineViz}
+            onChange={(e) => onSplineVizChange(e.target.checked)}
+          />
+          <span>{splineViz ? 'On' : 'Off'}</span>
+        </label>
+      </div>
+    </div>
+  )
+}
+
+function Header({ title, onReset }: { title: string; onReset: () => void }) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="text-[11px] font-semibold uppercase tracking-wider opacity-60">
+        {title}
+      </div>
+      <button
+        type="button"
+        onClick={onReset}
+        className="rounded border border-zinc-300 px-2 py-0.5 text-[11px] hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+      >
+        Reset
+      </button>
+    </div>
+  )
+}
+
+function EasingPicker({
+  value,
+  onChange,
+}: {
+  value: EasingSpec
+  onChange: (next: EasingSpec) => void
+}) {
+  const selectValue: EasingPreset | 'custom' =
+    value.kind === 'custom' ? 'custom' : value.name
+
+  const onSelect = (next: string) => {
+    if (next === 'custom') {
+      onChange({ kind: 'custom', x1: 0.4, y1: 0, x2: 0.2, y2: 1 })
+    } else {
+      onChange({ kind: 'preset', name: next as EasingPreset })
+    }
+  }
+
+  return (
+    <>
+      <select
+        value={selectValue}
+        onChange={(e) => onSelect(e.target.value)}
+        className="mt-1 w-full rounded border border-zinc-300 bg-white px-2 py-1 text-[12px] dark:border-zinc-700 dark:bg-zinc-900"
+      >
+        {EASING_PRESETS.map((preset) => (
+          <option key={preset} value={preset}>
+            {preset}
+          </option>
+        ))}
+        <option value="custom">custom cubic-bezier</option>
+      </select>
+      {value.kind === 'custom' ? (
+        <div className="mt-2 grid grid-cols-2 gap-2">
+          {(['x1', 'y1', 'x2', 'y2'] as const).map((key) => (
+            <div key={key}>
+              <label className="text-[10px] uppercase tracking-wider opacity-60">
+                {key}
+              </label>
+              <input
+                type="number"
+                step={0.05}
+                value={value[key]}
+                onChange={(e) =>
+                  onChange({ ...value, [key]: Number(e.target.value) })
+                }
+                className="mt-0.5 w-full rounded border border-zinc-300 bg-white px-1 py-0.5 text-[12px] tabular-nums dark:border-zinc-700 dark:bg-zinc-900"
+              />
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </>
+  )
+}
+
+function Field({
+  label,
+  value,
+  help,
+  children,
+}: {
+  label: string
+  value?: string
+  help?: string
+  children: ReactNode
+}) {
+  return (
+    <div>
+      <div className="flex items-baseline justify-between">
+        <label className="text-[11px] font-medium opacity-70">{label}</label>
+        {value !== undefined ? (
+          <span className="text-[11px] tabular-nums opacity-60">{value}</span>
+        ) : null}
+      </div>
+      {children}
+      {help ? (
+        <div className="mt-1 text-[10px] leading-snug opacity-55">{help}</div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/debug/PresenceTimelinePanel.tsx
+++ b/src/renderer/debug/PresenceTimelinePanel.tsx
@@ -1,0 +1,328 @@
+/**
+ * Two-column presence timeline: CLI dispatches on the left, director activity
+ * on the right, positioned vertically by wall-clock time. Newest at the bottom
+ * so the column scrolls upward like a live log.
+ *
+ * Vertical distance between entries reflects real elapsed time for short gaps,
+ * but idle stretches longer than GAP_THRESHOLD_MS are collapsed to a fixed
+ * band with a labelled break, so bursty work stays legible.
+ *
+ * Faint horizontal gridlines span both columns at every event Y so CLI and
+ * director rows on the same wall-clock moment line up visually.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { PresenceDebugEntry } from '../../shared/types'
+
+const DEFAULT_PX_PER_MS = 0.12
+const MIN_ROW_PX = 18
+const ROW_HEIGHT_PX = 22
+const TOP_PAD_PX = 12
+const BOTTOM_PAD_PX = 32
+const GAP_THRESHOLD_MS = 800
+const COMPRESSED_GAP_MS = 160
+
+export function PresenceTimelinePanel({
+  initialEntries,
+  subscribe,
+}: {
+  initialEntries: PresenceDebugEntry[]
+  subscribe: (cb: (entry: PresenceDebugEntry) => void) => () => void
+}) {
+  const [entries, setEntries] = useState<PresenceDebugEntry[]>(initialEntries)
+  const [pxPerMs, setPxPerMs] = useState<number>(DEFAULT_PX_PER_MS)
+  const [follow, setFollow] = useState(true)
+  const scrollerRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    return subscribe((entry) => {
+      setEntries((prev) => {
+        if (prev.length >= 500) return [...prev.slice(prev.length - 499), entry]
+        return [...prev, entry]
+      })
+    })
+  }, [subscribe])
+
+  // Compute y-positions from timestamps. Each row clamps to MIN_ROW_PX above
+  // the previous so bursts of same-millisecond events remain readable.
+  const { layout, totalHeight, gridYs, gapBreaks } = useMemo(
+    () => layoutEntries(entries, pxPerMs),
+    [entries, pxPerMs],
+  )
+
+  useEffect(() => {
+    if (!follow) return
+    const el = scrollerRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }, [totalHeight, follow])
+
+  const onScroll = () => {
+    const el = scrollerRef.current
+    if (!el) return
+    const distanceFromBottom =
+      el.scrollHeight - (el.scrollTop + el.clientHeight)
+    setFollow(distanceFromBottom < 24)
+  }
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col border-t border-[var(--surface-popover-border)]">
+      <Toolbar
+        entryCount={entries.length}
+        pxPerMs={pxPerMs}
+        setPxPerMs={setPxPerMs}
+        follow={follow}
+        setFollow={setFollow}
+        onClear={() => setEntries([])}
+      />
+      <div className="grid shrink-0 grid-cols-2 border-b border-[var(--surface-popover-border)] text-[10px] font-semibold uppercase tracking-wider opacity-55">
+        <div className="px-3 py-1">CLI</div>
+        <div className="border-l border-[var(--surface-popover-border)] px-3 py-1">
+          Director
+        </div>
+      </div>
+      <div
+        ref={scrollerRef}
+        onScroll={onScroll}
+        className="relative min-h-0 flex-1 overflow-y-auto"
+      >
+        <div className="relative" style={{ height: totalHeight }}>
+          {gridYs.map((y) => (
+            <div
+              key={`grid-${y}`}
+              className="pointer-events-none absolute left-0 right-0 border-t border-[var(--surface-popover-border)] opacity-30"
+              style={{ top: y }}
+            />
+          ))}
+          {gapBreaks.map((gb, i) => (
+            <GapBreak key={`gap-${i}`} topY={gb.topY} bottomY={gb.bottomY} dt={gb.dt} />
+          ))}
+          <div
+            className="pointer-events-none absolute bottom-0 top-0 border-r border-[var(--surface-popover-border)]"
+            style={{ left: '50%' }}
+          />
+          {layout.map(({ entry, y }) => (
+            <TimelineRow key={entry.id} entry={entry} y={y} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Toolbar({
+  entryCount,
+  pxPerMs,
+  setPxPerMs,
+  follow,
+  setFollow,
+  onClear,
+}: {
+  entryCount: number
+  pxPerMs: number
+  setPxPerMs: (n: number) => void
+  follow: boolean
+  setFollow: (b: boolean) => void
+  onClear: () => void
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-3 px-3 py-2 text-[11px]">
+      <span className="font-semibold opacity-70">Timeline</span>
+      <span className="tabular-nums opacity-55">{entryCount} events</span>
+      <label className="ml-2 flex items-center gap-1.5 opacity-70">
+        scale
+        <input
+          type="range"
+          min={0.02}
+          max={0.6}
+          step={0.01}
+          value={pxPerMs}
+          onChange={(e) => setPxPerMs(Number(e.target.value))}
+          className="w-28 accent-blue-600"
+        />
+        <span className="w-12 text-right tabular-nums opacity-70">
+          {pxPerMs.toFixed(2)} px/ms
+        </span>
+      </label>
+      <label className="flex items-center gap-1 opacity-70">
+        <input
+          type="checkbox"
+          checked={follow}
+          onChange={(e) => setFollow(e.target.checked)}
+        />
+        follow
+      </label>
+      <button
+        type="button"
+        onClick={onClear}
+        className="ml-auto rounded border border-zinc-300 px-2 py-0.5 text-[11px] hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+      >
+        Clear
+      </button>
+    </div>
+  )
+}
+
+type PositionedEntry = { entry: PresenceDebugEntry; y: number }
+type GapBreakRange = { topY: number; bottomY: number; dt: number }
+
+function layoutEntries(
+  entries: PresenceDebugEntry[],
+  pxPerMs: number,
+): {
+  layout: PositionedEntry[]
+  totalHeight: number
+  gridYs: number[]
+  gapBreaks: GapBreakRange[]
+} {
+  if (entries.length === 0) {
+    return {
+      layout: [],
+      totalHeight: TOP_PAD_PX + BOTTOM_PAD_PX,
+      gridYs: [],
+      gapBreaks: [],
+    }
+  }
+
+  // Merge-sort by time. Events share a compressed-time slot per distinct t,
+  // so a CLI and director event at the same wall-clock t start on the same Y.
+  const sorted = [...entries].sort((a, b) =>
+    a.t === b.t ? a.id - b.id : a.t - b.t,
+  )
+
+  // Build a map t → cumulative compressed-ms. Gaps over GAP_THRESHOLD_MS
+  // collapse to COMPRESSED_GAP_MS so quiet stretches don't dominate.
+  const tToCompressed = new Map<number, number>()
+  const compressedSpans: { beforeT: number; afterT: number; dt: number }[] = []
+  let cumulative = 0
+  let prevT: number | null = null
+  for (const entry of sorted) {
+    if (tToCompressed.has(entry.t)) continue
+    if (prevT !== null) {
+      const dt = entry.t - prevT
+      if (dt > GAP_THRESHOLD_MS) {
+        compressedSpans.push({ beforeT: prevT, afterT: entry.t, dt })
+        cumulative += COMPRESSED_GAP_MS
+      } else {
+        cumulative += dt
+      }
+    }
+    tToCompressed.set(entry.t, cumulative)
+    prevT = entry.t
+  }
+
+  const lastCliY = { y: -Infinity }
+  const lastDirY = { y: -Infinity }
+  const layout: PositionedEntry[] = []
+  for (const entry of entries) {
+    const rawY = TOP_PAD_PX + (tToCompressed.get(entry.t) ?? 0) * pxPerMs
+    const guard = entry.side === 'cli' ? lastCliY : lastDirY
+    const y = Math.max(rawY, guard.y + MIN_ROW_PX)
+    guard.y = y
+    layout.push({ entry, y })
+  }
+
+  // For each compressed span, locate the visible Y range it occupies: from
+  // the bottom of the latest event at beforeT to the top of the earliest
+  // event at afterT.
+  const gapBreaks: GapBreakRange[] = compressedSpans.map((span) => {
+    let topY = -Infinity
+    let bottomY = Infinity
+    for (const { entry, y } of layout) {
+      if (entry.t === span.beforeT) topY = Math.max(topY, y + ROW_HEIGHT_PX)
+      if (entry.t === span.afterT) bottomY = Math.min(bottomY, y)
+    }
+    return { topY, bottomY, dt: span.dt }
+  })
+
+  const uniqueYs = new Set<number>()
+  for (const { y } of layout) uniqueYs.add(Math.round(y))
+  const gridYs = [...uniqueYs].sort((a, b) => a - b)
+
+  const maxY = layout.reduce((m, e) => Math.max(m, e.y), TOP_PAD_PX)
+  return {
+    layout,
+    totalHeight: maxY + ROW_HEIGHT_PX + BOTTOM_PAD_PX,
+    gridYs,
+    gapBreaks,
+  }
+}
+
+function GapBreak({
+  topY,
+  bottomY,
+  dt,
+}: {
+  topY: number
+  bottomY: number
+  dt: number
+}) {
+  const height = Math.max(0, bottomY - topY)
+  if (height <= 0) return null
+  return (
+    <div
+      className="pointer-events-none absolute left-0 right-0 flex items-center justify-center"
+      style={{ top: topY, height }}
+    >
+      <div className="absolute left-0 right-0 top-1/2 border-t border-dashed border-[var(--surface-popover-border)] opacity-60" />
+      <span className="relative rounded bg-[var(--surface-panel)] px-1.5 text-[9px] uppercase tracking-wider opacity-70">
+        {formatGap(dt)} idle
+      </span>
+    </div>
+  )
+}
+
+function formatGap(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  if (ms < 10_000) return `${(ms / 1000).toFixed(1)}s`
+  return `${Math.round(ms / 1000)}s`
+}
+
+function TimelineRow({ entry, y }: { entry: PresenceDebugEntry; y: number }) {
+  const isCli = entry.side === 'cli'
+  const tone = toneFor(entry.kind)
+  return (
+    <div
+      className="absolute flex items-center gap-2 overflow-hidden px-3 text-[11px] leading-[18px]"
+      style={{
+        top: y,
+        left: isCli ? 0 : '50%',
+        width: '50%',
+        height: ROW_HEIGHT_PX,
+      }}
+    >
+      <span
+        className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+        style={{ background: tone.dot }}
+      />
+      <span className="shrink-0 font-medium" style={{ color: tone.text }}>
+        {entry.label}
+      </span>
+      {entry.detail ? (
+        <span className="min-w-0 truncate opacity-55">{entry.detail}</span>
+      ) : null}
+    </div>
+  )
+}
+
+function toneFor(kind: PresenceDebugEntry['kind']): {
+  dot: string
+  text: string
+} {
+  switch (kind) {
+    case 'cli:emit':
+      return { dot: '#2563eb', text: 'inherit' }
+    case 'cli:sync-wait':
+      return { dot: '#f59e0b', text: '#b45309' }
+    case 'cli:sync-resolve':
+      return { dot: '#16a34a', text: '#15803d' }
+    case 'cli:box-resolve':
+      return { dot: '#0ea5e9', text: '#0369a1' }
+    case 'dir:apply':
+      return { dot: '#8b5cf6', text: 'inherit' }
+    case 'dir:phase':
+      return { dot: '#64748b', text: 'inherit' }
+    case 'dir:drop':
+      return { dot: '#dc2626', text: '#b91c1c' }
+  }
+}

--- a/src/renderer/debug/index.html
+++ b/src/renderer/debug/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Telescope Motion Debug</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+  </html>

--- a/src/renderer/debug/main.tsx
+++ b/src/renderer/debug/main.tsx
@@ -1,0 +1,23 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import './styles.css'
+import { initRendererSentry } from '../shared/sentry-init'
+import type { DebugElectronAPI } from '../../shared/types'
+
+initRendererSentry()
+
+const api = (window as unknown as { electronAPI: DebugElectronAPI }).electronAPI
+
+async function bootstrap() {
+  const initialData = await api.getInitialData()
+  document.documentElement.classList.toggle('dark', initialData.theme.isDark)
+
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <App api={api} initialData={initialData} />
+    </StrictMode>,
+  )
+}
+
+void bootstrap()

--- a/src/renderer/debug/styles.css
+++ b/src/renderer/debug/styles.css
@@ -1,0 +1,26 @@
+@import "tailwindcss";
+@import "../shared/surfaceTheme.css";
+@variant dark (&:where(.dark, .dark *));
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: var(--surface-panel);
+  color: var(--surface-toolbar-foreground);
+}
+
+.titlebar-drag {
+  -webkit-app-region: drag;
+}
+
+.titlebar-drag button,
+.titlebar-drag a,
+.titlebar-drag input,
+.titlebar-drag select {
+  -webkit-app-region: no-drag;
+}

--- a/src/renderer/shared/FilledCursorIcon.tsx
+++ b/src/renderer/shared/FilledCursorIcon.tsx
@@ -1,0 +1,23 @@
+export function FilledCursorIcon({
+  color,
+  size = 16,
+}: {
+  color: string
+  size?: number
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={color}
+      stroke="rgba(255,255,255,0.9)"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.3))' }}
+    >
+      <path d="M4.037 4.688a.495.495 0 0 1 .651-.651l16 6.5a.5.5 0 0 1-.063.947l-6.124 1.58a2 2 0 0 0-1.438 1.435l-1.579 6.126a.5.5 0 0 1-.947.063z" />
+    </svg>
+  )
+}

--- a/src/shared/cursor-motion.ts
+++ b/src/shared/cursor-motion.ts
@@ -1,0 +1,376 @@
+/**
+ * Cursor motion math — pure, side-effect-free.
+ *
+ * Used by:
+ * - renderer cursor playback to ease progress along motion paths
+ * - the debug playground to visualize candidate curves and sampled points
+ * - future motion/presence work that needs stable normalization helpers
+ */
+
+export type Vec2 = { x: number; y: number }
+
+export type EasingPreset =
+  | 'linear'
+  | 'easeInOutCubic'
+  | 'easeOutExpo'
+  | 'easeInOutQuart'
+  | 'easeOutBack'
+  | 'easeInOutSine'
+
+export type EasingSpec =
+  | { kind: 'preset'; name: EasingPreset }
+  | { kind: 'custom'; x1: number; y1: number; x2: number; y2: number }
+
+export type CurveDirection = 'auto' | 'left' | 'right' | 'alternating'
+
+export interface CursorMotionParams {
+  durationMs: number
+  easing: EasingSpec
+  curveStrength: number
+  curveAsymmetry: number
+  curveDirection: CurveDirection
+  curveJitter: number
+  distanceScaling: number
+}
+
+export const DEFAULT_CURSOR_MOTION: CursorMotionParams = {
+  durationMs: 1080,
+  easing: { kind: 'preset', name: 'easeInOutCubic' },
+  curveStrength: 0.55,
+  curveAsymmetry: -0.15,
+  curveDirection: 'auto',
+  curveJitter: 0.2,
+  distanceScaling: 1,
+}
+
+export const DISTANCE_SCALE_REFERENCE_PX = 400
+export const CANDIDATE_COUNT = 6
+
+export interface MotionCandidate {
+  p1: Vec2
+  p2: Vec2
+  side: -1 | 1
+}
+
+export function effectiveDurationMs(
+  params: CursorMotionParams,
+  distance: number,
+): number {
+  const exp = Math.max(0, Math.min(1, params.distanceScaling))
+  if (exp === 0 || distance <= 0) return params.durationMs
+  const ratio = distance / DISTANCE_SCALE_REFERENCE_PX
+  const scaled = params.durationMs * Math.pow(ratio, exp)
+  return Math.max(50, Math.min(3000, scaled))
+}
+
+export const CURSOR_MOTION_PRESETS: Record<EasingPreset, (t: number) => number> = {
+  linear: (t) => t,
+  easeInOutCubic: (t) =>
+    t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2,
+  easeOutExpo: (t) => (t === 1 ? 1 : 1 - Math.pow(2, -10 * t)),
+  easeInOutQuart: (t) =>
+    t < 0.5 ? 8 * t * t * t * t : 1 - Math.pow(-2 * t + 2, 4) / 2,
+  easeOutBack: (t) => {
+    const c1 = 1.70158
+    const c3 = c1 + 1
+    return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2)
+  },
+  easeInOutSine: (t) => -(Math.cos(Math.PI * t) - 1) / 2,
+}
+
+function cubicBezier1D(p1: number, p2: number, t: number): number {
+  return 3 * (1 - t) * (1 - t) * t * p1 + 3 * (1 - t) * t * t * p2 + t * t * t
+}
+
+function cubicBezier1DDeriv(p1: number, p2: number, t: number): number {
+  return (
+    3 * (1 - t) * (1 - t) * p1 +
+    6 * (1 - t) * t * (p2 - p1) +
+    3 * t * t * (1 - p2)
+  )
+}
+
+function solveCubicBezierX(x: number, x1: number, x2: number): number {
+  if (x <= 0) return 0
+  if (x >= 1) return 1
+
+  let t = x
+  for (let i = 0; i < 8; i++) {
+    const currentX = cubicBezier1D(x1, x2, t) - x
+    if (Math.abs(currentX) < 1e-6) return t
+    const d = cubicBezier1DDeriv(x1, x2, t)
+    if (Math.abs(d) < 1e-6) break
+    t = t - currentX / d
+  }
+
+  let lo = 0
+  let hi = 1
+  t = x
+  for (let i = 0; i < 24; i++) {
+    const currentX = cubicBezier1D(x1, x2, t)
+    if (Math.abs(currentX - x) < 1e-6) return t
+    if (currentX < x) lo = t
+    else hi = t
+    t = (lo + hi) / 2
+  }
+  return t
+}
+
+export function easeAt(spec: EasingSpec, t: number): number {
+  if (t <= 0) return 0
+  if (t >= 1) return 1
+  if (spec.kind === 'preset') {
+    const fn = CURSOR_MOTION_PRESETS[spec.name] ?? CURSOR_MOTION_PRESETS.linear
+    return fn(t)
+  }
+  const u = solveCubicBezierX(t, spec.x1, spec.x2)
+  return cubicBezier1D(spec.y1, spec.y2, u)
+}
+
+export function cubicBezierPoint(
+  p0: Vec2,
+  p1: Vec2,
+  p2: Vec2,
+  p3: Vec2,
+  t: number,
+): Vec2 {
+  const mt = 1 - t
+  const a = mt * mt * mt
+  const b = 3 * mt * mt * t
+  const c = 3 * mt * t * t
+  const d = t * t * t
+  return {
+    x: a * p0.x + b * p1.x + c * p2.x + d * p3.x,
+    y: a * p0.y + b * p1.y + c * p2.y + d * p3.y,
+  }
+}
+
+function seededRandom(seed: number, salt: number): number {
+  let h = Math.imul(seed | 0, 2654435761) ^ Math.imul(salt | 0, 1597334677)
+  h = Math.imul(h ^ (h >>> 15), 2246822519)
+  h = Math.imul(h ^ (h >>> 13), 3266489917)
+  h = (h ^ (h >>> 16)) >>> 0
+  return h / 4294967296
+}
+
+function candidateSides(
+  direction: CurveDirection,
+  sequenceIndex: number,
+  count: number,
+): (-1 | 1)[] {
+  switch (direction) {
+    case 'left':
+      return Array.from({ length: count }, () => -1 as const)
+    case 'right':
+      return Array.from({ length: count }, () => 1 as const)
+    case 'alternating': {
+      const side: -1 | 1 = sequenceIndex % 2 === 0 ? 1 : -1
+      return Array.from({ length: count }, () => side)
+    }
+    case 'auto':
+    default: {
+      const half = Math.floor(count / 2)
+      return Array.from({ length: count }, (_, i) =>
+        i < half ? -1 : (1 as -1 | 1),
+      )
+    }
+  }
+}
+
+const HANDLE_ROTATION_MAX = Math.PI * 0.75
+
+function rotateAround(point: Vec2, pivot: Vec2, angle: number): Vec2 {
+  const dx = point.x - pivot.x
+  const dy = point.y - pivot.y
+  const c = Math.cos(angle)
+  const s = Math.sin(angle)
+  return {
+    x: pivot.x + dx * c - dy * s,
+    y: pivot.y + dx * s + dy * c,
+  }
+}
+
+function candidateFromIndex(
+  p0: Vec2,
+  p3: Vec2,
+  params: CursorMotionParams,
+  sequenceIndex: number,
+  candidateIndex: number,
+  side: -1 | 1,
+  dx: number,
+  dy: number,
+  dist: number,
+): MotionCandidate {
+  const jitter = Math.max(0, Math.min(1, params.curveJitter))
+  const rStrength =
+    seededRandom(sequenceIndex, candidateIndex * 7 + 11) * 2 - 1
+  const rAsym =
+    seededRandom(sequenceIndex, candidateIndex * 7 + 13) * 2 - 1
+  const rAngle1 =
+    seededRandom(sequenceIndex, candidateIndex * 7 + 15) * 2 - 1
+  const rAngle2 =
+    seededRandom(sequenceIndex, candidateIndex * 7 + 17) * 2 - 1
+
+  const px = -dy / dist
+  const py = dx / dist
+
+  const strengthMul = 1 + rStrength * jitter * 0.6
+  const strength = Math.max(0, Math.min(1, params.curveStrength * strengthMul))
+  const offset = strength * dist * side
+
+  const asymRaw = params.curveAsymmetry + rAsym * jitter * 0.5
+  const asym = Math.max(-1, Math.min(1, asymRaw))
+
+  const t1 = 1 / 3 - asym * (1 / 3)
+  const t2 = 2 / 3 - asym * (1 / 3)
+
+  const p1Base: Vec2 = {
+    x: p0.x + dx * t1 + px * offset,
+    y: p0.y + dy * t1 + py * offset,
+  }
+  const p2Base: Vec2 = {
+    x: p0.x + dx * t2 + px * offset,
+    y: p0.y + dy * t2 + py * offset,
+  }
+
+  const angle1 = rAngle1 * jitter * HANDLE_ROTATION_MAX
+  const angle2 = rAngle2 * jitter * HANDLE_ROTATION_MAX
+
+  return {
+    p1: rotateAround(p1Base, p0, angle1),
+    p2: rotateAround(p2Base, p3, angle2),
+    side,
+  }
+}
+
+export function deriveCandidatePaths(
+  p0: Vec2,
+  p3: Vec2,
+  params: CursorMotionParams,
+  sequenceIndex: number,
+  count: number = CANDIDATE_COUNT,
+): MotionCandidate[] {
+  const dx = p3.x - p0.x
+  const dy = p3.y - p0.y
+  const dist = Math.hypot(dx, dy)
+  if (dist < 1e-3) {
+    return Array.from({ length: count }, () => ({
+      p1: { ...p0 },
+      p2: { ...p3 },
+      side: 1 as const,
+    }))
+  }
+
+  const sides = candidateSides(params.curveDirection, sequenceIndex, count)
+  return sides.map((side, i) =>
+    candidateFromIndex(p0, p3, params, sequenceIndex, i, side, dx, dy, dist),
+  )
+}
+
+export function pickCandidateIndex(
+  sequenceIndex: number,
+  count: number = CANDIDATE_COUNT,
+): number {
+  if (count <= 0) return 0
+  return Math.floor(seededRandom(sequenceIndex, 9973) * count)
+}
+
+export function deriveControlPoints(
+  p0: Vec2,
+  p3: Vec2,
+  params: CursorMotionParams,
+  sequenceIndex: number,
+): { p1: Vec2; p2: Vec2 } {
+  const candidates = deriveCandidatePaths(p0, p3, params, sequenceIndex)
+  const picked = candidates[pickCandidateIndex(sequenceIndex, candidates.length)]
+  return { p1: picked.p1, p2: picked.p2 }
+}
+
+export function sampleCursorPath(
+  p0: Vec2,
+  p3: Vec2,
+  params: CursorMotionParams,
+  sequenceIndex: number,
+  t: number,
+): Vec2 {
+  const easedT = easeAt(params.easing, t)
+  const { p1, p2 } = deriveControlPoints(p0, p3, params, sequenceIndex)
+  return cubicBezierPoint(p0, p1, p2, p3, easedT)
+}
+
+const PRESETS: readonly EasingPreset[] = [
+  'linear',
+  'easeInOutCubic',
+  'easeOutExpo',
+  'easeInOutQuart',
+  'easeOutBack',
+  'easeInOutSine',
+]
+
+const DIRECTIONS: readonly CurveDirection[] = ['auto', 'left', 'right', 'alternating']
+
+function clamp(n: number, min: number, max: number): number {
+  if (!Number.isFinite(n)) return min
+  return Math.max(min, Math.min(max, n))
+}
+
+export function normalizeEasing(raw: unknown): EasingSpec {
+  if (raw && typeof raw === 'object') {
+    const r = raw as Record<string, unknown>
+    if (r.kind === 'custom') {
+      return {
+        kind: 'custom',
+        x1: clamp(Number(r.x1), 0, 1),
+        y1: Number.isFinite(Number(r.y1)) ? Number(r.y1) : 0,
+        x2: clamp(Number(r.x2), 0, 1),
+        y2: Number.isFinite(Number(r.y2)) ? Number(r.y2) : 1,
+      }
+    }
+    if (r.kind === 'preset' && typeof r.name === 'string') {
+      const name = (PRESETS as readonly string[]).includes(r.name)
+        ? (r.name as EasingPreset)
+        : DEFAULT_CURSOR_MOTION.easing.kind === 'preset'
+          ? DEFAULT_CURSOR_MOTION.easing.name
+          : 'easeInOutCubic'
+      return { kind: 'preset', name }
+    }
+  }
+  return { ...(DEFAULT_CURSOR_MOTION.easing as EasingSpec) }
+}
+
+export function normalizeCursorMotion(raw: unknown): CursorMotionParams {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>
+  const dir = typeof r.curveDirection === 'string' &&
+    (DIRECTIONS as readonly string[]).includes(r.curveDirection)
+    ? (r.curveDirection as CurveDirection)
+    : DEFAULT_CURSOR_MOTION.curveDirection
+  return {
+    durationMs: clamp(
+      Number(r.durationMs ?? DEFAULT_CURSOR_MOTION.durationMs),
+      50,
+      2000,
+    ),
+    easing: normalizeEasing(r.easing),
+    curveStrength: clamp(
+      Number(r.curveStrength ?? DEFAULT_CURSOR_MOTION.curveStrength),
+      0,
+      1,
+    ),
+    curveAsymmetry: clamp(
+      Number(r.curveAsymmetry ?? DEFAULT_CURSOR_MOTION.curveAsymmetry),
+      -1,
+      1,
+    ),
+    curveDirection: dir,
+    curveJitter: clamp(
+      Number(r.curveJitter ?? DEFAULT_CURSOR_MOTION.curveJitter),
+      0,
+      1,
+    ),
+    distanceScaling: clamp(
+      Number(r.distanceScaling ?? DEFAULT_CURSOR_MOTION.distanceScaling),
+      0,
+      1,
+    ),
+  }
+}

--- a/src/shared/cursor-spline.ts
+++ b/src/shared/cursor-spline.ts
@@ -1,0 +1,274 @@
+/**
+ * Centripetal Catmull-Rom spline with arc-length reparameterization.
+ *
+ * Used by renderer cursor playback to animate along a curve at a steady,
+ * eased pace, and by the debug surface to render sampled motion paths.
+ */
+
+import type { Vec2 } from './cursor-motion'
+
+export type Alpha = 0 | 0.5 | 1 | number
+
+export interface SampleResult {
+  position: Vec2
+  tangent: Vec2
+  segmentIndex: number
+  localT: number
+}
+
+export interface CatmullRomSegment {
+  p0: Vec2
+  p1: Vec2
+  p2: Vec2
+  p3: Vec2
+  t0: number
+  t1: number
+  t2: number
+  t3: number
+  lengthStart: number
+  lengthEnd: number
+  arcSamples: number[]
+}
+
+export interface CatmullRomSpline {
+  readonly segments: readonly CatmullRomSegment[]
+  readonly totalLength: number
+  sample(s: number): SampleResult
+  sampleT(u: number): SampleResult
+  polyline(n: number): Vec2[]
+}
+
+const ARC_SAMPLES_PER_SEGMENT = 16
+
+function add(a: Vec2, b: Vec2): Vec2 {
+  return { x: a.x + b.x, y: a.y + b.y }
+}
+
+function sub(a: Vec2, b: Vec2): Vec2 {
+  return { x: a.x - b.x, y: a.y - b.y }
+}
+
+function scale(v: Vec2, k: number): Vec2 {
+  return { x: v.x * k, y: v.y * k }
+}
+
+function dist(a: Vec2, b: Vec2): number {
+  return Math.hypot(b.x - a.x, b.y - a.y)
+}
+
+function lengthOf(v: Vec2): number {
+  return Math.hypot(v.x, v.y)
+}
+
+function normalize(v: Vec2): Vec2 {
+  const m = lengthOf(v)
+  if (m < 1e-9) return { x: 1, y: 0 }
+  return { x: v.x / m, y: v.y / m }
+}
+
+function knotSpacing(a: Vec2, b: Vec2, alpha: number): number {
+  const d = dist(a, b)
+  if (d < 1e-9) return 1e-6
+  return Math.pow(d, alpha)
+}
+
+function interp(a: Vec2, b: Vec2, u: number): Vec2 {
+  return { x: a.x + (b.x - a.x) * u, y: a.y + (b.y - a.y) * u }
+}
+
+function crPoint(seg: CatmullRomSegment, t: number): Vec2 {
+  const { p0, p1, p2, p3, t0, t1, t2, t3 } = seg
+  const a1 = interp(p0, p1, (t - t0) / (t1 - t0))
+  const a2 = interp(p1, p2, (t - t1) / (t2 - t1))
+  const a3 = interp(p2, p3, (t - t2) / (t3 - t2))
+  const b1 = interp(a1, a2, (t - t0) / (t2 - t0))
+  const b2 = interp(a2, a3, (t - t1) / (t3 - t1))
+  return interp(b1, b2, (t - t1) / (t2 - t1))
+}
+
+function crTangent(seg: CatmullRomSegment, t: number): Vec2 {
+  const span = seg.t2 - seg.t1
+  const eps = Math.max(1e-5, span * 1e-3)
+  const lo = Math.max(seg.t1, t - eps)
+  const hi = Math.min(seg.t2, t + eps)
+  return normalize(sub(crPoint(seg, hi), crPoint(seg, lo)))
+}
+
+function buildSegment(
+  p0: Vec2,
+  p1: Vec2,
+  p2: Vec2,
+  p3: Vec2,
+  alpha: number,
+  lengthStart: number,
+): CatmullRomSegment {
+  const t0 = 0
+  const t1 = t0 + knotSpacing(p0, p1, alpha)
+  const t2 = t1 + knotSpacing(p1, p2, alpha)
+  const t3 = t2 + knotSpacing(p2, p3, alpha)
+
+  const seg: CatmullRomSegment = {
+    p0,
+    p1,
+    p2,
+    p3,
+    t0,
+    t1,
+    t2,
+    t3,
+    lengthStart,
+    lengthEnd: lengthStart,
+    arcSamples: [],
+  }
+
+  const samples: number[] = []
+  let cumulative = 0
+  let prev = crPoint(seg, t1)
+  samples.push(0)
+  for (let i = 1; i <= ARC_SAMPLES_PER_SEGMENT; i++) {
+    const u = i / ARC_SAMPLES_PER_SEGMENT
+    const t = t1 + (t2 - t1) * u
+    const curr = crPoint(seg, t)
+    cumulative += dist(prev, curr)
+    samples.push(cumulative)
+    prev = curr
+  }
+  seg.arcSamples = samples
+  seg.lengthEnd = lengthStart + cumulative
+  return seg
+}
+
+function reflectPhantom(p: Vec2, neighbor: Vec2): Vec2 {
+  return { x: 2 * p.x - neighbor.x, y: 2 * p.y - neighbor.y }
+}
+
+export function fitCatmullRom(
+  anchors: Vec2[],
+  opts: {
+    alpha?: number
+    startTangent?: Vec2 | null
+    endTangent?: Vec2 | null
+  } = {},
+): CatmullRomSpline {
+  if (anchors.length < 2) {
+    const p = anchors[0] ?? { x: 0, y: 0 }
+    return {
+      segments: [],
+      totalLength: 0,
+      sample(_s: number): SampleResult {
+        return { position: { ...p }, tangent: { x: 1, y: 0 }, segmentIndex: 0, localT: 0 }
+      },
+      sampleT(_u: number): SampleResult {
+        return { position: { ...p }, tangent: { x: 1, y: 0 }, segmentIndex: 0, localT: 0 }
+      },
+      polyline(n: number): Vec2[] {
+        return Array.from({ length: Math.max(1, n) }, () => ({ ...p }))
+      },
+    }
+  }
+
+  const alpha = opts.alpha ?? 0.5
+  const points = anchors.slice()
+  const firstChord = dist(points[0], points[1])
+  const lastChord = dist(points[points.length - 2], points[points.length - 1])
+
+  const startPhantom: Vec2 = opts.startTangent
+    ? sub(points[0], scale(normalize(opts.startTangent), Math.max(firstChord, 1)))
+    : reflectPhantom(points[0], points[1])
+  const endPhantom: Vec2 = opts.endTangent
+    ? add(points[points.length - 1], scale(normalize(opts.endTangent), Math.max(lastChord, 1)))
+    : reflectPhantom(points[points.length - 1], points[points.length - 2])
+
+  const segments: CatmullRomSegment[] = []
+  let cumulative = 0
+  for (let i = 0; i < points.length - 1; i++) {
+    const p0 = i === 0 ? startPhantom : points[i - 1]
+    const p1 = points[i]
+    const p2 = points[i + 1]
+    const p3 = i === points.length - 2 ? endPhantom : points[i + 2]
+    const seg = buildSegment(p0, p1, p2, p3, alpha, cumulative)
+    segments.push(seg)
+    cumulative = seg.lengthEnd
+  }
+
+  const totalLength = cumulative
+
+  function sample(s: number): SampleResult {
+    if (segments.length === 0) {
+      return {
+        position: { ...points[0] },
+        tangent: { x: 1, y: 0 },
+        segmentIndex: 0,
+        localT: 0,
+      }
+    }
+    const clamped = Math.max(0, Math.min(totalLength, s))
+
+    let segIdx = 0
+    for (let i = 0; i < segments.length; i++) {
+      if (clamped <= segments[i].lengthEnd) {
+        segIdx = i
+        break
+      }
+      segIdx = i
+    }
+    const seg = segments[segIdx]
+    const localArcTarget = clamped - seg.lengthStart
+
+    const table = seg.arcSamples
+    let lo = 0
+    let hi = table.length - 1
+    while (lo < hi - 1) {
+      const mid = (lo + hi) >>> 1
+      if (table[mid] <= localArcTarget) lo = mid
+      else hi = mid
+    }
+
+    const loLen = table[lo]
+    const hiLen = table[hi]
+    const span = hiLen - loLen
+    const frac = span < 1e-9 ? 0 : (localArcTarget - loLen) / span
+    const loU = lo / ARC_SAMPLES_PER_SEGMENT
+    const hiU = hi / ARC_SAMPLES_PER_SEGMENT
+    const u = loU + (hiU - loU) * frac
+    const t = seg.t1 + (seg.t2 - seg.t1) * u
+
+    return {
+      position: crPoint(seg, t),
+      tangent: crTangent(seg, t),
+      segmentIndex: segIdx,
+      localT: u,
+    }
+  }
+
+  function sampleT(u: number): SampleResult {
+    return sample(Math.max(0, Math.min(1, u)) * totalLength)
+  }
+
+  function polyline(n: number): Vec2[] {
+    const count = Math.max(2, n)
+    const out: Vec2[] = []
+    for (let i = 0; i < count; i++) {
+      const u = i / (count - 1)
+      out.push(sample(u * totalLength).position)
+    }
+    return out
+  }
+
+  return { segments, totalLength, sample, sampleT, polyline }
+}
+
+export function foldSpline(
+  current: Vec2,
+  tangent: Vec2,
+  remaining: Vec2[],
+  alpha: number = 0.5,
+): CatmullRomSpline {
+  if (remaining.length === 0) {
+    return fitCatmullRom([current], { alpha })
+  }
+  return fitCatmullRom([current, ...remaining], {
+    alpha,
+    startTangent: tangent,
+  })
+}

--- a/src/shared/cursor-tuning.ts
+++ b/src/shared/cursor-tuning.ts
@@ -1,8 +1,5 @@
 /**
  * Cursor tuning defaults + normalization.
- *
- * In this branch the values are used by the debug presence playground only;
- * they do not drive production cursor playback yet.
  */
 
 import { type EasingSpec, normalizeEasing } from './cursor-motion'

--- a/src/shared/cursor-tuning.ts
+++ b/src/shared/cursor-tuning.ts
@@ -1,0 +1,56 @@
+/**
+ * Cursor tuning defaults + normalization.
+ *
+ * In this branch the values are used by the debug presence playground only;
+ * they do not drive production cursor playback yet.
+ */
+
+import { type EasingSpec, normalizeEasing } from './cursor-motion'
+
+export interface CursorTuningParams {
+  baseSpeedPxS: number
+  distanceScaling: number
+  easing: EasingSpec
+  syncCapMs: number
+  commitHoldMs: number
+  commitDwellMs: number
+}
+
+export const DEFAULT_CURSOR_TUNING: CursorTuningParams = {
+  baseSpeedPxS: 600,
+  distanceScaling: 1,
+  easing: { kind: 'preset', name: 'easeInOutCubic' },
+  syncCapMs: 300,
+  commitHoldMs: 160,
+  commitDwellMs: 150,
+}
+
+export const CURSOR_DISTANCE_REFERENCE_PX = 400
+
+function clamp(n: number, lo: number, hi: number, fallback: number): number {
+  if (!Number.isFinite(n)) return fallback
+  return Math.max(lo, Math.min(hi, n))
+}
+
+export function normalizeCursorTuning(raw: unknown): CursorTuningParams {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>
+  const d = DEFAULT_CURSOR_TUNING
+  return {
+    baseSpeedPxS: clamp(Number(r.baseSpeedPxS ?? d.baseSpeedPxS), 50, 2000, d.baseSpeedPxS),
+    distanceScaling: clamp(Number(r.distanceScaling ?? d.distanceScaling), 0, 1, d.distanceScaling),
+    easing: normalizeEasing(r.easing),
+    syncCapMs: clamp(Number(r.syncCapMs ?? d.syncCapMs), 0, 1000, d.syncCapMs),
+    commitHoldMs: clamp(Number(r.commitHoldMs ?? d.commitHoldMs), 0, 1000, d.commitHoldMs),
+    commitDwellMs: clamp(Number(r.commitDwellMs ?? d.commitDwellMs), 0, 1000, d.commitDwellMs),
+  }
+}
+
+export function distanceSpeedScale(
+  tuning: CursorTuningParams,
+  totalLengthPx: number,
+): number {
+  const exp = Math.max(0, Math.min(1, tuning.distanceScaling))
+  if (exp >= 1 || totalLengthPx <= 0) return 1
+  const ratio = totalLengthPx / CURSOR_DISTANCE_REFERENCE_PX
+  return Math.pow(ratio, 1 - exp)
+}

--- a/src/shared/presence-debug.ts
+++ b/src/shared/presence-debug.ts
@@ -1,0 +1,20 @@
+export type PresenceDebugSide = 'cli' | 'director'
+
+export type PresenceDebugKind =
+  | 'cli:emit'
+  | 'cli:sync-wait'
+  | 'cli:sync-resolve'
+  | 'cli:box-resolve'
+  | 'dir:apply'
+  | 'dir:phase'
+  | 'dir:drop'
+
+export interface PresenceDebugEntry {
+  id: number
+  t: number
+  side: PresenceDebugSide
+  kind: PresenceDebugKind
+  sessionId: string
+  label: string
+  detail?: string
+}

--- a/src/shared/presence-targeting.ts
+++ b/src/shared/presence-targeting.ts
@@ -7,16 +7,23 @@ export function resolvePresenceFramePoint(input: {
   fallbackX: number
   fallbackY: number
 }): { x: number; y: number } {
-  if (typeof input.frameX === 'number' && typeof input.frameY === 'number') {
-    return { x: input.frameX, y: input.frameY }
+  const targetCenter = input.targetRect
+    ? {
+        x: input.targetRect.x + input.targetRect.width / 2,
+        y: input.targetRect.y + input.targetRect.height / 2,
+      }
+    : null
+
+  return {
+    x:
+      typeof input.frameX === 'number'
+        ? input.frameX
+        : targetCenter?.x ?? input.fallbackX,
+    y:
+      typeof input.frameY === 'number'
+        ? input.frameY
+        : targetCenter?.y ?? input.fallbackY,
   }
-  if (input.targetRect) {
-    return {
-      x: input.targetRect.x + input.targetRect.width / 2,
-      y: input.targetRect.y + input.targetRect.height / 2,
-    }
-  }
-  return { x: input.fallbackX, y: input.fallbackY }
 }
 
 export function framePointMatchesTargetRect(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,3 +1,14 @@
+import type {
+  CursorMotionParams,
+  CurveDirection,
+  EasingPreset,
+  EasingSpec,
+  MotionCandidate,
+  Vec2,
+} from './cursor-motion'
+import type { CursorTuningParams } from './cursor-tuning'
+import type { PresenceDebugEntry } from './presence-debug'
+
 // --- IPC Channel Types ---
 
 export interface ViewportPreset {
@@ -494,6 +505,13 @@ export interface ThemeBootstrapData {
   theme: ThemeData
 }
 
+export interface DebugBootstrapData extends ThemeBootstrapData {
+  cursorMotion: CursorMotionParams
+  cursorSplineViz: boolean
+  cursorTuning: CursorTuningParams
+  presenceTimeline: PresenceDebugEntry[]
+}
+
 export interface LeftSidebarBootstrapData extends ThemeBootstrapData {
   sidebarData: LeftSidebarData
 }
@@ -547,6 +565,38 @@ export interface OnboardingElectronAPI {
   dismiss: () => void
   onProgress: (callback: (event: OnboardingProgressEvent) => void) => () => void
   onThemeChanged: (callback: (data: ThemeData) => void) => () => void
+}
+
+export interface DebugElectronAPI {
+  getInitialData: () => Promise<DebugBootstrapData>
+  updateCursorMotion: (params: CursorMotionParams) => void
+  resetCursorMotion: () => void
+  onCursorMotionChanged: (callback: (params: CursorMotionParams) => void) => () => void
+  updateCursorSplineViz: (on: boolean) => void
+  onCursorSplineVizChanged: (callback: (on: boolean) => void) => () => void
+  updateCursorTuning: (params: CursorTuningParams) => void
+  resetCursorTuning: () => void
+  onPresenceTimelineAppend: (callback: (entry: PresenceDebugEntry) => void) => () => void
+  onThemeChanged: (callback: (data: ThemeData) => void) => () => void
+}
+
+export interface DebugPreviewPath {
+  start: Vec2
+  end: Vec2
+  candidates: MotionCandidate[]
+  selectedCandidateIndex: number
+  samples: Vec2[]
+}
+
+export type {
+  CursorMotionParams,
+  CurveDirection,
+  CursorTuningParams,
+  EasingPreset,
+  EasingSpec,
+  MotionCandidate,
+  PresenceDebugEntry,
+  Vec2,
 }
 
 export interface CanvasLayoutBootstrapData extends ThemeBootstrapData {

--- a/tests/unit/cursor-motion.test.ts
+++ b/tests/unit/cursor-motion.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CURSOR_MOTION_PRESETS,
+  DEFAULT_CURSOR_MOTION,
+  cubicBezierPoint,
+  deriveControlPoints,
+  easeAt,
+  normalizeCursorMotion,
+  sampleCursorPath,
+} from '../../src/shared/cursor-motion'
+
+describe('easeAt', () => {
+  it('linear is identity', () => {
+    expect(easeAt({ kind: 'preset', name: 'linear' }, 0.25)).toBeCloseTo(0.25)
+    expect(easeAt({ kind: 'preset', name: 'linear' }, 0.75)).toBeCloseTo(0.75)
+  })
+
+  it('preset easings pin endpoints', () => {
+    for (const name of Object.keys(CURSOR_MOTION_PRESETS) as Array<
+      keyof typeof CURSOR_MOTION_PRESETS
+    >) {
+      expect(easeAt({ kind: 'preset', name }, 0)).toBe(0)
+      expect(easeAt({ kind: 'preset', name }, 1)).toBe(1)
+    }
+  })
+
+  it('easeInOutCubic is monotonic over [0,1]', () => {
+    let prev = 0
+    for (let i = 1; i <= 10; i++) {
+      const t = i / 10
+      const v = easeAt({ kind: 'preset', name: 'easeInOutCubic' }, t)
+      expect(v).toBeGreaterThanOrEqual(prev)
+      prev = v
+    }
+  })
+
+  it('custom bezier matches an ease-out shape', () => {
+    const v = easeAt({ kind: 'custom', x1: 0, y1: 0, x2: 0.58, y2: 1 }, 0.5)
+    expect(v).toBeGreaterThan(0.5)
+  })
+})
+
+describe('cubicBezierPoint', () => {
+  it('maps endpoints to p0 and p3', () => {
+    const p0 = { x: 10, y: 20 }
+    const p1 = { x: 50, y: -30 }
+    const p2 = { x: 70, y: 120 }
+    const p3 = { x: 200, y: 80 }
+    expect(cubicBezierPoint(p0, p1, p2, p3, 0)).toEqual(p0)
+    expect(cubicBezierPoint(p0, p1, p2, p3, 1)).toEqual(p3)
+  })
+})
+
+describe('deriveControlPoints', () => {
+  const p0 = { x: 0, y: 0 }
+  const p3 = { x: 100, y: 0 }
+
+  it('curveStrength=0 places controls on the straight line', () => {
+    const { p1, p2 } = deriveControlPoints(
+      p0,
+      p3,
+      {
+        ...DEFAULT_CURSOR_MOTION,
+        curveStrength: 0,
+        curveAsymmetry: 0,
+        curveJitter: 0,
+      },
+      0,
+    )
+    expect(p1.y).toBeCloseTo(0)
+    expect(p2.y).toBeCloseTo(0)
+  })
+
+  it('left and right produce mirrored offsets', () => {
+    const left = deriveControlPoints(
+      p0,
+      p3,
+      {
+        ...DEFAULT_CURSOR_MOTION,
+        curveStrength: 0.5,
+        curveJitter: 0,
+        curveDirection: 'left',
+      },
+      0,
+    )
+    const right = deriveControlPoints(
+      p0,
+      p3,
+      {
+        ...DEFAULT_CURSOR_MOTION,
+        curveStrength: 0.5,
+        curveJitter: 0,
+        curveDirection: 'right',
+      },
+      0,
+    )
+    expect(Math.sign(left.p1.y)).not.toBe(Math.sign(right.p1.y))
+    expect(left.p1.y).toBeCloseTo(-right.p1.y)
+  })
+
+  it('zero-distance returns endpoints unchanged', () => {
+    const { p1, p2 } = deriveControlPoints(
+      { x: 5, y: 5 },
+      { x: 5, y: 5 },
+      DEFAULT_CURSOR_MOTION,
+      0,
+    )
+    expect(p1).toEqual({ x: 5, y: 5 })
+    expect(p2).toEqual({ x: 5, y: 5 })
+  })
+})
+
+describe('sampleCursorPath', () => {
+  it('endpoints match p0 and p3', () => {
+    const p0 = { x: 0, y: 0 }
+    const p3 = { x: 100, y: 50 }
+    const params = {
+      ...DEFAULT_CURSOR_MOTION,
+      curveStrength: 0.8,
+      curveAsymmetry: 0.5,
+      curveDirection: 'right' as const,
+    }
+    const start = sampleCursorPath(p0, p3, params, 0, 0)
+    const end = sampleCursorPath(p0, p3, params, 0, 1)
+    expect(start.x).toBeCloseTo(p0.x)
+    expect(start.y).toBeCloseTo(p0.y)
+    expect(end.x).toBeCloseTo(p3.x)
+    expect(end.y).toBeCloseTo(p3.y)
+  })
+})
+
+describe('normalizeCursorMotion', () => {
+  it('empty object returns defaults', () => {
+    expect(normalizeCursorMotion({})).toEqual(DEFAULT_CURSOR_MOTION)
+  })
+
+  it('undefined and non-objects return defaults', () => {
+    expect(normalizeCursorMotion(undefined)).toEqual(DEFAULT_CURSOR_MOTION)
+    expect(normalizeCursorMotion(null)).toEqual(DEFAULT_CURSOR_MOTION)
+    expect(normalizeCursorMotion(42)).toEqual(DEFAULT_CURSOR_MOTION)
+  })
+
+  it('clamps out-of-range values', () => {
+    const n = normalizeCursorMotion({
+      durationMs: 99999,
+      curveStrength: 5,
+      curveAsymmetry: -10,
+    })
+    expect(n.durationMs).toBe(2000)
+    expect(n.curveStrength).toBe(1)
+    expect(n.curveAsymmetry).toBe(-1)
+  })
+
+  it('accepts custom easing', () => {
+    const n = normalizeCursorMotion({
+      easing: { kind: 'custom', x1: 0.25, y1: 0.1, x2: 0.25, y2: 1 },
+    })
+    expect(n.easing.kind).toBe('custom')
+    if (n.easing.kind === 'custom') {
+      expect(n.easing.x1).toBeCloseTo(0.25)
+      expect(n.easing.x2).toBeCloseTo(0.25)
+    }
+  })
+})

--- a/tests/unit/cursor-spline.test.ts
+++ b/tests/unit/cursor-spline.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import type { Vec2 } from '../../src/shared/cursor-motion'
+import { fitCatmullRom, foldSpline } from '../../src/shared/cursor-spline'
+
+function pt(x: number, y: number): Vec2 {
+  return { x, y }
+}
+
+function dist(a: Vec2, b: Vec2): number {
+  return Math.hypot(a.x - b.x, a.y - b.y)
+}
+
+describe('fitCatmullRom', () => {
+  it('two-point fit produces a straight-line spline', () => {
+    const s = fitCatmullRom([pt(0, 0), pt(100, 0)])
+    expect(s.segments).toHaveLength(1)
+    expect(s.totalLength).toBeCloseTo(100, 1)
+
+    const mid = s.sampleT(0.5)
+    expect(mid.position.x).toBeCloseTo(50, 1)
+    expect(mid.position.y).toBeCloseTo(0, 1)
+    expect(mid.tangent.x).toBeCloseTo(1, 2)
+    expect(Math.abs(mid.tangent.y)).toBeLessThan(0.01)
+  })
+
+  it('samples endpoints exactly', () => {
+    const anchors = [pt(0, 0), pt(50, 20), pt(120, -10), pt(200, 40)]
+    const s = fitCatmullRom(anchors)
+
+    const start = s.sample(0)
+    expect(start.position.x).toBeCloseTo(0, 1)
+    expect(start.position.y).toBeCloseTo(0, 1)
+
+    const end = s.sample(s.totalLength)
+    expect(end.position.x).toBeCloseTo(200, 0.5)
+    expect(end.position.y).toBeCloseTo(40, 0.5)
+  })
+
+  it('arc length is monotonic across samples', () => {
+    const anchors = [pt(0, 0), pt(50, 30), pt(100, -20), pt(180, 10), pt(240, 50)]
+    const s = fitCatmullRom(anchors)
+
+    let prev = s.sample(0).position
+    let travelled = 0
+    const steps = 64
+    for (let i = 1; i <= steps; i++) {
+      const sample = s.sample((i / steps) * s.totalLength)
+      travelled += dist(prev, sample.position)
+      prev = sample.position
+    }
+
+    expect(travelled).toBeGreaterThan(s.totalLength * 0.95)
+    expect(travelled).toBeLessThan(s.totalLength * 1.05)
+  })
+
+  it('passes through all interior anchors', () => {
+    const anchors = [pt(0, 0), pt(80, 40), pt(160, -20), pt(240, 30)]
+    const s = fitCatmullRom(anchors)
+
+    for (let i = 1; i < anchors.length - 1; i++) {
+      const seg = s.segments[i - 1]
+      const p = s.sample(seg.lengthEnd).position
+      expect(p.x).toBeCloseTo(anchors[i].x, 0.5)
+      expect(p.y).toBeCloseTo(anchors[i].y, 0.5)
+    }
+  })
+})
+
+describe('foldSpline', () => {
+  it('starts at current position with matching tangent', () => {
+    const tangent: Vec2 = pt(1, 0)
+    const s = foldSpline(pt(50, 50), tangent, [pt(120, 60), pt(200, 40)])
+
+    const start = s.sample(0)
+    expect(start.position.x).toBeCloseTo(50, 0.5)
+    expect(start.position.y).toBeCloseTo(50, 0.5)
+    expect(start.tangent.x).toBeGreaterThan(0.5)
+    expect(Math.abs(start.tangent.y)).toBeLessThan(0.7)
+  })
+
+  it('with no remaining anchors returns a degenerate spline', () => {
+    const s = foldSpline(pt(10, 20), pt(1, 0), [])
+    expect(s.totalLength).toBe(0)
+    const r = s.sample(0)
+    expect(r.position.x).toBe(10)
+    expect(r.position.y).toBe(20)
+  })
+})

--- a/tests/unit/presence-targeting.test.ts
+++ b/tests/unit/presence-targeting.test.ts
@@ -27,6 +27,17 @@ describe('resolvePresenceFramePoint', () => {
     expect(result).toEqual({ x: 35, y: 50 })
   })
 
+  it('mixes partial frame coordinates with fallback values', () => {
+    const result = resolvePresenceFramePoint({
+      frameX: null,
+      frameY: 20,
+      targetRect: null,
+      fallbackX: 500,
+      fallbackY: 300,
+    })
+    expect(result).toEqual({ x: 500, y: 20 })
+  })
+
   it('falls back to fallback coordinates when nothing else available', () => {
     const result = resolvePresenceFramePoint({
       frameX: null,

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
         'devtools-resize-handle': resolve(__dirname, 'src/renderer/devtools-resize-handle/index.html'),
         'right-details-panel': resolve(__dirname, 'src/renderer/right-details-panel/index.html'),
         onboarding: resolve(__dirname, 'src/renderer/onboarding/index.html'),
+        debug: resolve(__dirname, 'src/renderer/debug/index.html'),
       },
     },
   },


### PR DESCRIPTION
## Summary

- Replace bezier-candidate cursor motion with a folding spline model for smoother agent cursor travel (shared primitives in `src/shared/cursor-spline.ts` + `cursor-motion.ts`; production path uses spline fold on repeated clicks).
- Add a standalone debug window (Cmd+Shift+D) with a presence playground and cursor-tuning controls, persisted via user preferences. Main-process wiring in `src/main/debug-window.ts` + `src/main/ipc/register-debug-ipc.ts`.
- Fix same-frame presence: preserve cursor position when the agent issues an intent for the frame it's already in and no `targetRect` resolves (prevents visible hops between interactions).
- Fix cursor projection: offset agent cursor by chrome header height when converting frame DOM points to canvas coords.
- Simplify pass: dedupe debug broadcasts, drop TOCTOU in preferences read, reduce presence-expiry timer churn, extract `FilledCursorIcon` to `renderer/shared/` so the debug bundle doesn't pull from `canvas-bg`.

## Test plan

- [ ] `pnpm typecheck`
- [ ] `pnpm test:unit`
- [ ] `pnpm test:smoke`
- [ ] Manual: open debug window (Cmd+Shift+D), adjust cursor tuning sliders — verify values persist across app restart
- [ ] Manual: run an agent session with multiple intents in the same frame — confirm cursor no longer hops to frame center between interactions
- [ ] Manual: toggle spline viz on — confirm overlay renders on canvas and clears when off