### PR TITLE
Add modifier key support for multi-select operations

### DIFF
--- a/src/main/ipc/register-canvas-ipc.ts
+++ b/src/main/ipc/register-canvas-ipc.ts
@@ -1,7 +1,8 @@
 import { ipcMain } from 'electron'
 import { DRAWING_FEATURE_ENABLED } from '../../shared/featureFlags'
-import type { CanvasEntityKind } from '../../shared/types'
+import type { CanvasEntityKind, SelectionModifiers } from '../../shared/types'
 import type { EdgeSide } from '../../shared/types'
+import { selectionMutationMode } from '../../shared/selection-modifiers'
 import { pages } from '../runtime/page-runtime'
 import { aboveView } from '../runtime/view-refs'
 import { setCommentOverlayActive } from '../runtime/runtime-core'
@@ -57,7 +58,12 @@ import {
 import { createEdges, deleteEdges } from '../workspace-edges'
 import { selectEntitiesInRect } from '../workspace-entities'
 import { createFileEntity } from '../runtime/document-commands'
-import { enterGroup, selectGroup, selectNone } from '../runtime/selection-controller'
+import {
+  applyEntitySelectionMutation,
+  enterGroup,
+  selectGroup,
+  selectNone,
+} from '../runtime/selection-controller'
 import { consumeDragId } from '../runtime/drop-owner'
 import { registerCanvasDragIpc } from './register-canvas-drag-ipc'
 import { registerCanvasEntityIpc } from './register-canvas-entity-ipc'
@@ -70,8 +76,18 @@ export function registerCanvasIpc(): void {
 
   ipcMain.on(
     'canvas-select-in-rect',
-    (_event, bounds: { x: number; y: number; width: number; height: number }) => {
-      selectEntitiesInRect(bounds)
+    (
+      _event,
+      payload: {
+        x: number
+        y: number
+        width: number
+        height: number
+        modifiers?: SelectionModifiers
+      },
+    ) => {
+      const { modifiers, ...bounds } = payload
+      selectEntitiesInRect(bounds, { mode: selectionMutationMode(modifiers) })
     },
   )
 
@@ -82,33 +98,69 @@ export function registerCanvasIpc(): void {
     }
   })
 
-  ipcMain.on('canvas-select-frame', (_event, { frameId }: { frameId: string }) => {
-    if (interactionBlocksPageSelection()) return
-    const idx = pages.findIndex((candidate) => candidate.id === frameId)
-    if (idx === -1) return
-    selectPage(idx)
-  })
+  ipcMain.on(
+    'canvas-select-frame',
+    (
+      _event,
+      { frameId, modifiers }: { frameId: string; modifiers?: SelectionModifiers },
+    ) => {
+      if (interactionBlocksPageSelection()) return
+      if (!pages.some((candidate) => candidate.id === frameId)) return
+      const mode = selectionMutationMode(modifiers)
+      if (mode === 'replace') {
+        const idx = pages.findIndex((candidate) => candidate.id === frameId)
+        if (idx !== -1) selectPage(idx)
+        return
+      }
+      applyEntitySelectionMutation([frameId], mode)
+    },
+  )
 
-  ipcMain.on('canvas-click-at', (_event, { screenX, screenY }: { screenX: number; screenY: number }) => {
-    if (interactionBlocksPageSelection()) return
-    const origin = canvasOrigin()
-    const canvasX = (screenX - origin.x - pan.x) / zoom
-    const canvasY = (screenY - origin.y - pan.y) / zoom
-    // Use a 1x1 rect at the click point for hit-testing.
-    // Drawings are hit-tested in the renderer (SVG stroke hit-paths), not by bbox here.
-    selectEntitiesInRect(
-      { x: canvasX, y: canvasY, width: 1, height: 1 },
-      { includeDrawings: false },
-    )
-  })
+  ipcMain.on(
+    'canvas-click-at',
+    (
+      _event,
+      {
+        screenX,
+        screenY,
+        modifiers,
+      }: { screenX: number; screenY: number; modifiers?: SelectionModifiers },
+    ) => {
+      if (interactionBlocksPageSelection()) return
+      const origin = canvasOrigin()
+      const canvasX = (screenX - origin.x - pan.x) / zoom
+      const canvasY = (screenY - origin.y - pan.y) / zoom
+      // Use a 1x1 rect at the click point for hit-testing.
+      // Drawings are hit-tested in the renderer (SVG stroke hit-paths), not by bbox here.
+      selectEntitiesInRect(
+        { x: canvasX, y: canvasY, width: 1, height: 1 },
+        { includeDrawings: false, mode: selectionMutationMode(modifiers) },
+      )
+    },
+  )
 
-  ipcMain.on('canvas-select-in-screen-rect', (_event, rect: { x: number; y: number; width: number; height: number }) => {
-    if (interactionBlocksPageSelection()) return
-    const origin = canvasOrigin()
-    const canvasX = (rect.x - origin.x - pan.x) / zoom
-    const canvasY = (rect.y - origin.y - pan.y) / zoom
-    selectEntitiesInRect({ x: canvasX, y: canvasY, width: rect.width / zoom, height: rect.height / zoom })
-  })
+  ipcMain.on(
+    'canvas-select-in-screen-rect',
+    (
+      _event,
+      rect: {
+        x: number
+        y: number
+        width: number
+        height: number
+        modifiers?: SelectionModifiers
+      },
+    ) => {
+      if (interactionBlocksPageSelection()) return
+      const origin = canvasOrigin()
+      const canvasX = (rect.x - origin.x - pan.x) / zoom
+      const canvasY = (rect.y - origin.y - pan.y) / zoom
+      selectEntitiesInRect(
+        { x: canvasX, y: canvasY, width: rect.width / zoom, height: rect.height / zoom },
+        { mode: selectionMutationMode(rect.modifiers) },
+      )
+    },
+  )
 
   ipcMain.on('canvas-select-entities', (_event, entityIds: string[]) => {
     setSelectedEntities(entityIds)
@@ -121,10 +173,22 @@ export function registerCanvasIpc(): void {
 
   ipcMain.on(
     'canvas-select-entity',
-    (_event, { entityId, entityKind }: { entityId: string; entityKind: string }) => {
+    (
+      _event,
+      {
+        entityId,
+        entityKind,
+        modifiers,
+      }: { entityId: string; entityKind: string; modifiers?: SelectionModifiers },
+    ) => {
       if (!VALID_ENTITY_KINDS.has(entityKind as CanvasEntityKind)) return
       if (entityKind === 'frame' && interactionBlocksPageSelection()) return
-      selectEntity(entityId, entityKind)
+      const mode = selectionMutationMode(modifiers)
+      if (mode === 'replace') {
+        selectEntity(entityId, entityKind)
+        return
+      }
+      applyEntitySelectionMutation([entityId], mode)
     },
   )
 

--- a/src/main/ipc/register-page-chrome-ipc.ts
+++ b/src/main/ipc/register-page-chrome-ipc.ts
@@ -1,6 +1,10 @@
 import { ipcMain } from 'electron'
 import { VIEWPORT_PRESETS } from '../../shared/constants'
-import type { ScrollSyncData } from '../../shared/types'
+import type { ScrollSyncData, SelectionModifiers } from '../../shared/types'
+import {
+  isAdditiveSelection,
+  selectionMutationMode,
+} from '../../shared/selection-modifiers'
 import {
   canvasOrigin,
   bgView,
@@ -49,7 +53,10 @@ import {
 } from '../navigation-sync'
 import { deleteFrames, selectEntitiesInRect } from '../workspace-entities'
 import { duplicateFrameFromSource } from '../workspace-frames'
-import { selectedDragEntityIds } from '../runtime/selection-controller'
+import {
+  applyEntitySelectionMutation,
+  selectedDragEntityIds,
+} from '../runtime/selection-controller'
 import { aboveView } from '../runtime/view-refs'
 import { setCommentOverlayActive } from '../runtime/runtime-core'
 import { setSelectionOverlayRect } from '../runtime/window-shell'
@@ -66,20 +73,39 @@ function resolveDraggedEntityIds(entityId: string): string[] {
 }
 
 export function registerPageChromeIpc(): void {
-  ipcMain.on('page-select', (event) => {
-    if (interactionBlocksPageSelection()) {
-      selectionDebug('ipc:page-select:suppressed', { senderId: event.sender.id })
-      return
-    }
-    const idx = pages.findIndex((page) => page.pageView.webContents === event.sender)
-    selectionDebug('ipc:page-select', { idx, senderId: event.sender.id })
-    if (idx !== -1) selectPage(idx)
-  })
+  ipcMain.on(
+    'page-select',
+    (event, payload?: { modifiers?: SelectionModifiers }) => {
+      if (interactionBlocksPageSelection()) {
+        selectionDebug('ipc:page-select:suppressed', { senderId: event.sender.id })
+        return
+      }
+      const page = pages.find((candidate) => candidate.pageView.webContents === event.sender)
+      if (!page) return
+      const mode = selectionMutationMode(payload?.modifiers)
+      selectionDebug('ipc:page-select', { pageId: page.id, senderId: event.sender.id, mode })
+      if (mode === 'replace') {
+        const idx = pages.indexOf(page)
+        if (idx !== -1) selectPage(idx)
+        return
+      }
+      applyEntitySelectionMutation([page.id], mode)
+    },
+  )
 
-  ipcMain.on('page-deselect', () => {
-    selectionDebug('ipc:page-deselect')
-    deselectAll()
-  })
+  ipcMain.on(
+    'page-deselect',
+    (_event, payload?: { modifiers?: SelectionModifiers }) => {
+      // Additive modifiers (shift/meta/ctrl) preserve the existing selection
+      // so clicking on empty space with a modifier held does not wipe it.
+      if (isAdditiveSelection(payload?.modifiers)) {
+        selectionDebug('ipc:page-deselect:suppressed-additive')
+        return
+      }
+      selectionDebug('ipc:page-deselect')
+      deselectAll()
+    },
+  )
 
   ipcMain.on('frame-hover', (event, hovered: boolean) => {
     if (interactionBlocksPageHover()) return
@@ -88,15 +114,25 @@ export function registerPageChromeIpc(): void {
     setHoverEntity(hovered && page ? { id: page.id, kind: 'frame' } : null)
   })
 
-  ipcMain.on('chrome-select', (event) => {
-    if (interactionBlocksPageSelection()) {
-      selectionDebug('ipc:chrome-select:suppressed', { senderId: event.sender.id })
-      return
-    }
-    const idx = pages.findIndex((page) => page.chromeView.webContents === event.sender)
-    selectionDebug('ipc:chrome-select', { idx, senderId: event.sender.id })
-    if (idx !== -1) selectPage(idx)
-  })
+  ipcMain.on(
+    'chrome-select',
+    (event, payload?: { modifiers?: SelectionModifiers }) => {
+      if (interactionBlocksPageSelection()) {
+        selectionDebug('ipc:chrome-select:suppressed', { senderId: event.sender.id })
+        return
+      }
+      const page = pages.find((candidate) => candidate.chromeView.webContents === event.sender)
+      if (!page) return
+      const mode = selectionMutationMode(payload?.modifiers)
+      selectionDebug('ipc:chrome-select', { pageId: page.id, senderId: event.sender.id, mode })
+      if (mode === 'replace') {
+        const idx = pages.indexOf(page)
+        if (idx !== -1) selectPage(idx)
+        return
+      }
+      applyEntitySelectionMutation([page.id], mode)
+    },
+  )
 
   ipcMain.on('chrome-navigate', (event, url: string) => {
     const page = findPageBySender(event.sender)
@@ -225,7 +261,13 @@ export function registerPageChromeIpc(): void {
     'page-marquee-select-commit',
     (
       event,
-      rect: { screenX: number; screenY: number; width: number; height: number },
+      rect: {
+        screenX: number
+        screenY: number
+        width: number
+        height: number
+        modifiers?: SelectionModifiers
+      },
     ) => {
       const page = findPageByPageView(event.sender)
       if (!page || !win) return
@@ -239,12 +281,15 @@ export function registerPageChromeIpc(): void {
       const origin = canvasOrigin()
       const clientX = rect.screenX - contentBounds.x
       const clientY = rect.screenY - contentBounds.y
-      selectEntitiesInRect({
-        x: (clientX - origin.x - pan.x) / zoom,
-        y: (clientY - origin.y - pan.y) / zoom,
-        width: rect.width / zoom,
-        height: rect.height / zoom,
-      })
+      selectEntitiesInRect(
+        {
+          x: (clientX - origin.x - pan.x) / zoom,
+          y: (clientY - origin.y - pan.y) / zoom,
+          width: rect.width / zoom,
+          height: rect.height / zoom,
+        },
+        { mode: selectionMutationMode(rect.modifiers) },
+      )
     },
   )
 

--- a/src/main/runtime/selection-controller.ts
+++ b/src/main/runtime/selection-controller.ts
@@ -1,4 +1,5 @@
 import type { CanvasEntityKind, UiState } from '../../shared/types'
+import type { SelectionMutationMode } from '../../shared/selection-modifiers'
 import {
   devtoolsPanelTab as uiDevtoolsPanelTab,
   getUiState,
@@ -247,6 +248,32 @@ export function enterGroup(
   ]
   if (!childIds.length) return false
   return selectEntities(childIds, { clearInteraction: true, ...options })
+}
+
+export function applyEntitySelectionMutation(
+  targetIds: string[],
+  mode: SelectionMutationMode,
+  options?: CommitOptions,
+): boolean {
+  if (mode === 'replace') return selectEntities(targetIds, options)
+
+  const current = uiSelectedEntityIds()
+  const currentSet = new Set(current)
+  const targetSet = new Set(targetIds)
+
+  let nextIds: string[]
+  if (mode === 'add') {
+    nextIds = [...new Set([...current, ...targetIds])]
+  } else if (mode === 'remove') {
+    nextIds = current.filter((id) => !targetSet.has(id))
+  } else {
+    // toggle: XOR — entities already selected are dropped, new ones are added
+    const kept = current.filter((id) => !targetSet.has(id))
+    const added = targetIds.filter((id) => !currentSet.has(id))
+    nextIds = [...kept, ...added]
+  }
+
+  return selectEntities(nextIds, options)
 }
 
 export function selectedDragEntityIds(entityId: string): string[] {

--- a/src/main/workspace-entities.ts
+++ b/src/main/workspace-entities.ts
@@ -6,6 +6,8 @@ import type {
   WorkspaceGraph,
   WorkspaceSelection,
 } from '../shared/types'
+import type { SelectionMutationMode } from '../shared/selection-modifiers'
+import { applyEntitySelectionMutation } from './runtime/selection-controller'
 import {
   findPageById,
   pages,
@@ -254,9 +256,13 @@ export function deleteFrames(input: DeleteFramesRequest): DeleteFramesResponse {
 
 export function selectEntitiesInRect(
   bounds: WorkspaceBounds,
-  options: { includeDrawings?: boolean } = {},
+  options: {
+    includeDrawings?: boolean
+    mode?: SelectionMutationMode
+  } = {},
 ): { entityIds: string[] } {
   const includeDrawings = options.includeDrawings ?? true
+  const mode = options.mode ?? 'replace'
   const frameIds = pages
     .filter((page) => boundsOverlap(frameSelectableBounds(page), bounds))
     .map((page) => page.id)
@@ -301,6 +307,14 @@ export function selectEntitiesInRect(
     .map((de) => de.id)
 
   const entityIds = [...frameIds, ...textIds, ...fileIds, ...drawingIds]
+
+  if (mode !== 'replace') {
+    // Additive / toggle / remove modes: preserve existing selection outside the rect
+    // and merge rect hits according to the mode. An empty rect with an additive
+    // mode is a no-op, which matches OS-level shift-click conventions.
+    applyEntitySelectionMutation(entityIds, mode)
+    return { entityIds }
+  }
 
   if (!entityIds.length) {
     deselectAll()

--- a/src/preload/canvas-bg.ts
+++ b/src/preload/canvas-bg.ts
@@ -71,13 +71,16 @@ const api: CanvasBgElectronAPI = {
     ipcRenderer.on('canvas-selection-overlay', handler)
     return () => ipcRenderer.removeListener('canvas-selection-overlay', handler)
   },
-  canvasSelectInRect: (rect) => ipcRenderer.send('canvas-select-in-rect', rect),
-  canvasSelectInScreenRect: (rect) => ipcRenderer.send('canvas-select-in-screen-rect', rect),
-  canvasDeselect: () => ipcRenderer.send('page-deselect'),
-  canvasClickAt: (screenX: number, screenY: number) =>
-    ipcRenderer.send('canvas-click-at', { screenX, screenY }),
+  canvasSelectInRect: (rect, modifiers) =>
+    ipcRenderer.send('canvas-select-in-rect', { ...rect, modifiers }),
+  canvasSelectInScreenRect: (rect, modifiers) =>
+    ipcRenderer.send('canvas-select-in-screen-rect', { ...rect, modifiers }),
+  canvasDeselect: (modifiers) => ipcRenderer.send('page-deselect', { modifiers }),
+  canvasClickAt: (screenX, screenY, modifiers) =>
+    ipcRenderer.send('canvas-click-at', { screenX, screenY, modifiers }),
   clearAnnotateHover: () => ipcRenderer.send('canvas-clear-annotate-hover'),
-  selectFrame: (frameId) => ipcRenderer.send('canvas-select-frame', { frameId }),
+  selectFrame: (frameId, modifiers) =>
+    ipcRenderer.send('canvas-select-frame', { frameId, modifiers }),
   selectBrowserTab: (frameId) => ipcRenderer.send('canvas-select-browser-tab', { frameId }),
   addBrowserFrame: (presetIndex) => ipcRenderer.send('add-browser-frame', presetIndex),
   navigateFrame: (frameId, url) => ipcRenderer.send('canvas-navigate-frame', { frameId, url }),
@@ -143,8 +146,8 @@ const api: CanvasBgElectronAPI = {
     ipcRenderer.send('canvas-rename-drawing-entity', { entityId, name }),
   dropFileBuffer: (buffer: Uint8Array, ext: string, canvasX: number, canvasY: number) =>
     ipcRenderer.send('canvas-drop-file-buffer', { buffer: Buffer.from(buffer), ext, canvasX, canvasY }),
-  selectEntity: (entityId: string, entityKind: string) =>
-    ipcRenderer.send('canvas-select-entity', { entityId, entityKind }),
+  selectEntity: (entityId, entityKind, modifiers) =>
+    ipcRenderer.send('canvas-select-entity', { entityId, entityKind, modifiers }),
   selectGroup: (groupId: string) =>
     ipcRenderer.send('canvas-select-group', { groupId }),
   enterGroup: (groupId: string) =>

--- a/src/preload/page-content.ts
+++ b/src/preload/page-content.ts
@@ -321,7 +321,13 @@ function injectBlockingOverlay(): void {
         if (dragStarted) {
           ipcRenderer.send('page-group-drag-end')
         } else {
-          ipcRenderer.send('page-select')
+          ipcRenderer.send('page-select', {
+            modifiers: {
+              shift: e.shiftKey,
+              meta: e.metaKey,
+              ctrl: e.ctrlKey,
+            },
+          })
         }
       }
 

--- a/src/preload/page-content.ts
+++ b/src/preload/page-content.ts
@@ -206,6 +206,40 @@ window.addEventListener(
   { passive: false, capture: true }
 )
 
+// Additive-selection intercept.
+//
+// When a frame is singly selected, `interactive` is true and the blocking
+// overlay is removed — clicks on the body land inside the webpage. Without
+// this capturing listener, there is no way to shift-click the frame body
+// to toggle its selection. Routing the mousedown to main as a page-select
+// with modifiers keeps OS-level additive selection working regardless of
+// the interactive / overlay state.
+window.addEventListener(
+  'mousedown',
+  (e: MouseEvent) => {
+    if (e.button !== 0) return
+    if (!e.shiftKey && !e.metaKey && !e.ctrlKey) return
+    if (annotationMode === 'region_select') return
+    if (annotateEnabled) return
+    if (isDomInspectionEnabled()) return
+    selectionDebug('additive-click-intercept', {
+      shift: e.shiftKey,
+      meta: e.metaKey,
+      ctrl: e.ctrlKey,
+    })
+    e.preventDefault()
+    e.stopImmediatePropagation()
+    ipcRenderer.send('page-select', {
+      modifiers: {
+        shift: e.shiftKey,
+        meta: e.metaKey,
+        ctrl: e.ctrlKey,
+      },
+    })
+  },
+  { capture: true },
+)
+
 // --- Selection overlay ---
 // When the page is not interactive (unselected), inject an overlay that blocks
 // all pointer events and forwards wheel/click to canvas operations.

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -244,16 +244,22 @@ export default function App({
   )
 
   const onMarqueeEnd = useCallback(
-    (startX: number, startY: number, endX: number, endY: number) => {
+    (
+      startX: number,
+      startY: number,
+      endX: number,
+      endY: number,
+      modifiers?: import('../../shared/types').SelectionModifiers,
+    ) => {
       const layout = layoutRef.current
       const rect = normalizeRect(startX, startY, endX, endY)
       api.setSelectionOverlayRect(null)
       if (rect.width < 4 || rect.height < 4) {
-        api.canvasDeselect()
+        api.canvasDeselect(modifiers)
         return
       }
       const windowRect = { ...rect, top: rect.top + layout.canvasOrigin.y }
-      api.canvasSelectInRect(screenRectToCanvasRect(windowRect, layout))
+      api.canvasSelectInRect(screenRectToCanvasRect(windowRect, layout), modifiers)
     },
     [api, layoutRef],
   )
@@ -343,6 +349,15 @@ export default function App({
 
   const onFramePointerDown = useCallback(
     (frameId: string, event: MouseEvent) => {
+      const isAdditive = event.shiftKey || event.metaKey || event.ctrlKey
+      if (isAdditive) {
+        api.selectFrame(frameId, {
+          shift: event.shiftKey,
+          meta: event.metaKey,
+          ctrl: event.ctrlKey,
+        })
+        return
+      }
       api.selectFrame(frameId)
       api.startDragFrame(frameId)
       let lastScreenX = event.screenX

--- a/src/renderer/canvas-bg/App.tsx
+++ b/src/renderer/canvas-bg/App.tsx
@@ -317,6 +317,15 @@ export default function App({
             onResizeMulti={(entries) => api.resizeMultiSelection(entries)}
             onDrawingMouseDown={(id, event) => {
               event.stopPropagation()
+              const isAdditive = event.shiftKey || event.metaKey || event.ctrlKey
+              if (isAdditive) {
+                api.selectEntity(id, 'drawing', {
+                  shift: event.shiftKey,
+                  meta: event.metaKey,
+                  ctrl: event.ctrlKey,
+                })
+                return
+              }
               api.selectEntity(id, 'drawing')
               api.startDragEntity(id)
               let lastX = event.screenX
@@ -372,7 +381,7 @@ export default function App({
             onDragEnd={api.endDragEntity}
             onDragStart={api.startDragEntity}
             onResize={(id, patch) => api.updateTextEntity(id, patch)}
-            onSelect={(id) => api.selectEntity(id, 'text')}
+            onSelect={(id, modifiers) => api.selectEntity(id, 'text', modifiers)}
             onTextEditingChange={api.setTextEditing}
             onUpdateText={(id, text) => api.updateTextEntity(id, { text })}
             selectedEntityCount={layoutData.selectedEntityIds.length}
@@ -396,7 +405,7 @@ export default function App({
             onDragEnd={api.endDragEntity}
             onDragStart={api.startDragEntity}
             onResize={(id, patch) => api.updateFileEntity(id, patch)}
-            onSelect={(id) => api.selectEntity(id, 'file')}
+            onSelect={(id, modifiers) => api.selectEntity(id, 'file', modifiers)}
             onTextEditingChange={api.setTextEditing}
             selectedEntityCount={layoutData.selectedEntityIds.length}
             selectedEntityIdSet={selectedEntityIdSet}

--- a/src/renderer/canvas-bg/FileBlockLayer.tsx
+++ b/src/renderer/canvas-bg/FileBlockLayer.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import Markdown from 'react-markdown'
 import { ContextMenu } from '@base-ui/react/context-menu'
 import { Menu } from '@base-ui/react/menu'
-import type { CanvasSceneFileEntity } from '../../shared/types'
+import type { CanvasSceneFileEntity, SelectionModifiers } from '../../shared/types'
 import { SelectableEntityShell } from './SelectableEntityShell'
 import { aspectRatioResizeModeForCanvasFile, type EntityResizePatch, IMAGE_EXTENSIONS, VIDEO_EXTENSIONS, MARKDOWN_EXTENSIONS, WIREFRAME_EXTENSIONS } from './entityConstants'
 import { MIN_FILE_WIDTH, MIN_FILE_HEIGHT } from './entityConstants'
@@ -37,7 +37,7 @@ function FileBlockCard({
   isMarqueePreview: boolean
   canEdit: boolean
   wireframeJsonMode: boolean
-  onSelect: (id: string) => void
+  onSelect: (id: string, modifiers?: SelectionModifiers) => void
   onResize: (id: string, patch: EntityResizePatch) => void
   onTextEditingChange: (active: boolean) => void
   onDragStart: (id: string) => void
@@ -386,7 +386,7 @@ export function FileBlockLayer({
   selectedEntityIdSet: Set<string>
   selectedEntityCount: number
   jsonModeMap: FileJsonModeMap
-  onSelect: (id: string) => void
+  onSelect: (id: string, modifiers?: SelectionModifiers) => void
   onResize: (id: string, patch: EntityResizePatch) => void
   onTextEditingChange: (active: boolean) => void
   onDragStart: (id: string) => void

--- a/src/renderer/canvas-bg/SelectableEntityShell.tsx
+++ b/src/renderer/canvas-bg/SelectableEntityShell.tsx
@@ -4,6 +4,7 @@ import { useCornerResize, useEdgeResize } from './useEntityResize'
 import { CornerResizeHandle, EdgeResizeHandle } from './ResizeHandles'
 import { useDragGesture } from '../shared/useDragGesture'
 import type { AspectRatioResizeMode, EntityResizePatch } from './entityConstants'
+import type { SelectionModifiers } from '../../shared/types'
 
 // --- Selectable Entity Shell (shared wrapper for text blocks, file blocks, etc.) ---
 
@@ -49,7 +50,7 @@ export function SelectableEntityShell({
   background: string
   borderRadius?: number
   showCardShadow?: boolean
-  onSelect: (id: string) => void
+  onSelect: (id: string, modifiers?: SelectionModifiers) => void
   onResize: (id: string, patch: EntityResizePatch) => void
   onDragStart: (id: string) => void
   onDrag: (id: string, dx: number, dy: number) => void
@@ -75,7 +76,13 @@ export function SelectableEntityShell({
       if (shouldStartDrag && !shouldStartDrag(event)) return false
       return true
     },
-    onBegin: () => {
+    onBegin: (ctx) => {
+      const { shift, meta, ctrl } = ctx.modifiers
+      if (shift || meta || ctrl) {
+        // Additive click: toggle this entity's selection without starting a drag.
+        onSelect(id, { shift, meta, ctrl })
+        return null
+      }
       if (!isSelectedRef.current) onSelect(id)
       onDragStart(id)
       return { lastDx: 0, lastDy: 0 }

--- a/src/renderer/canvas-bg/TextBlockLayer.tsx
+++ b/src/renderer/canvas-bg/TextBlockLayer.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useRef, useState } from 'react'
 import Markdown from 'react-markdown'
-import type { CanvasSceneTextEntity } from '../../shared/types'
+import type { CanvasSceneTextEntity, SelectionModifiers } from '../../shared/types'
 import { resolveCanvasColor } from '../../shared/canvas-colors'
 import { SelectableEntityShell } from './SelectableEntityShell'
 import type { EntityResizePatch } from './entityConstants'
@@ -27,7 +27,7 @@ function TextBlockCard({
   isSelected: boolean
   isMarqueePreview: boolean
   canEdit: boolean
-  onSelect: (id: string) => void
+  onSelect: (id: string, modifiers?: SelectionModifiers) => void
   onUpdateText: (id: string, text: string) => void
   onResize: (id: string, patch: EntityResizePatch) => void
   onTextEditingChange: (active: boolean) => void
@@ -182,7 +182,7 @@ export function TextBlockLayer({
   marqueePreviewIds: Set<string> | null
   selectedEntityIdSet: Set<string>
   selectedEntityCount: number
-  onSelect: (id: string) => void
+  onSelect: (id: string, modifiers?: SelectionModifiers) => void
   onUpdateText: (id: string, text: string) => void
   onResize: (id: string, patch: EntityResizePatch) => void
   onTextEditingChange: (active: boolean) => void

--- a/src/renderer/canvas-bg/useCanvasViewportGestures.ts
+++ b/src/renderer/canvas-bg/useCanvasViewportGestures.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react'
 import type { RefObject } from 'react'
-import type { CanvasBgElectronAPI, LayoutUpdateData } from '../../shared/types'
+import type { CanvasBgElectronAPI, LayoutUpdateData, SelectionModifiers } from '../../shared/types'
 import {
   classifyViewportWheel,
   isOverlayUiTarget,
@@ -12,6 +12,10 @@ import {
 } from '../../shared/gesture-utils'
 import { useDragGesture } from '../shared/useDragGesture'
 import { toOverlayRect } from './canvasGeometry'
+
+function toSelectionModifiers(mods: { shift: boolean; meta: boolean; ctrl: boolean }): SelectionModifiers {
+  return { shift: mods.shift, meta: mods.meta, ctrl: mods.ctrl }
+}
 
 /**
  * Canvas-bg viewport gestures.
@@ -144,10 +148,11 @@ export function useCanvasViewportGestures({
         return
       }
       // marquee
+      const modifiers = toSelectionModifiers(ctx.modifiers)
       if (rect.width < 4 || rect.height < 4) {
-        if (layout.viewMode === 'canvas') api.canvasDeselect()
+        if (layout.viewMode === 'canvas') api.canvasDeselect(modifiers)
       } else {
-        api.canvasSelectInRect(screenRectToCanvasRect(rect, layout))
+        api.canvasSelectInRect(screenRectToCanvasRect(rect, layout), modifiers)
       }
       stopDragging()
     },

--- a/src/renderer/canvas-bg/useFrameChromeDrag.ts
+++ b/src/renderer/canvas-bg/useFrameChromeDrag.ts
@@ -123,6 +123,18 @@ export function useFrameChromeDrag({
       }
 
       const layout = layoutRef.current
+      const isAdditive = event.shiftKey || event.metaKey || event.ctrlKey
+      if (isAdditive) {
+        // Toggle this frame in/out of the selection. A shift/meta-click is a
+        // pure selection gesture — do not start a drag.
+        api.selectFrame(frameId, {
+          shift: event.shiftKey,
+          meta: event.metaKey,
+          ctrl: event.ctrlKey,
+        })
+        event.preventDefault()
+        return
+      }
       if (!layout.selectedEntityIds.includes(frameId)) {
         api.selectFrame(frameId)
       }

--- a/src/renderer/shared/hooks/useViewportForwarding.ts
+++ b/src/renderer/shared/hooks/useViewportForwarding.ts
@@ -5,17 +5,38 @@ import {
   middleDragDelta,
   shouldStartMouseViewportPan,
 } from '../../../shared/gesture-utils'
+import type { SelectionModifiers } from '../../../shared/types'
+
+function selectionModifiersFromEvent(event: MouseEvent): SelectionModifiers {
+  return { shift: event.shiftKey, meta: event.metaKey, ctrl: event.ctrlKey }
+}
 
 interface ViewportForwardingApi {
   canvasZoom: (deltaY: number, mouseX: number, mouseY: number) => void
   canvasPan: (deltaX: number, deltaY: number) => void
-  canvasDeselect?: () => void
-  canvasClickAt?: (screenX: number, screenY: number) => void
+  canvasDeselect?: (modifiers?: SelectionModifiers) => void
+  canvasClickAt?: (
+    screenX: number,
+    screenY: number,
+    modifiers?: SelectionModifiers,
+  ) => void
   /** Optional left-drag forwarding. When provided, left-button drags are
    *  forwarded through these callbacks instead of immediately firing
    *  canvasClickAt on mousedown. */
-  onDragMove?: (startClientX: number, startClientY: number, clientX: number, clientY: number) => void
-  onDragEnd?: (startClientX: number, startClientY: number, clientX: number, clientY: number) => void
+  onDragMove?: (
+    startClientX: number,
+    startClientY: number,
+    clientX: number,
+    clientY: number,
+    modifiers?: SelectionModifiers,
+  ) => void
+  onDragEnd?: (
+    startClientX: number,
+    startClientY: number,
+    clientX: number,
+    clientY: number,
+    modifiers?: SelectionModifiers,
+  ) => void
   /** Optional renderer-side hit test: given client coords, return a frame id
    *  if a frame body/chrome was clicked, else null. When provided together
    *  with onFramePointerDown, left-button clicks on a frame bypass click/drag
@@ -88,9 +109,9 @@ export function useViewportForwarding(
           }
           event.preventDefault()
         } else if (api.canvasClickAt) {
-          api.canvasClickAt(event.clientX, event.clientY)
+          api.canvasClickAt(event.clientX, event.clientY, selectionModifiersFromEvent(event))
         } else if (api.canvasDeselect) {
-          api.canvasDeselect()
+          api.canvasDeselect(selectionModifiersFromEvent(event))
         }
       }
     }
@@ -112,7 +133,13 @@ export function useViewportForwarding(
           return
         }
         leftDrag.dragging = true
-        api.onDragMove(leftDrag.startClientX, leftDrag.startClientY, event.clientX, event.clientY)
+        api.onDragMove(
+          leftDrag.startClientX,
+          leftDrag.startClientY,
+          event.clientX,
+          event.clientY,
+          selectionModifiersFromEvent(event),
+        )
       }
     }
 
@@ -123,13 +150,20 @@ export function useViewportForwarding(
 
       if (leftDrag && event.button === 0) {
         if (leftDrag.dragging && api.onDragEnd) {
-          api.onDragEnd(leftDrag.startClientX, leftDrag.startClientY, event.clientX, event.clientY)
+          api.onDragEnd(
+            leftDrag.startClientX,
+            leftDrag.startClientY,
+            event.clientX,
+            event.clientY,
+            selectionModifiersFromEvent(event),
+          )
         } else {
           // Was a click, not a drag
+          const modifiers = selectionModifiersFromEvent(event)
           if (api.canvasClickAt) {
-            api.canvasClickAt(event.clientX, event.clientY)
+            api.canvasClickAt(event.clientX, event.clientY, modifiers)
           } else if (api.canvasDeselect) {
-            api.canvasDeselect()
+            api.canvasDeselect(modifiers)
           }
         }
         leftDrag = null

--- a/src/shared/selection-modifiers.ts
+++ b/src/shared/selection-modifiers.ts
@@ -1,0 +1,26 @@
+import type { SelectionModifiers } from './types'
+
+export type SelectionMutationMode = 'replace' | 'add' | 'remove' | 'toggle'
+
+export function modifiersFromEvent(event: {
+  shiftKey?: boolean
+  metaKey?: boolean
+  ctrlKey?: boolean
+}): SelectionModifiers {
+  return {
+    shift: Boolean(event.shiftKey),
+    meta: Boolean(event.metaKey),
+    ctrl: Boolean(event.ctrlKey),
+  }
+}
+
+export function isAdditiveSelection(modifiers: SelectionModifiers | null | undefined): boolean {
+  if (!modifiers) return false
+  return modifiers.shift || modifiers.meta || modifiers.ctrl
+}
+
+export function selectionMutationMode(
+  modifiers: SelectionModifiers | null | undefined,
+): SelectionMutationMode {
+  return isAdditiveSelection(modifiers) ? 'toggle' : 'replace'
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -46,6 +46,12 @@ export type CanvasSelectableTarget = CanvasEntityRef
 
 export type CanvasHoverTarget = CanvasSelectableTarget | null
 
+export type SelectionModifiers = {
+  shift: boolean
+  meta: boolean
+  ctrl: boolean
+}
+
 export type CanvasInteractionState =
   | { kind: 'idle' }
   | {
@@ -1371,12 +1377,16 @@ export interface CanvasBgElectronAPI {
   setSelectionOverlayRect: (
     overlay: SelectionOverlayPayload | null,
   ) => void
-  canvasSelectInRect: (rect: WorkspaceBounds) => void
-  canvasSelectInScreenRect: (rect: WorkspaceBounds) => void
-  canvasDeselect: () => void
-  canvasClickAt: (screenX: number, screenY: number) => void
+  canvasSelectInRect: (rect: WorkspaceBounds, modifiers?: SelectionModifiers) => void
+  canvasSelectInScreenRect: (rect: WorkspaceBounds, modifiers?: SelectionModifiers) => void
+  canvasDeselect: (modifiers?: SelectionModifiers) => void
+  canvasClickAt: (
+    screenX: number,
+    screenY: number,
+    modifiers?: SelectionModifiers,
+  ) => void
   clearAnnotateHover: () => void
-  selectFrame: (frameId: string) => void
+  selectFrame: (frameId: string, modifiers?: SelectionModifiers) => void
   selectBrowserTab: (frameId: string) => void
   addBrowserFrame: (presetIndex: number | 'custom') => void
   navigateFrame: (frameId: string, url: string) => void
@@ -1422,7 +1432,11 @@ export interface CanvasBgElectronAPI {
   renameTextEntity: (entityId: string, name: string) => void
   renameDrawingEntity: (entityId: string, name: string) => void
   dropFileBuffer: (buffer: Uint8Array, ext: string, canvasX: number, canvasY: number) => void
-  selectEntity: (entityId: string, entityKind: CanvasEntityKind) => void
+  selectEntity: (
+    entityId: string,
+    entityKind: CanvasEntityKind,
+    modifiers?: SelectionModifiers,
+  ) => void
   selectGroup: (groupId: string) => void
   enterGroup: (groupId: string) => void
   startDragGroup: (groupId: string) => void

--- a/tests/unit/selection-modifiers.test.ts
+++ b/tests/unit/selection-modifiers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isAdditiveSelection,
+  modifiersFromEvent,
+  selectionMutationMode,
+} from '../../src/shared/selection-modifiers'
+
+describe('selection-modifiers', () => {
+  describe('modifiersFromEvent', () => {
+    it('reads shift/meta/ctrl flags from a MouseEvent-like object', () => {
+      expect(modifiersFromEvent({ shiftKey: true, metaKey: false, ctrlKey: false })).toEqual({
+        shift: true,
+        meta: false,
+        ctrl: false,
+      })
+      expect(modifiersFromEvent({ shiftKey: false, metaKey: true, ctrlKey: false })).toEqual({
+        shift: false,
+        meta: true,
+        ctrl: false,
+      })
+    })
+
+    it('coerces undefined flags to false', () => {
+      expect(modifiersFromEvent({})).toEqual({ shift: false, meta: false, ctrl: false })
+    })
+  })
+
+  describe('isAdditiveSelection', () => {
+    it('returns false for null, undefined, or all-off modifiers', () => {
+      expect(isAdditiveSelection(null)).toBe(false)
+      expect(isAdditiveSelection(undefined)).toBe(false)
+      expect(isAdditiveSelection({ shift: false, meta: false, ctrl: false })).toBe(false)
+    })
+
+    it('returns true when any of shift/meta/ctrl is held', () => {
+      expect(isAdditiveSelection({ shift: true, meta: false, ctrl: false })).toBe(true)
+      expect(isAdditiveSelection({ shift: false, meta: true, ctrl: false })).toBe(true)
+      expect(isAdditiveSelection({ shift: false, meta: false, ctrl: true })).toBe(true)
+    })
+  })
+
+  describe('selectionMutationMode', () => {
+    it('maps no modifier to replace', () => {
+      expect(selectionMutationMode(null)).toBe('replace')
+      expect(selectionMutationMode({ shift: false, meta: false, ctrl: false })).toBe('replace')
+    })
+
+    it('maps additive modifier to toggle', () => {
+      expect(selectionMutationMode({ shift: true, meta: false, ctrl: false })).toBe('toggle')
+      expect(selectionMutationMode({ shift: false, meta: true, ctrl: false })).toBe('toggle')
+      expect(selectionMutationMode({ shift: false, meta: false, ctrl: true })).toBe('toggle')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
This PR adds support for keyboard modifiers (Shift, Ctrl/Cmd, Meta) during selection operations, enabling multi-select functionality across the canvas and page chrome. Selection behavior now respects standard OS conventions: holding modifiers allows toggling entities in/out of the selection, while clicking without modifiers replaces the selection.

## Key Changes

- **New selection modifier infrastructure**: Created `src/shared/selection-modifiers.ts` with utilities to:
  - Extract modifier flags from mouse events (`modifiersFromEvent`)
  - Determine selection mode from modifiers (`selectionMutationMode`)
  - Check for additive selection (`isAdditiveSelection`)

- **Selection mutation modes**: Introduced `SelectionMutationMode` type supporting:
  - `'replace'`: Clear existing selection and select only targets (default, no modifiers)
  - `'toggle'`: Add new targets or remove already-selected targets (with modifiers)
  - `'add'` and `'remove'`: Explicit modes for future use

- **IPC layer updates**: Modified all selection-related IPC handlers to accept and forward `SelectionModifiers`:
  - `canvas-select-in-rect`, `canvas-select-in-screen-rect`, `canvas-click-at`
  - `canvas-select-frame`, `canvas-select-entity`
  - `page-select`, `page-deselect`, `chrome-select`
  - `page-marquee-select-commit`

- **Selection controller enhancement**: Added `applyEntitySelectionMutation()` function to handle multi-select logic:
  - Merges/toggles entities based on the mutation mode
  - Preserves existing selection outside the operation scope

- **Renderer integration**: Updated viewport gesture handling and entity selection callbacks to:
  - Capture modifier keys from mouse events
  - Pass modifiers through the API layer
  - Handle additive selection for frames and entities (preventing drag when modifiers held)

- **Workspace entities**: Extended `selectEntitiesInRect()` to support mutation modes for marquee selection

- **Type definitions**: Added `SelectionModifiers` type to shared types for consistent typing across IPC boundaries

## Notable Implementation Details

- Modifier detection is consistent across all input paths (viewport gestures, entity clicks, frame chrome interactions)
- Empty rect selections with additive modifiers are no-ops, matching OS conventions
- Frame selection with modifiers uses `applyEntitySelectionMutation` rather than `selectPage` to preserve multi-select state
- Comprehensive unit tests added for modifier utility functions

https://claude.ai/code/session_015FRaqcuG2cwtBWHDgsQDE8