### PR TITLE
Improve presence cursor positioning and pre-click timing

### DIFF
--- a/src/main/app-control-server.ts
+++ b/src/main/app-control-server.ts
@@ -29,6 +29,7 @@ import {
   PRESENCE_CURSOR_STEP_DELAY_MS,
   PRESENCE_CURSOR_POSITION_SKIP_PX,
 } from './presence-cursor'
+import { framePointMatchesTargetRect } from '../shared/presence-targeting'
 import {
   type CdpProxyRegistration,
   type CdpClientBridge,
@@ -548,12 +549,9 @@ export async function startAppControlServer(): Promise<void> {
           const y = params.y as number
           const resolved = resolveCanvasPointForFrame(registration.frameId, { frameX: x, frameY: y })
           if (resolved) {
-            // For mousePressed, if the CDP-resolved point is already inside the
-            // cursor's current targetRect (or just a few px away in canvas
-            // space), the intent already put us at the target — a second
-            // reposition would restart the 250ms animation from almost-zero
-            // distance and make the click land mid-correction. Flip activity
-            // but leave the position alone.
+            // On mousePressed, if the intent already placed the cursor at the
+            // target, suppress the reposition — otherwise the click lands
+            // mid-animation instead of on the dwelled cursor.
             let skipPosition = false
             if (cdpType === 'mousePressed') {
               const existing = registration.sessionId
@@ -562,9 +560,7 @@ export async function startAppControlServer(): Promise<void> {
               if (existing && existing.frameId === registration.frameId) {
                 const rect = existing.targetRect
                 const withinTargetRect =
-                  rect != null &&
-                  x >= rect.x && x <= rect.x + rect.width &&
-                  y >= rect.y && y <= rect.y + rect.height
+                  rect != null && framePointMatchesTargetRect(x, y, rect, 0)
                 const canvasDistance = Math.hypot(
                   resolved.canvasX - existing.canvasX,
                   resolved.canvasY - existing.canvasY,
@@ -578,10 +574,9 @@ export async function startAppControlServer(): Promise<void> {
               body: pageSessionBody(),
               surface: 'frame',
               frameId: registration.frameId,
-              frameX: skipPosition ? undefined : x,
-              frameY: skipPosition ? undefined : y,
-              canvasX: skipPosition ? undefined : resolved.canvasX,
-              canvasY: skipPosition ? undefined : resolved.canvasY,
+              ...(skipPosition
+                ? {}
+                : { frameX: x, frameY: y, canvasX: resolved.canvasX, canvasY: resolved.canvasY }),
               activity: 'acting',
               labelKey: cdpType === 'mouseMoved' ? undefined : 'click_target',
               targetRef: null,
@@ -597,10 +592,9 @@ export async function startAppControlServer(): Promise<void> {
               clearTimeout(intent.expiryTimer)
               pendingIntents.delete(intentSessionId)
             }
-            // Budget the pre-click wait from the cursor's most recent actual
-            // position change, not from intent arrival. If agent-browser
-            // cold-start + scrollintoview ate the intent head-start, this
-            // restores the full travel+dwell window after the final reposition.
+            // Budget the pre-click dwell from the cursor's last reposition,
+            // not from intent arrival — otherwise cold-start / scrollIntoView
+            // can consume the head-start before the cursor finishes moving.
             const cursor = intentSessionId ? presenceCursors.get(intentSessionId) : undefined
             const elapsed = cursor ? Date.now() - cursor.lastMoveAt : 0
             const remaining = Math.max(0, PRESENCE_CURSOR_STEP_DELAY_MS - elapsed)

--- a/src/main/app-control-server.ts
+++ b/src/main/app-control-server.ts
@@ -574,15 +574,24 @@ export async function startAppControlServer(): Promise<void> {
               body: pageSessionBody(),
               surface: 'frame',
               frameId: registration.frameId,
+              // On skip, preserve all rendering-input fields (frame coords,
+              // targetRect, targetRef/Name). canvas-layout-data recomputes
+              // frame-cursor canvasX/Y from frameX/Y or targetRect; clearing
+              // both would snap the cursor to frame center.
               ...(skipPosition
                 ? {}
-                : { frameX: x, frameY: y, canvasX: resolved.canvasX, canvasY: resolved.canvasY }),
+                : {
+                    frameX: x,
+                    frameY: y,
+                    canvasX: resolved.canvasX,
+                    canvasY: resolved.canvasY,
+                    targetRef: null,
+                    targetRefSource: null,
+                    targetName: null,
+                    targetRect: null,
+                  }),
               activity: 'acting',
               labelKey: cdpType === 'mouseMoved' ? undefined : 'click_target',
-              targetRef: null,
-              targetRefSource: null,
-              targetName: null,
-              targetRect: null,
             })
           }
           if (cdpType === 'mousePressed') {

--- a/src/main/app-control-server.ts
+++ b/src/main/app-control-server.ts
@@ -25,7 +25,9 @@ import {
 } from './presence-manager'
 import {
   upsertPresenceCursor,
+  presenceCursors,
   PRESENCE_CURSOR_STEP_DELAY_MS,
+  PRESENCE_CURSOR_POSITION_SKIP_PX,
 } from './presence-cursor'
 import {
   type CdpProxyRegistration,
@@ -546,14 +548,40 @@ export async function startAppControlServer(): Promise<void> {
           const y = params.y as number
           const resolved = resolveCanvasPointForFrame(registration.frameId, { frameX: x, frameY: y })
           if (resolved) {
+            // For mousePressed, if the CDP-resolved point is already inside the
+            // cursor's current targetRect (or just a few px away in canvas
+            // space), the intent already put us at the target — a second
+            // reposition would restart the 250ms animation from almost-zero
+            // distance and make the click land mid-correction. Flip activity
+            // but leave the position alone.
+            let skipPosition = false
+            if (cdpType === 'mousePressed') {
+              const existing = registration.sessionId
+                ? presenceCursors.get(registration.sessionId)
+                : undefined
+              if (existing && existing.frameId === registration.frameId) {
+                const rect = existing.targetRect
+                const withinTargetRect =
+                  rect != null &&
+                  x >= rect.x && x <= rect.x + rect.width &&
+                  y >= rect.y && y <= rect.y + rect.height
+                const canvasDistance = Math.hypot(
+                  resolved.canvasX - existing.canvasX,
+                  resolved.canvasY - existing.canvasY,
+                )
+                skipPosition =
+                  withinTargetRect ||
+                  canvasDistance < PRESENCE_CURSOR_POSITION_SKIP_PX
+              }
+            }
             upsertPresenceCursor(request, {
               body: pageSessionBody(),
               surface: 'frame',
               frameId: registration.frameId,
-              frameX: x,
-              frameY: y,
-              canvasX: resolved.canvasX,
-              canvasY: resolved.canvasY,
+              frameX: skipPosition ? undefined : x,
+              frameY: skipPosition ? undefined : y,
+              canvasX: skipPosition ? undefined : resolved.canvasX,
+              canvasY: skipPosition ? undefined : resolved.canvasY,
               activity: 'acting',
               labelKey: cdpType === 'mouseMoved' ? undefined : 'click_target',
               targetRef: null,
@@ -565,11 +593,16 @@ export async function startAppControlServer(): Promise<void> {
           if (cdpType === 'mousePressed') {
             const intentSessionId = registration.sessionId ?? ''
             const intent = pendingIntents.get(intentSessionId)
-            const elapsed = intent ? Date.now() - intent.receivedAt : 0
             if (intent) {
               clearTimeout(intent.expiryTimer)
               pendingIntents.delete(intentSessionId)
             }
+            // Budget the pre-click wait from the cursor's most recent actual
+            // position change, not from intent arrival. If agent-browser
+            // cold-start + scrollintoview ate the intent head-start, this
+            // restores the full travel+dwell window after the final reposition.
+            const cursor = intentSessionId ? presenceCursors.get(intentSessionId) : undefined
+            const elapsed = cursor ? Date.now() - cursor.lastMoveAt : 0
             const remaining = Math.max(0, PRESENCE_CURSOR_STEP_DELAY_MS - elapsed)
             if (remaining > 0) {
               await new Promise<void>((resolve) => setTimeout(resolve, remaining))

--- a/src/main/app-control-server.ts
+++ b/src/main/app-control-server.ts
@@ -348,6 +348,13 @@ export async function startAppControlServer(): Promise<void> {
 
     const IPC_TIMEOUT_MS = 5000
 
+    const waitForPresenceDwell = async (sessionId: string | null | undefined): Promise<void> => {
+      const cursor = sessionId ? presenceCursors.get(sessionId) : undefined
+      const elapsed = cursor ? Date.now() - cursor.lastMoveAt : 0
+      const remaining = Math.max(0, PRESENCE_CURSOR_STEP_DELAY_MS - elapsed)
+      if (remaining > 0) await new Promise<void>((resolve) => setTimeout(resolve, remaining))
+    }
+
     const sendScrollIpc = (
       wc: Electron.WebContents,
       x: number,
@@ -604,12 +611,7 @@ export async function startAppControlServer(): Promise<void> {
             // Budget the pre-click dwell from the cursor's last reposition,
             // not from intent arrival — otherwise cold-start / scrollIntoView
             // can consume the head-start before the cursor finishes moving.
-            const cursor = intentSessionId ? presenceCursors.get(intentSessionId) : undefined
-            const elapsed = cursor ? Date.now() - cursor.lastMoveAt : 0
-            const remaining = Math.max(0, PRESENCE_CURSOR_STEP_DELAY_MS - elapsed)
-            if (remaining > 0) {
-              await new Promise<void>((resolve) => setTimeout(resolve, remaining))
-            }
+            await waitForPresenceDwell(registration.sessionId)
           }
 
           // DOM.getBoxModel returns CSS viewport coords; Input.dispatchMouseEvent
@@ -687,6 +689,7 @@ export async function startAppControlServer(): Promise<void> {
           activity: 'acting',
           labelKey: 'scroll_page',
         })
+        await waitForPresenceDwell(registration.sessionId)
         try {
           const startedAt = Date.now()
           const result = await sendScrollIpc(
@@ -731,6 +734,7 @@ export async function startAppControlServer(): Promise<void> {
           activity: 'acting',
           labelKey: 'scroll_page',
         })
+        await waitForPresenceDwell(registration.sessionId)
         try {
           const startedAt = Date.now()
           const result = await sendScrollIpc(

--- a/src/main/presence-cursor.ts
+++ b/src/main/presence-cursor.ts
@@ -44,6 +44,10 @@ export interface PresenceCursorEntry {
   targetName?: string | null
   targetRect?: PresenceTargetRect | null
   updatedAt: number
+  // Wall-clock time of the most recent canvasX/canvasY change. Drives the
+  // CDP-proxy pre-click sleep so the budget resets when the cursor is
+  // actually repositioned (not just re-tagged).
+  lastMoveAt: number
 }
 
 export interface ActivePresenceTask {
@@ -72,6 +76,10 @@ let presenceExpiryTimer: NodeJS.Timeout | null = null
 // --- Constants ---
 
 export const PRESENCE_CURSOR_STEP_DELAY_MS = PRESENCE_STEP_DELAY_MS
+/** Canvas-space distance below which a CDP-time reposition is treated as a
+ *  no-op correction — the cursor stays where the intent placed it rather than
+ *  restarting its animation to a few-pixel-off coordinate. */
+export const PRESENCE_CURSOR_POSITION_SKIP_PX = 30
 const PRESENCE_CURSOR_THINKING_DELAY_MS = PRESENCE_THINKING_DELAY_MS
 const PRESENCE_DEPARTURE_GRACE_MS = 1500
 const PRESENCE_IDLE_RETIRE_MS = 10_000
@@ -384,12 +392,18 @@ export function upsertPresenceCursor(
   }
 
   const existing = presenceCursors.get(sessionId)
+  const resolvedCanvasX = patch.canvasX ?? existing?.canvasX ?? 0
+  const resolvedCanvasY = patch.canvasY ?? existing?.canvasY ?? 0
+  const positionChanged =
+    !existing ||
+    existing.canvasX !== resolvedCanvasX ||
+    existing.canvasY !== resolvedCanvasY
   const next: PresenceCursorEntry = {
     sessionId,
     clientName: session.clientName,
     color: existing?.color ?? deriveColor(sessionId),
-    canvasX: patch.canvasX ?? existing?.canvasX ?? 0,
-    canvasY: patch.canvasY ?? existing?.canvasY ?? 0,
+    canvasX: resolvedCanvasX,
+    canvasY: resolvedCanvasY,
     surface: patch.surface ?? existing?.surface ?? 'canvas',
     activity: patch.activity ?? existing?.activity ?? 'acting',
     frameId:
@@ -437,6 +451,9 @@ export function upsertPresenceCursor(
         ? existing?.targetRect ?? null
         : patch.targetRect,
     updatedAt: Date.now(),
+    lastMoveAt: positionChanged
+      ? Date.now()
+      : existing?.lastMoveAt ?? Date.now(),
   }
 
   presenceCursors.set(sessionId, next)
@@ -630,6 +647,7 @@ export function movePresenceCursorTo(
     activity: 'traveling',
     labelKey,
     updatedAt: Date.now(),
+    lastMoveAt: Date.now(),
   }
   presenceCursors.set(resolved.sessionId, next)
   logPresenceMove(

--- a/src/main/presence-cursor.ts
+++ b/src/main/presence-cursor.ts
@@ -398,6 +398,7 @@ export function upsertPresenceCursor(
     !existing ||
     existing.canvasX !== resolvedCanvasX ||
     existing.canvasY !== resolvedCanvasY
+  const now = Date.now()
   const next: PresenceCursorEntry = {
     sessionId,
     clientName: session.clientName,
@@ -450,10 +451,8 @@ export function upsertPresenceCursor(
       patch.targetRect === undefined
         ? existing?.targetRect ?? null
         : patch.targetRect,
-    updatedAt: Date.now(),
-    lastMoveAt: positionChanged
-      ? Date.now()
-      : existing?.lastMoveAt ?? Date.now(),
+    updatedAt: now,
+    lastMoveAt: positionChanged ? now : existing?.lastMoveAt ?? now,
   }
 
   presenceCursors.set(sessionId, next)

--- a/src/main/presence-cursor.ts
+++ b/src/main/presence-cursor.ts
@@ -638,6 +638,8 @@ export function movePresenceCursorTo(
   if (existing.canvasX === canvasX && existing.canvasY === canvasY && existing.labelKey === labelKey) {
     return
   }
+  const positionChanged = existing.canvasX !== canvasX || existing.canvasY !== canvasY
+  const now = Date.now()
   const next: PresenceCursorEntry = {
     ...existing,
     canvasX,
@@ -645,8 +647,8 @@ export function movePresenceCursorTo(
     surface: 'canvas',
     activity: 'traveling',
     labelKey,
-    updatedAt: Date.now(),
-    lastMoveAt: Date.now(),
+    updatedAt: now,
+    lastMoveAt: positionChanged ? now : existing.lastMoveAt,
   }
   presenceCursors.set(resolved.sessionId, next)
   logPresenceMove(

--- a/src/preload/page-content.ts
+++ b/src/preload/page-content.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from 'electron'
 import type { Annotation, AnnotationMode, ScrollSyncData } from '../shared/types'
+import { PRESENCE_SCROLL_ANIMATION_MS } from '../shared/presence-timing'
 
 import {
   getInspectableElementByNodeId,
@@ -698,6 +699,8 @@ ipcRenderer.on(
 )
 
 
+let activeScrollToken = 0
+
 ipcRenderer.on(
   'dispatch-scroll',
   (
@@ -735,24 +738,62 @@ ipcRenderer.on(
     }
     const beforeLeft = target.scrollLeft
     const beforeTop = target.scrollTop
-    target.scrollBy(payload.deltaX, payload.deltaY)
-    const afterLeft = target.scrollLeft
-    const afterTop = target.scrollTop
-    ipcRenderer.send('dispatch-scroll-result', {
-      requestId: payload.requestId,
-      data: {
-        ok: true,
-        consumed: beforeLeft !== afterLeft || beforeTop !== afterTop,
-        targetTag:
-          target instanceof Element
-            ? target.tagName.toLowerCase()
-            : 'document',
-        beforeLeft,
-        beforeTop,
-        afterLeft,
-        afterTop,
-      },
-    })
+
+    const finish = () => {
+      const afterLeft = target.scrollLeft
+      const afterTop = target.scrollTop
+      ipcRenderer.send('dispatch-scroll-result', {
+        requestId: payload.requestId,
+        data: {
+          ok: true,
+          consumed: beforeLeft !== afterLeft || beforeTop !== afterTop,
+          targetTag:
+            target instanceof Element
+              ? target.tagName.toLowerCase()
+              : 'document',
+          beforeLeft,
+          beforeTop,
+          afterLeft,
+          afterTop,
+        },
+      })
+    }
+
+    if (payload.deltaX === 0 && payload.deltaY === 0) {
+      finish()
+      return
+    }
+
+    // Supersede any in-flight ramp so back-to-back scrolls don't stack.
+    const token = ++activeScrollToken
+    const duration = PRESENCE_SCROLL_ANIMATION_MS
+    const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3)
+    let startedAt = 0
+    let appliedX = 0
+    let appliedY = 0
+
+    const tick = (now: number) => {
+      if (token !== activeScrollToken) {
+        finish()
+        return
+      }
+      if (startedAt === 0) startedAt = now
+      const progress = Math.min(1, (now - startedAt) / duration)
+      const eased = easeOutCubic(progress)
+      const targetX = payload.deltaX * eased
+      const targetY = payload.deltaY * eased
+      const stepX = targetX - appliedX
+      const stepY = targetY - appliedY
+      if (stepX !== 0 || stepY !== 0) target.scrollBy(stepX, stepY)
+      appliedX = targetX
+      appliedY = targetY
+      if (progress < 1) {
+        requestAnimationFrame(tick)
+      } else {
+        finish()
+      }
+    }
+    requestAnimationFrame(tick)
   },
 )
 

--- a/src/renderer/canvas-bg/AgentCursorLayer.tsx
+++ b/src/renderer/canvas-bg/AgentCursorLayer.tsx
@@ -5,7 +5,11 @@ import type {
   PresenceActivity,
 } from '../../shared/types'
 import { labelForPresenceCursor } from '../../shared/agent-presence'
-import { DEFAULT_CURSOR_MOTION, easeAt } from '../../shared/cursor-motion'
+import {
+  DEFAULT_CURSOR_MOTION,
+  DISTANCE_SCALE_REFERENCE_PX,
+  easeAt,
+} from '../../shared/cursor-motion'
 import { foldSpline } from '../../shared/cursor-spline'
 import { framePointMatchesTargetRect } from '../../shared/presence-targeting'
 import {
@@ -15,12 +19,22 @@ import {
 import { FilledCursorIcon } from '../shared/FilledCursorIcon'
 
 const ANIMATE_DURATION_MS = PRESENCE_TRAVEL_MS
+// Short hops complete faster, longer hops cap at ANIMATE_DURATION_MS, so the
+// pre-click dwell budget grows when the cursor only needs to travel a few px.
+const MIN_ANIMATE_DURATION_MS = 60
 const PRODUCTION_CURSOR_MOTION = {
   ...DEFAULT_CURSOR_MOTION,
   durationMs: ANIMATE_DURATION_MS,
   distanceScaling: 0,
 }
 const POSITION_EPSILON = 0.5
+
+function animationDurationForDistance(distance: number): number {
+  if (distance <= 0) return 0
+  if (distance >= DISTANCE_SCALE_REFERENCE_PX) return ANIMATE_DURATION_MS
+  const scaled = ANIMATE_DURATION_MS * (distance / DISTANCE_SCALE_REFERENCE_PX)
+  return Math.max(MIN_ANIMATE_DURATION_MS, scaled)
+}
 
 function activityStyle(activity: PresenceActivity): CSSProperties {
   switch (activity) {
@@ -164,11 +178,13 @@ function AgentCursor({
     }
 
     const spline = foldSpline(current, tangentRef.current, [target])
+    const distance = Math.hypot(target.x - current.x, target.y - current.y)
+    const duration = animationDurationForDistance(distance)
     let startedAt = 0
 
     const tick = (now: number) => {
       if (startedAt === 0) startedAt = now
-      const progress = Math.min(1, (now - startedAt) / PRODUCTION_CURSOR_MOTION.durationMs)
+      const progress = duration <= 0 ? 1 : Math.min(1, (now - startedAt) / duration)
       const sample = spline.sampleT(easeAt(PRODUCTION_CURSOR_MOTION.easing, progress))
       pointRef.current = sample.position
       tangentRef.current = sample.tangent

--- a/src/shared/presence-timing.ts
+++ b/src/shared/presence-timing.ts
@@ -38,3 +38,8 @@ export const PRESENCE_THINKING_DELAY_MS = 3_000
  *  Prevents stale intents from affecting unrelated CDP commands. */
 export const PRESENCE_INTENT_TTL_MS = 2_000
 
+/** Duration of the rAF-driven scroll ramp. Scroll is intercepted in the
+ *  preload and animated with an ease curve instead of applying the full
+ *  delta instantly, so the page motion reads as continuous like the cursor. */
+export const PRESENCE_SCROLL_ANIMATION_MS = 300
+


### PR DESCRIPTION
## Summary

- Skip redundant mousePressed reposition when CDP point is already inside the cursor's targetRect or within 30px canvas — prevents clicks landing mid-animation.
- Budget the pre-click dwell from the cursor's last actual reposition (`lastMoveAt`), not intent arrival — restores the full travel+dwell window when cold-start/scrollIntoView eat the head-start.
- Scale cursor animation duration by hop distance (min 60ms, cap at travel ms) so short corrections don't eat the dwell budget.
- Simplification pass: reuse `framePointMatchesTargetRect`, collapse skip branch into conditional spread, cache `Date.now()`.

## Test plan

- [ ] Agent-driven click lands on the dwelled cursor (no mid-animation click)
- [ ] Cold-start click still shows full travel + dwell
- [ ] Short-hop corrections animate briefly instead of restarting full 250ms
- [ ] `pnpm typecheck`
- [ ] `pnpm test:unit`
- [ ] `pnpm test:smoke`