### PR TITLE
[codex] Fix selected group drag and resize

### DIFF
--- a/src/main/runtime/layout-engine.ts
+++ b/src/main/runtime/layout-engine.ts
@@ -45,6 +45,7 @@ import {
   selectedCanvasTargets,
 } from '../ui-state'
 import { drawingEntities } from './drawing-entity-state'
+import { descendantEntityIdsForGroup } from './group-descendants'
 import {
   devtoolsOpen as uiDevtoolsOpen,
   devtoolsPanelTab as uiDevtoolsPanelTab,
@@ -265,9 +266,14 @@ export function layoutAllViews(): void {
   if (aboveView && win) {
     const { width, height } = win.getBounds()
     const selectedTargets = selectedCanvasTargets()
+    const selectedGroupOwnsFrameContent =
+      selectedTargets.length === 1 &&
+      selectedTargets[0]?.kind === 'group' &&
+      pages.some((page) => descendantEntityIdsForGroup(selectedTargets[0].id).includes(page.id))
     const selectionOwnsFrameContent =
-      selectedTargets.length > 1 &&
-      selectedTargets.some((target) => target.kind === 'frame')
+      (selectedTargets.length > 1 &&
+        selectedTargets.some((target) => target.kind === 'frame')) ||
+      selectedGroupOwnsFrameContent
     const shouldCover = shouldGateBeOpen({
       interactionKind: interactionState.kind === 'idle' ? 'idle'
         : interactionState.kind === 'panning-canvas' ? 'panning'

--- a/src/main/runtime/layout-engine.ts
+++ b/src/main/runtime/layout-engine.ts
@@ -266,10 +266,11 @@ export function layoutAllViews(): void {
   if (aboveView && win) {
     const { width, height } = win.getBounds()
     const selectedTargets = selectedCanvasTargets()
-    const selectedGroupOwnsFrameContent =
-      selectedTargets.length === 1 &&
-      selectedTargets[0]?.kind === 'group' &&
-      pages.some((page) => descendantEntityIdsForGroup(selectedTargets[0].id).includes(page.id))
+    let selectedGroupOwnsFrameContent = false
+    if (selectedTargets.length === 1 && selectedTargets[0]?.kind === 'group') {
+      const groupDescendantIds = new Set(descendantEntityIdsForGroup(selectedTargets[0].id))
+      selectedGroupOwnsFrameContent = pages.some((page) => groupDescendantIds.has(page.id))
+    }
     const selectionOwnsFrameContent =
       (selectedTargets.length > 1 &&
         selectedTargets.some((target) => target.kind === 'frame')) ||

--- a/src/main/runtime/selection-controller.ts
+++ b/src/main/runtime/selection-controller.ts
@@ -282,12 +282,14 @@ export function selectedDragEntityIds(entityId: string): string[] {
   if (selectedIds.length > 1 && selectedIds.includes(entityId)) {
     return selectedIds
   }
+
   const activeGroupId = uiSelectedGroupId()
   if (activeGroupId) {
     const descendantIds = descendantEntityIdsForGroup(activeGroupId)
-    if (descendantIds.includes(entityId)) {
-      return descendantIds
+    if (entityId === activeGroupId || descendantIds.includes(entityId)) {
+      return [activeGroupId, ...descendantIds]
     }
   }
+
   return [entityId]
 }

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -15,9 +15,16 @@ import {
   snapToGrid,
 } from '../../shared/gesture-utils'
 import { TOOLBAR_HEIGHT } from '../../shared/constants'
-import { DRAW_CURSOR } from '../canvas-bg/canvasBgConstants'
+import { DRAW_CURSOR, selectionColor } from '../canvas-bg/canvasBgConstants'
 import { PlacementPreviewLayer } from '../canvas-bg/CanvasGridSurface'
 import { buildPendingPlacementPreview } from '../canvas-bg/canvasBgSelectors'
+import { MIN_GROUP_HEIGHT, MIN_GROUP_WIDTH } from '../canvas-bg/entityConstants'
+import {
+  descendantIdsForGroup,
+  selectedGroupHasDescendantFrame,
+  selectedGroupDragTargetId,
+} from '../canvas-bg/groupMembership'
+import { SelectionResizeGrid } from '../canvas-bg/SelectionResizeGrid'
 import { DrawingLayer, SavedDrawingEntities } from './DrawingsLayer'
 import { RegionSelectAnnotations } from './AnnotationsLayer'
 import {
@@ -36,6 +43,53 @@ import { useTheme } from '../shared/hooks/useTheme'
 import { useViewportForwarding } from '../shared/hooks/useViewportForwarding'
 
 const api = (window as unknown as { electronAPI: CanvasBgElectronAPI }).electronAPI
+const GROUP_DRAG_THRESHOLD = 4
+
+function SelectedGroupResizeOverlay({
+  isDark,
+  layoutData,
+}: {
+  isDark: boolean
+  layoutData: LayoutUpdateData
+}) {
+  const selectedGroupId = layoutData.selectedGroupId ?? null
+  if (!selectedGroupId) return null
+  if (!selectedGroupHasDescendantFrame(layoutData)) return null
+
+  const group = (layoutData.groups ?? []).find((candidate) => candidate.id === selectedGroupId)
+  if (!group) return null
+
+  const zoom = group.width > 0 ? group.screenWidth / group.width : 1
+
+  return (
+    <div
+      className="absolute border-2"
+      data-overlay-ui
+      style={{
+        left: group.screenX,
+        top: group.screenY - layoutData.canvasOrigin.y,
+        width: group.screenWidth,
+        height: group.screenHeight,
+        borderColor: selectionColor(isDark),
+        borderRadius: 2,
+        pointerEvents: 'none',
+      }}
+    >
+      <SelectionResizeGrid
+        id={group.id}
+        width={group.width}
+        height={group.height}
+        canvasX={group.canvasX}
+        canvasY={group.canvasY}
+        zoom={zoom}
+        minWidth={MIN_GROUP_WIDTH}
+        minHeight={MIN_GROUP_HEIGHT}
+        onResize={(id, patch) => api.updateGroupEntity(id, patch)}
+        isDark={isDark}
+      />
+    </div>
+  )
+}
 
 export default function App({
   initialLayoutData,
@@ -311,8 +365,46 @@ export default function App({
     [hitTestSceneEntity, layoutRef],
   )
 
+  const hitTestSelectedGroupEntity = useCallback(
+    (clientX: number, clientY: number): CanvasSelectableTarget | null => {
+      const layout = layoutRef.current
+      const selectedGroupId = layout.selectedGroupId ?? null
+      if (!selectedGroupId) return null
+
+      const group = (layout.groups ?? []).find((candidate) => candidate.id === selectedGroupId)
+      if (!group) return null
+
+      const descendantIds = descendantIdsForGroup(layout.groups ?? [], selectedGroupId)
+      const descendant = hitTestSceneEntity(clientX, clientY, (candidate) => {
+        if (candidate.kind === 'group') return false
+        return descendantIds.has(candidate.id)
+      })
+      if (descendant) return { id: descendant.id, kind: descendant.kind }
+
+      const windowY = clientY + layout.canvasOrigin.y
+      const insideBounds =
+        clientX >= group.screenX &&
+        clientX <= group.screenX + group.screenWidth &&
+        windowY >= group.screenY &&
+        windowY <= group.screenY + group.screenHeight
+      const insideHeader =
+        clientX >= group.screenX &&
+        clientX <= group.screenX + Math.max(group.screenWidth, 160) &&
+        windowY >= group.screenY - 24 &&
+        windowY <= group.screenY
+
+      return insideBounds || insideHeader
+        ? { id: group.id, kind: 'group' }
+        : null
+    },
+    [hitTestSceneEntity, layoutRef],
+  )
+
   const hitTestPointerEntity = useCallback(
     (clientX: number, clientY: number): CanvasSelectableTarget | null => {
+      const selectedGroupTarget = hitTestSelectedGroupEntity(clientX, clientY)
+      if (selectedGroupTarget) return selectedGroupTarget
+
       const preservedSelectionTarget = hitTestSelectionEntity(clientX, clientY)
       if (preservedSelectionTarget) return preservedSelectionTarget
 
@@ -323,7 +415,7 @@ export default function App({
       )
       return frame ? { id: frame.id, kind: 'frame' } : null
     },
-    [hitTestSceneEntity, hitTestSelectionEntity],
+    [hitTestSceneEntity, hitTestSelectedGroupEntity, hitTestSelectionEntity],
   )
 
   const hitTestHoverTarget = useCallback(
@@ -396,6 +488,74 @@ export default function App({
       }
 
       const layout = layoutRef.current
+      const selectedGroupTargetId = selectedGroupDragTargetId(layout, target.id)
+      if (selectedGroupTargetId) {
+        let dragging = false
+        let lastScreenX = event.screenX
+        let lastScreenY = event.screenY
+        const startScreenX = event.screenX
+        const startScreenY = event.screenY
+
+        const selectClickTarget = () => {
+          if (target.kind === 'group') {
+            api.selectGroup(target.id)
+          } else if (target.kind === 'frame') {
+            api.selectFrame(target.id)
+          } else {
+            api.selectEntity(target.id, target.kind)
+          }
+        }
+
+        const onMove = (ev: MouseEvent) => {
+          const totalDx = ev.screenX - startScreenX
+          const totalDy = ev.screenY - startScreenY
+          if (
+            !dragging &&
+            Math.abs(totalDx) < GROUP_DRAG_THRESHOLD &&
+            Math.abs(totalDy) < GROUP_DRAG_THRESHOLD
+          ) {
+            return
+          }
+
+          if (!dragging) {
+            dragging = true
+            api.startDragGroup(selectedGroupTargetId)
+          }
+
+          const dx = ev.screenX - lastScreenX
+          const dy = ev.screenY - lastScreenY
+          lastScreenX = ev.screenX
+          lastScreenY = ev.screenY
+          if (dx !== 0 || dy !== 0) api.dragGroup(selectedGroupTargetId, dx, dy)
+        }
+
+        const cleanup = () => {
+          window.removeEventListener('mousemove', onMove)
+          window.removeEventListener('mouseup', onUp)
+          window.removeEventListener('blur', onCancel)
+        }
+
+        const onUp = () => {
+          cleanup()
+          if (dragging) {
+            api.endDragGroup()
+            return
+          }
+          selectClickTarget()
+        }
+
+        const onCancel = () => {
+          cleanup()
+          if (dragging) api.endDragGroup()
+        }
+
+        event.preventDefault()
+        window.addEventListener('mousemove', onMove)
+        window.addEventListener('mouseup', onUp)
+        window.addEventListener('blur', onCancel)
+        return
+      }
+
       const preserveSelection = layout.selectedEntityIds.includes(target.id)
 
       if (!preserveSelection) {
@@ -621,6 +781,8 @@ export default function App({
           />
 
           <MarqueeLayer overlay={selectionOverlay} />
+
+          <SelectedGroupResizeOverlay isDark={isDark} layoutData={layoutData} />
 
           <FloatingUiLayer api={api} isDark={isDark} layoutData={layoutData} />
         </>

--- a/src/renderer/canvas-bg/App.tsx
+++ b/src/renderer/canvas-bg/App.tsx
@@ -32,7 +32,7 @@ import { useCanvasLayoutState } from './useCanvasLayoutState'
 import { usePendingPlacementState } from './usePendingPlacementState'
 import { useCanvasViewportGestures } from './useCanvasViewportGestures'
 import { useFrameChromeDrag } from './useFrameChromeDrag'
-import { useGroupBoundsDrag } from './useGroupBoundsDrag'
+import { descendantIdsForGroup, selectedGroupHasDescendantFrame } from './groupMembership'
 
 const api = (window as unknown as { electronAPI: CanvasBgElectronAPI }).electronAPI
 const GROUP_MENU_DELAY_MS = 150
@@ -85,7 +85,6 @@ export default function App({
 
   const handleSelectEdge = useCallback((edgeId: string | null) => api.selectEdge(edgeId), [api])
   const handleHoverEntity = useCallback((entityId: string | null) => api.hoverFrame(entityId), [api])
-  const handleGroupBoundsPointerDown = useGroupBoundsDrag(api)
 
   const frameEntities = useMemo(
     () => layoutData.entities.filter((e): e is CanvasSceneFrameEntity => e.kind === 'frame'),
@@ -117,6 +116,14 @@ export default function App({
     if (!layoutData.selectedGroupId) return null
     return (layoutData.groups ?? []).find((group) => group.id === layoutData.selectedGroupId) ?? null
   }, [layoutData.groups, layoutData.selectedGroupId])
+  const selectedGroupDescendantIds = useMemo(() => {
+    if (!layoutData.selectedGroupId) return new Set<string>()
+    return descendantIdsForGroup(layoutData.groups ?? [], layoutData.selectedGroupId)
+  }, [layoutData.groups, layoutData.selectedGroupId])
+  const selectedGroupControlsMirroredToAboveView = useMemo(
+    () => selectedGroupHasDescendantFrame(layoutData),
+    [layoutData],
+  )
   const [delayedSelectedGroupMenuId, setDelayedSelectedGroupMenuId] = useState<string | null>(null)
   const shouldQueueSelectedGroupMenu =
     layoutData.viewMode === 'canvas' &&
@@ -181,8 +188,10 @@ export default function App({
             isDark={isDark}
             selectedGroupId={layoutData.selectedGroupId ?? null}
             zoom={layoutData.zoom}
-            onResize={(id, patch) => api.updateGroupEntity(id, patch)}
-            onPointerDown={handleGroupBoundsPointerDown}
+            onSelectGroup={api.selectGroup}
+            onStartDragGroup={api.startDragGroup}
+            onDragGroup={api.dragGroup}
+            onEndDragGroup={api.endDragGroup}
             onDoubleClick={(groupId) => {
               api.enterGroup(groupId)
             }}
@@ -229,7 +238,11 @@ export default function App({
             groups={layoutData.groups ?? []}
             isDark={isDark}
             selectedGroupId={layoutData.selectedGroupId ?? null}
+            suppressOverlay={selectedGroupControlsMirroredToAboveView}
             onResizeGroup={(id, patch) => api.updateGroupEntity(id, patch)}
+            onStartDragGroup={api.startDragGroup}
+            onDragGroup={api.dragGroup}
+            onEndDragGroup={api.endDragGroup}
           />
         ) : null}
 
@@ -380,12 +393,17 @@ export default function App({
             onDrag={api.dragEntity}
             onDragEnd={api.endDragEntity}
             onDragStart={api.startDragEntity}
+            onGroupDrag={api.dragGroup}
+            onGroupDragEnd={api.endDragGroup}
+            onGroupDragStart={api.startDragGroup}
             onResize={(id, patch) => api.updateTextEntity(id, patch)}
             onSelect={(id, modifiers) => api.selectEntity(id, 'text', modifiers)}
             onTextEditingChange={api.setTextEditing}
             onUpdateText={(id, text) => api.updateTextEntity(id, { text })}
             selectedEntityCount={layoutData.selectedEntityIds.length}
             selectedEntityIdSet={selectedEntityIdSet}
+            selectedGroupDescendantIds={selectedGroupDescendantIds}
+            selectedGroupId={layoutData.selectedGroupId ?? null}
           />
         </CanvasEntityViewportLayer>
       ) : null}
@@ -404,11 +422,16 @@ export default function App({
             onDrag={api.dragEntity}
             onDragEnd={api.endDragEntity}
             onDragStart={api.startDragEntity}
+            onGroupDrag={api.dragGroup}
+            onGroupDragEnd={api.endDragGroup}
+            onGroupDragStart={api.startDragGroup}
             onResize={(id, patch) => api.updateFileEntity(id, patch)}
             onSelect={(id, modifiers) => api.selectEntity(id, 'file', modifiers)}
             onTextEditingChange={api.setTextEditing}
             selectedEntityCount={layoutData.selectedEntityIds.length}
             selectedEntityIdSet={selectedEntityIdSet}
+            selectedGroupDescendantIds={selectedGroupDescendantIds}
+            selectedGroupId={layoutData.selectedGroupId ?? null}
             jsonModeMap={fileJsonModeMap}
           />
         </CanvasEntityViewportLayer>

--- a/src/renderer/canvas-bg/App.tsx
+++ b/src/renderer/canvas-bg/App.tsx
@@ -120,10 +120,7 @@ export default function App({
     if (!layoutData.selectedGroupId) return new Set<string>()
     return descendantIdsForGroup(layoutData.groups ?? [], layoutData.selectedGroupId)
   }, [layoutData.groups, layoutData.selectedGroupId])
-  const selectedGroupControlsMirroredToAboveView = useMemo(
-    () => selectedGroupHasDescendantFrame(layoutData),
-    [layoutData],
-  )
+  const selectedGroupControlsMirroredToAboveView = selectedGroupHasDescendantFrame(layoutData)
   const [delayedSelectedGroupMenuId, setDelayedSelectedGroupMenuId] = useState<string | null>(null)
   const shouldQueueSelectedGroupMenu =
     layoutData.viewMode === 'canvas' &&

--- a/src/renderer/canvas-bg/CanvasSelectionLayers.tsx
+++ b/src/renderer/canvas-bg/CanvasSelectionLayers.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react'
+import { useContext, useMemo, useRef } from 'react'
 import type {
   CanvasSceneDrawingEntity,
   CanvasSceneFileEntity,
@@ -22,6 +22,7 @@ import { CornerResizeHandle, EdgeResizeHandle } from './ResizeHandles'
 import { SelectionResizeGrid } from './SelectionResizeGrid'
 import { useMultiCornerResize, useMultiEdgeResize } from './useMultiSelectionResize'
 import type { MultiResizeEntity } from './useMultiSelectionResize'
+import { useGroupDragGesture } from './useGroupBoundsDrag'
 
 // Re-export for consumers that imported from this file
 export type { EntityResizePatch } from './entityConstants'
@@ -81,15 +82,31 @@ function GroupSelectionOverlay({
   group,
   isDark,
   onResize,
+  onStartDragGroup,
+  onDragGroup,
+  onEndDragGroup,
 }: {
   group: CanvasSceneGroupEntity
   isDark: boolean
   onResize: (id: string, patch: EntityResizePatch) => void
+  onStartDragGroup: (groupId: string) => void
+  onDragGroup: (groupId: string, dx: number, dy: number) => void
+  onEndDragGroup: () => void
 }) {
+  const ref = useRef<HTMLDivElement>(null)
   const zoom = group.width > 0 ? group.screenWidth / group.width : 1
+  useGroupDragGesture({
+    target: ref,
+    groupId: group.id,
+    selectOnBegin: false,
+    onStartDragGroup,
+    onDragGroup,
+    onEndDragGroup,
+  })
 
   return (
     <div
+      ref={ref}
       className="absolute border-2"
       style={{
         left: group.screenX,
@@ -404,16 +421,34 @@ export function GroupSelectionOverlayLayer({
   groups,
   isDark,
   selectedGroupId,
+  suppressOverlay = false,
   onResizeGroup,
+  onStartDragGroup,
+  onDragGroup,
+  onEndDragGroup,
 }: {
   groups: CanvasSceneGroupEntity[]
   isDark: boolean
   selectedGroupId: string | null
+  suppressOverlay?: boolean
   onResizeGroup: (id: string, patch: EntityResizePatch) => void
+  onStartDragGroup: (groupId: string) => void
+  onDragGroup: (groupId: string, dx: number, dy: number) => void
+  onEndDragGroup: () => void
 }) {
+  if (suppressOverlay) return null
   if (!selectedGroupId) return null
   const group = groups.find((candidate) => candidate.id === selectedGroupId)
   if (!group) return null
 
-  return <GroupSelectionOverlay group={group} isDark={isDark} onResize={onResizeGroup} />
+  return (
+    <GroupSelectionOverlay
+      group={group}
+      isDark={isDark}
+      onResize={onResizeGroup}
+      onStartDragGroup={onStartDragGroup}
+      onDragGroup={onDragGroup}
+      onEndDragGroup={onEndDragGroup}
+    />
+  )
 }

--- a/src/renderer/canvas-bg/FileBlockLayer.tsx
+++ b/src/renderer/canvas-bg/FileBlockLayer.tsx
@@ -29,6 +29,10 @@ function FileBlockCard({
   onDragStart,
   onDrag,
   onDragEnd,
+  selectedGroupDragTargetId,
+  onGroupDragStart,
+  onGroupDrag,
+  onGroupDragEnd,
 }: {
   entity: CanvasSceneFileEntity
   getZoom: () => number
@@ -43,6 +47,10 @@ function FileBlockCard({
   onDragStart: (id: string) => void
   onDrag: (id: string, dx: number, dy: number) => void
   onDragEnd: () => void
+  selectedGroupDragTargetId?: string | null
+  onGroupDragStart: (groupId: string) => void
+  onGroupDrag: (groupId: string, dx: number, dy: number) => void
+  onGroupDragEnd: () => void
 }) {
   const isImage = IMAGE_EXTENSIONS.test(entity.file)
   const isVideo = VIDEO_EXTENSIONS.test(entity.file)
@@ -174,6 +182,10 @@ function FileBlockCard({
       onDragStart={onDragStart}
       onDrag={onDrag}
       onDragEnd={onDragEnd}
+      selectedGroupDragTargetId={selectedGroupDragTargetId}
+      onGroupDragStart={onGroupDragStart}
+      onGroupDrag={onGroupDrag}
+      onGroupDragEnd={onGroupDragEnd}
       showResizeHandles={false}
       aspectRatioResizeMode={aspectRatioResizeModeForCanvasFile(entity.file)}
       shouldStartDrag={(event) => {
@@ -357,7 +369,8 @@ const MemoFileBlockCard = memo(FileBlockCard, (prev, next) => {
     prev.isSelected === next.isSelected &&
     prev.isMarqueePreview === next.isMarqueePreview &&
     prev.canEdit === next.canEdit &&
-    prev.wireframeJsonMode === next.wireframeJsonMode
+    prev.wireframeJsonMode === next.wireframeJsonMode &&
+    prev.selectedGroupDragTargetId === next.selectedGroupDragTargetId
   )
 })
 
@@ -371,6 +384,8 @@ export function FileBlockLayer({
   marqueePreviewIds,
   selectedEntityIdSet,
   selectedEntityCount,
+  selectedGroupId,
+  selectedGroupDescendantIds,
   jsonModeMap,
   onSelect,
   onResize,
@@ -378,6 +393,9 @@ export function FileBlockLayer({
   onDragStart,
   onDrag,
   onDragEnd,
+  onGroupDragStart,
+  onGroupDrag,
+  onGroupDragEnd,
 }: {
   entities: CanvasSceneFileEntity[]
   getZoom: () => number
@@ -385,6 +403,8 @@ export function FileBlockLayer({
   marqueePreviewIds: Set<string> | null
   selectedEntityIdSet: Set<string>
   selectedEntityCount: number
+  selectedGroupId: string | null
+  selectedGroupDescendantIds: Set<string>
   jsonModeMap: FileJsonModeMap
   onSelect: (id: string, modifiers?: SelectionModifiers) => void
   onResize: (id: string, patch: EntityResizePatch) => void
@@ -392,6 +412,9 @@ export function FileBlockLayer({
   onDragStart: (id: string) => void
   onDrag: (id: string, dx: number, dy: number) => void
   onDragEnd: () => void
+  onGroupDragStart: (groupId: string) => void
+  onGroupDrag: (groupId: string, dx: number, dy: number) => void
+  onGroupDragEnd: () => void
 }) {
   if (!entities.length) return null
   return (
@@ -406,9 +429,17 @@ export function FileBlockLayer({
           canEdit={selectedEntityIdSet.has(entity.id) && selectedEntityCount === 1}
           wireframeJsonMode={jsonModeMap.get(entity.id) ?? false}
           entity={entity}
+          selectedGroupDragTargetId={
+            selectedGroupId && selectedGroupDescendantIds.has(entity.id)
+              ? selectedGroupId
+              : null
+          }
           onDrag={onDrag}
           onDragEnd={onDragEnd}
           onDragStart={onDragStart}
+          onGroupDrag={onGroupDrag}
+          onGroupDragEnd={onGroupDragEnd}
+          onGroupDragStart={onGroupDragStart}
           onResize={onResize}
           onSelect={onSelect}
           onTextEditingChange={onTextEditingChange}

--- a/src/renderer/canvas-bg/GroupBoundsLayer.tsx
+++ b/src/renderer/canvas-bg/GroupBoundsLayer.tsx
@@ -1,15 +1,21 @@
-import { memo, useState } from 'react'
+import { memo, useRef, useState } from 'react'
 import { FolderOpen } from 'lucide-react'
 import type { CanvasSceneGroupEntity } from '../../shared/types'
 import { resolveCanvasColor } from '../../shared/canvas-colors'
-import { SelectableEntityShell } from './SelectableEntityShell'
 import { InlineEditLabel } from '../shared/InlineEditLabel'
-import type { EntityResizePatch } from './entityConstants'
+import { selectionColor } from './canvasBgConstants'
+import { useGroupDragGesture } from './useGroupBoundsDrag'
 
-function groupSurfaceStyle(group: CanvasSceneGroupEntity, isDark: boolean) {
+function groupSurfaceStyle(
+  group: CanvasSceneGroupEntity,
+  isDark: boolean,
+  highlighted: boolean,
+) {
   if (!group.color) {
     return {
-      borderColor: isDark ? 'rgba(161,161,170,0.25)' : 'rgba(113,113,122,0.25)',
+      borderColor: highlighted
+        ? selectionColor(isDark)
+        : isDark ? 'rgba(161,161,170,0.25)' : 'rgba(113,113,122,0.25)',
       background: isDark ? 'rgba(39,39,42,0.35)' : 'rgba(244,244,245,0.45)',
       labelColor: isDark ? 'text-zinc-300' : 'text-zinc-700',
       iconColor: 'text-zinc-500',
@@ -18,9 +24,11 @@ function groupSurfaceStyle(group: CanvasSceneGroupEntity, isDark: boolean) {
 
   const resolvedColor = resolveCanvasColor(group.color)
   return {
-    borderColor: isDark
-      ? `color-mix(in srgb, ${resolvedColor} 72%, #f4f4f5)`
-      : `color-mix(in srgb, ${resolvedColor} 78%, #a16207)`,
+    borderColor: highlighted
+      ? selectionColor(isDark)
+      : isDark
+        ? `color-mix(in srgb, ${resolvedColor} 72%, #f4f4f5)`
+        : `color-mix(in srgb, ${resolvedColor} 78%, #a16207)`,
     background: `color-mix(in srgb, ${resolvedColor} ${isDark ? '20%' : '30%'}, transparent)`,
     labelColor: isDark ? 'text-zinc-100' : 'text-zinc-900',
     iconColor: isDark ? 'text-zinc-300' : 'text-zinc-600',
@@ -32,8 +40,10 @@ export const GroupBoundsLayer = memo(function GroupBoundsLayer({
   isDark,
   selectedGroupId,
   zoom,
-  onResize,
-  onPointerDown,
+  onSelectGroup,
+  onStartDragGroup,
+  onDragGroup,
+  onEndDragGroup,
   onDoubleClick,
   onRenameGroup,
 }: {
@@ -41,8 +51,10 @@ export const GroupBoundsLayer = memo(function GroupBoundsLayer({
   isDark: boolean
   selectedGroupId: string | null
   zoom: number
-  onResize: (id: string, patch: EntityResizePatch) => void
-  onPointerDown: (groupId: string, e: React.PointerEvent) => void
+  onSelectGroup: (groupId: string) => void
+  onStartDragGroup: (groupId: string) => void
+  onDragGroup: (groupId: string, dx: number, dy: number) => void
+  onEndDragGroup: () => void
   onDoubleClick: (groupId: string) => void
   onRenameGroup: (groupId: string, name: string) => void
 }) {
@@ -58,9 +70,10 @@ export const GroupBoundsLayer = memo(function GroupBoundsLayer({
           isDark={isDark}
           isSelected={group.id === selectedGroupId}
           inverseScale={inverseScale}
-          zoom={zoom}
-          onResize={onResize}
-          onPointerDown={onPointerDown}
+          onSelectGroup={onSelectGroup}
+          onStartDragGroup={onStartDragGroup}
+          onDragGroup={onDragGroup}
+          onEndDragGroup={onEndDragGroup}
           onDoubleClick={onDoubleClick}
           onRenameGroup={onRenameGroup}
         />
@@ -74,9 +87,10 @@ function GroupBoundsItem({
   isDark,
   isSelected,
   inverseScale,
-  zoom,
-  onResize,
-  onPointerDown,
+  onSelectGroup,
+  onStartDragGroup,
+  onDragGroup,
+  onEndDragGroup,
   onDoubleClick,
   onRenameGroup,
 }: {
@@ -84,38 +98,46 @@ function GroupBoundsItem({
   isDark: boolean
   isSelected: boolean
   inverseScale: number
-  zoom: number
-  onResize: (id: string, patch: EntityResizePatch) => void
-  onPointerDown: (groupId: string, e: React.PointerEvent) => void
+  onSelectGroup: (groupId: string) => void
+  onStartDragGroup: (groupId: string) => void
+  onDragGroup: (groupId: string, dx: number, dy: number) => void
+  onEndDragGroup: () => void
   onDoubleClick: (groupId: string) => void
   onRenameGroup: (groupId: string, name: string) => void
 }) {
-  const surfaceStyle = groupSurfaceStyle(group, isDark)
+  const dragRef = useRef<HTMLDivElement>(null)
+  const [isHeaderHovered, setIsHeaderHovered] = useState(false)
   const [isRenaming, setIsRenaming] = useState(false)
+  const surfaceStyle = groupSurfaceStyle(group, isDark, isHeaderHovered)
+
+  useGroupDragGesture({
+    target: dragRef,
+    groupId: group.id,
+    enabled: !isRenaming,
+    selectOnPointerDown: true,
+    onSelectGroup,
+    onStartDragGroup,
+    onDragGroup,
+    onEndDragGroup,
+    filter: (event) => {
+      const target = event.target as HTMLElement | null
+      return Boolean(target?.closest('[data-group-drag-handle]'))
+    },
+  })
 
   return (
-    <SelectableEntityShell
-      id={group.id}
-      canvasX={group.canvasX}
-      canvasY={group.canvasY}
-      width={group.width}
-      height={group.height}
-      getZoom={() => zoom}
-      minWidth={120}
-      minHeight={80}
-      isDark={isDark}
-      isSelected={isSelected}
-      isMarqueePreview={false}
-      background="transparent"
-      borderRadius={2 * inverseScale}
-      overflowVisible
-      showResizeHandles={false}
-      onSelect={() => undefined}
-      onResize={onResize}
-      onDragStart={() => undefined}
-      onDrag={() => undefined}
-      onDragEnd={() => undefined}
-      shouldStartDrag={() => false}
+    <div
+      ref={dragRef}
+      className="absolute"
+      style={{
+        left: group.canvasX,
+        top: group.canvasY,
+        width: group.width,
+        height: group.height,
+        overflow: 'visible',
+        pointerEvents: 'none',
+        touchAction: 'none',
+      }}
     >
       <div
         className="absolute inset-0"
@@ -123,47 +145,54 @@ function GroupBoundsItem({
           borderRadius: 2 * inverseScale,
           border: `${1.5 * inverseScale}px solid ${surfaceStyle.borderColor}`,
           background: surfaceStyle.background,
+          transition: 'border-color 120ms ease',
         }}
-        onMouseDown={(event) => {
+        onDoubleClick={() => {
+          if (isSelected) onDoubleClick(group.id)
+        }}
+      />
+      <span
+        className={`absolute select-none text-[11px] font-medium ${surfaceStyle.labelColor}`}
+        data-group-drag-handle
+        style={{
+          top: -20 * inverseScale,
+          left: 0,
+          whiteSpace: 'nowrap',
+          cursor: isRenaming ? 'text' : 'grab',
+          pointerEvents: 'auto',
+          transformOrigin: 'top left',
+          transform: `scale(${inverseScale})`,
+        }}
+        onClick={(event) => {
+          if (isRenaming) return
           event.stopPropagation()
-          onPointerDown(group.id, event as unknown as React.PointerEvent)
+          onSelectGroup(group.id)
         }}
-        onDoubleClick={() => onDoubleClick(group.id)}
+        onMouseEnter={() => setIsHeaderHovered(true)}
+        onMouseLeave={() => setIsHeaderHovered(false)}
+        onMouseDown={isRenaming ? (event) => event.stopPropagation() : undefined}
       >
-        <span
-          className={`absolute select-none text-[11px] font-medium ${surfaceStyle.labelColor}`}
-          style={{
-            top: -20 * inverseScale,
-            left: 0,
-            whiteSpace: 'nowrap',
-            cursor: isRenaming ? 'text' : 'grab',
-            transformOrigin: 'top left',
-            transform: `scale(${inverseScale})`,
-          }}
-          onMouseDown={isRenaming ? (event) => event.stopPropagation() : undefined}
-        >
-          <span className="inline-flex items-center gap-1">
-            <FolderOpen
-              size={14}
-              className={`shrink-0 ${surfaceStyle.iconColor}`}
-            />
-            <InlineEditLabel
-              value={group.label}
-              isEditing={isRenaming}
-              onStartEdit={() => setIsRenaming(true)}
-              onCommit={(next) => {
-                setIsRenaming(false)
-                onRenameGroup(group.id, next)
-              }}
-              onCancel={() => setIsRenaming(false)}
-              variant="canvas-chrome"
-              isDark={isDark}
-              titleClassName="min-w-0 truncate"
-              inputClassName="min-w-[120px] border-0 bg-transparent text-[11px] font-medium outline-none focus:outline-none"
-            />
-          </span>
+        <span className="inline-flex items-center gap-1">
+          <FolderOpen
+            size={14}
+            className={`shrink-0 ${surfaceStyle.iconColor}`}
+          />
+          <InlineEditLabel
+            value={group.label}
+            isEditing={isRenaming}
+            onStartEdit={() => setIsRenaming(true)}
+            onCommit={(next) => {
+              setIsRenaming(false)
+              onRenameGroup(group.id, next)
+            }}
+            onCancel={() => setIsRenaming(false)}
+            variant="canvas-chrome"
+            isDark={isDark}
+            titleClassName="min-w-0 truncate"
+            inputClassName="min-w-[120px] border-0 bg-transparent text-[11px] font-medium outline-none focus:outline-none"
+          />
         </span>
-      </div>
-    </SelectableEntityShell>
+      </span>
+    </div>
   )
 }

--- a/src/renderer/canvas-bg/ResizeHandles.tsx
+++ b/src/renderer/canvas-bg/ResizeHandles.tsx
@@ -25,7 +25,7 @@ export function CornerResizeHandle({
 
   return (
     <div
-      data-resize-handle={scaleWithZoom || undefined}
+      data-resize-handle
       data-overlay-ui={scaleWithZoom ? undefined : true}
       onMouseDown={beginResize}
       style={{
@@ -38,6 +38,7 @@ export function CornerResizeHandle({
         border: `${borderWidth} solid ${selectionColor(isDark)}`,
         borderRadius: 0,
         cursor: CORNER_CURSORS[corner],
+        pointerEvents: 'auto',
         zIndex: 1,
       }}
     />
@@ -65,7 +66,7 @@ export function EdgeResizeHandle({
 
   return (
     <div
-      data-resize-handle={scaleWithZoom || undefined}
+      data-resize-handle
       data-overlay-ui={scaleWithZoom ? undefined : true}
       onMouseDown={beginResize}
       style={{
@@ -74,6 +75,7 @@ export function EdgeResizeHandle({
         width: isHorizontal ? undefined : size,
         height: isHorizontal ? size : undefined,
         cursor: EDGE_CURSORS[edge],
+        pointerEvents: 'auto',
         zIndex: 1,
       }}
     />

--- a/src/renderer/canvas-bg/SelectableEntityShell.tsx
+++ b/src/renderer/canvas-bg/SelectableEntityShell.tsx
@@ -9,6 +9,15 @@ import type { SelectionModifiers } from '../../shared/types'
 // --- Selectable Entity Shell (shared wrapper for text blocks, file blocks, etc.) ---
 
 type DragToken = { lastDx: number; lastDy: number }
+type DragTarget =
+  | { kind: 'entity'; id: string }
+  | { kind: 'group'; id: string }
+
+type EntityDragToken = DragToken & {
+  target: DragTarget
+}
+
+const GROUP_CHILD_DRAG_THRESHOLD_PX = 3
 
 export function SelectableEntityShell({
   id,
@@ -30,6 +39,10 @@ export function SelectableEntityShell({
   onDragStart,
   onDrag,
   onDragEnd,
+  selectedGroupDragTargetId = null,
+  onGroupDragStart,
+  onGroupDrag,
+  onGroupDragEnd,
   shouldStartDrag,
   overflowVisible = false,
   showResizeHandles = true,
@@ -55,6 +68,10 @@ export function SelectableEntityShell({
   onDragStart: (id: string) => void
   onDrag: (id: string, dx: number, dy: number) => void
   onDragEnd: () => void
+  selectedGroupDragTargetId?: string | null
+  onGroupDragStart?: (groupId: string) => void
+  onGroupDrag?: (groupId: string, dx: number, dy: number) => void
+  onGroupDragEnd?: () => void
   shouldStartDrag?: (e: PointerEvent) => boolean
   overflowVisible?: boolean
   showResizeHandles?: boolean
@@ -64,10 +81,20 @@ export function SelectableEntityShell({
   const setHoveredEntityId = useContext(EntityHoverSetterContext)
   const ref = useRef<HTMLDivElement>(null)
   const isSelectedRef = useRef(isSelected)
+  const selectedGroupDragTargetIdRef = useRef(selectedGroupDragTargetId)
+  const suppressNextGroupClickRef = useRef(false)
   isSelectedRef.current = isSelected
+  selectedGroupDragTargetIdRef.current = selectedGroupDragTargetId
 
-  useDragGesture<DragToken>({
+  const clearSuppressedGroupClick = () => {
+    window.setTimeout(() => {
+      suppressNextGroupClickRef.current = false
+    }, 0)
+  }
+
+  useDragGesture<EntityDragToken>({
     target: ref,
+    threshold: selectedGroupDragTargetId ? GROUP_CHILD_DRAG_THRESHOLD_PX : 0,
     stopPropagation: true,
     filter: (event) => {
       if (event.button !== 0) return false
@@ -83,19 +110,49 @@ export function SelectableEntityShell({
         onSelect(id, { shift, meta, ctrl })
         return null
       }
+      const groupDragTargetId = selectedGroupDragTargetIdRef.current
+      if (groupDragTargetId && onGroupDragStart && onGroupDrag && onGroupDragEnd) {
+        suppressNextGroupClickRef.current = true
+        onGroupDragStart(groupDragTargetId)
+        if (ctx.dx !== 0 || ctx.dy !== 0) onGroupDrag(groupDragTargetId, ctx.dx, ctx.dy)
+        return {
+          lastDx: ctx.dx,
+          lastDy: ctx.dy,
+          target: { kind: 'group', id: groupDragTargetId },
+        }
+      }
       if (!isSelectedRef.current) onSelect(id)
       onDragStart(id)
-      return { lastDx: 0, lastDy: 0 }
+      return { lastDx: 0, lastDy: 0, target: { kind: 'entity', id } }
     },
     onUpdate: (ctx, token) => {
       const dx = ctx.dx - token.lastDx
       const dy = ctx.dy - token.lastDy
       token.lastDx = ctx.dx
       token.lastDy = ctx.dy
-      if (dx !== 0 || dy !== 0) onDrag(id, dx, dy)
+      if (dx === 0 && dy === 0) return
+      if (token.target.kind === 'group') {
+        onGroupDrag?.(token.target.id, dx, dy)
+        return
+      }
+      onDrag(id, dx, dy)
     },
-    onCommit: () => onDragEnd(),
-    onCancel: () => onDragEnd(),
+    onCommit: (_ctx, token) => {
+      if (token.target.kind === 'group') {
+        onGroupDragEnd?.()
+        clearSuppressedGroupClick()
+        return
+      }
+      onDragEnd()
+    },
+    onCancel: (token) => {
+      if (token.target.kind === 'group') {
+        onGroupDragEnd?.()
+        clearSuppressedGroupClick()
+        return
+      }
+      onDragEnd()
+    },
   })
 
   const zoom = getZoom()
@@ -127,6 +184,24 @@ export function SelectableEntityShell({
       }}
       onMouseEnter={() => setHoveredEntityId(id)}
       onMouseLeave={() => setHoveredEntityId(null)}
+      onClick={(event) => {
+        const groupDragTargetId = selectedGroupDragTargetIdRef.current
+        if (!groupDragTargetId) return
+        if (suppressNextGroupClickRef.current) {
+          event.preventDefault()
+          event.stopPropagation()
+          suppressNextGroupClickRef.current = false
+          return
+        }
+        const target = event.target as HTMLElement | null
+        if (target?.closest('[data-resize-handle], button, input, textarea')) return
+        onSelect(id, {
+          shift: event.shiftKey,
+          meta: event.metaKey,
+          ctrl: event.ctrlKey,
+        })
+        event.stopPropagation()
+      }}
     >
       {children}
       {isSelected && showResizeHandles && (

--- a/src/renderer/canvas-bg/TextBlockLayer.tsx
+++ b/src/renderer/canvas-bg/TextBlockLayer.tsx
@@ -20,6 +20,10 @@ function TextBlockCard({
   onDragStart,
   onDrag,
   onDragEnd,
+  selectedGroupDragTargetId,
+  onGroupDragStart,
+  onGroupDrag,
+  onGroupDragEnd,
 }: {
   note: CanvasSceneTextEntity
   getZoom: () => number
@@ -34,6 +38,10 @@ function TextBlockCard({
   onDragStart: (id: string) => void
   onDrag: (id: string, dx: number, dy: number) => void
   onDragEnd: () => void
+  selectedGroupDragTargetId?: string | null
+  onGroupDragStart: (groupId: string) => void
+  onGroupDrag: (groupId: string, dx: number, dy: number) => void
+  onGroupDragEnd: () => void
 }) {
   const [localText, setLocalText] = useState(note.text)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -81,6 +89,10 @@ function TextBlockCard({
       onDragStart={onDragStart}
       onDrag={onDrag}
       onDragEnd={onDragEnd}
+      selectedGroupDragTargetId={selectedGroupDragTargetId}
+      onGroupDragStart={onGroupDragStart}
+      onGroupDrag={onGroupDrag}
+      onGroupDragEnd={onGroupDragEnd}
       showResizeHandles={false}
       shouldStartDrag={(event) => {
         if (canEdit) return false
@@ -157,7 +169,8 @@ const MemoTextBlockCard = memo(TextBlockCard, (prev, next) => {
     prev.isDark === next.isDark &&
     prev.isSelected === next.isSelected &&
     prev.isMarqueePreview === next.isMarqueePreview &&
-    prev.canEdit === next.canEdit
+    prev.canEdit === next.canEdit &&
+    prev.selectedGroupDragTargetId === next.selectedGroupDragTargetId
   )
 })
 
@@ -168,6 +181,8 @@ export function TextBlockLayer({
   marqueePreviewIds,
   selectedEntityIdSet,
   selectedEntityCount,
+  selectedGroupId,
+  selectedGroupDescendantIds,
   onSelect,
   onUpdateText,
   onResize,
@@ -175,6 +190,9 @@ export function TextBlockLayer({
   onDragStart,
   onDrag,
   onDragEnd,
+  onGroupDragStart,
+  onGroupDrag,
+  onGroupDragEnd,
 }: {
   entities: CanvasSceneTextEntity[]
   getZoom: () => number
@@ -182,6 +200,8 @@ export function TextBlockLayer({
   marqueePreviewIds: Set<string> | null
   selectedEntityIdSet: Set<string>
   selectedEntityCount: number
+  selectedGroupId: string | null
+  selectedGroupDescendantIds: Set<string>
   onSelect: (id: string, modifiers?: SelectionModifiers) => void
   onUpdateText: (id: string, text: string) => void
   onResize: (id: string, patch: EntityResizePatch) => void
@@ -189,6 +209,9 @@ export function TextBlockLayer({
   onDragStart: (id: string) => void
   onDrag: (id: string, dx: number, dy: number) => void
   onDragEnd: () => void
+  onGroupDragStart: (groupId: string) => void
+  onGroupDrag: (groupId: string, dx: number, dy: number) => void
+  onGroupDragEnd: () => void
 }) {
   if (!entities.length) return null
   return (
@@ -202,9 +225,17 @@ export function TextBlockLayer({
           isMarqueePreview={marqueePreviewIds?.has(note.id) ?? false}
           canEdit={selectedEntityCount === 1 && selectedEntityIdSet.has(note.id)}
           note={note}
+          selectedGroupDragTargetId={
+            selectedGroupId && selectedGroupDescendantIds.has(note.id)
+              ? selectedGroupId
+              : null
+          }
           onDrag={onDrag}
           onDragEnd={onDragEnd}
           onDragStart={onDragStart}
+          onGroupDrag={onGroupDrag}
+          onGroupDragEnd={onGroupDragEnd}
+          onGroupDragStart={onGroupDragStart}
           onResize={onResize}
           onSelect={onSelect}
           onTextEditingChange={onTextEditingChange}

--- a/src/renderer/canvas-bg/groupMembership.ts
+++ b/src/renderer/canvas-bg/groupMembership.ts
@@ -1,0 +1,45 @@
+import type { CanvasSceneGroupEntity, LayoutUpdateData } from '../../shared/types'
+
+export function descendantIdsForGroup(
+  groups: readonly CanvasSceneGroupEntity[],
+  groupId: string,
+): Set<string> {
+  const descendants = new Set<string>()
+  const groupsById = new Map(groups.map((group) => [group.id, group]))
+
+  const visit = (currentGroupId: string) => {
+    const group = groupsById.get(currentGroupId)
+    if (!group) return
+
+    for (const entityId of group.entityIds) {
+      if (descendants.has(entityId)) continue
+      descendants.add(entityId)
+      if (groupsById.has(entityId)) visit(entityId)
+    }
+  }
+
+  visit(groupId)
+  return descendants
+}
+
+export function selectedGroupDragTargetId(
+  layout: Pick<LayoutUpdateData, 'groups' | 'selectedGroupId'>,
+  entityId: string,
+): string | null {
+  const selectedGroupId = layout.selectedGroupId ?? null
+  if (!selectedGroupId) return null
+  if (entityId === selectedGroupId) return selectedGroupId
+  return descendantIdsForGroup(layout.groups ?? [], selectedGroupId).has(entityId)
+    ? selectedGroupId
+    : null
+}
+
+export function selectedGroupHasDescendantFrame(
+  layout: Pick<LayoutUpdateData, 'entities' | 'groups' | 'selectedGroupId'>,
+): boolean {
+  const selectedGroupId = layout.selectedGroupId ?? null
+  if (!selectedGroupId) return false
+
+  const descendantIds = descendantIdsForGroup(layout.groups ?? [], selectedGroupId)
+  return layout.entities.some((entity) => entity.kind === 'frame' && descendantIds.has(entity.id))
+}

--- a/src/renderer/canvas-bg/useEntityResize.ts
+++ b/src/renderer/canvas-bg/useEntityResize.ts
@@ -67,7 +67,13 @@ export function useCornerResize({
       const aspect = width / height
       const flipX = corner === 'top-left' || corner === 'bottom-left' ? -1 : 1
       const flipY = corner === 'top-left' || corner === 'top-right' ? -1 : 1
+      let lastButtons = e.buttons || 1
       const handleMouseMove = (moveEvent: MouseEvent) => {
+        lastButtons = moveEvent.buttons
+        if (lastButtons === 0) {
+          finishResize()
+          return
+        }
         const dx = (moveEvent.screenX - lastX) / zoom
         const dy = (moveEvent.screenY - lastY) / zoom
         lastX = moveEvent.screenX
@@ -103,12 +109,19 @@ export function useCornerResize({
       }
       const finishResize = () => {
         window.removeEventListener('mousemove', handleMouseMove)
-        window.removeEventListener('mouseup', finishResize)
-        window.removeEventListener('blur', finishResize)
+        window.removeEventListener('mouseup', handleMouseUp)
+        window.removeEventListener('blur', handleBlur)
+      }
+      const handleMouseUp = () => {
+        lastButtons = 0
+        finishResize()
+      }
+      const handleBlur = () => {
+        if (lastButtons === 0) finishResize()
       }
       window.addEventListener('mousemove', handleMouseMove)
-      window.addEventListener('mouseup', finishResize)
-      window.addEventListener('blur', finishResize)
+      window.addEventListener('mouseup', handleMouseUp)
+      window.addEventListener('blur', handleBlur)
     },
     [id, width, height, canvasX, canvasY, zoom, minWidth, minHeight, corner, onResize, aspectRatioResizeMode],
   )
@@ -153,7 +166,13 @@ export function useEdgeResize({
       const aspect = width / height
       const isHorizontal = edge === 'left' || edge === 'right'
       const flip = edge === 'left' || edge === 'top' ? -1 : 1
+      let lastButtons = e.buttons || 1
       const handleMouseMove = (moveEvent: MouseEvent) => {
+        lastButtons = moveEvent.buttons
+        if (lastButtons === 0) {
+          finishResize()
+          return
+        }
         const dx = (moveEvent.screenX - lastX) / zoom
         const dy = (moveEvent.screenY - lastY) / zoom
         lastX = moveEvent.screenX
@@ -187,12 +206,19 @@ export function useEdgeResize({
       }
       const finishResize = () => {
         window.removeEventListener('mousemove', handleMouseMove)
-        window.removeEventListener('mouseup', finishResize)
-        window.removeEventListener('blur', finishResize)
+        window.removeEventListener('mouseup', handleMouseUp)
+        window.removeEventListener('blur', handleBlur)
+      }
+      const handleMouseUp = () => {
+        lastButtons = 0
+        finishResize()
+      }
+      const handleBlur = () => {
+        if (lastButtons === 0) finishResize()
       }
       window.addEventListener('mousemove', handleMouseMove)
-      window.addEventListener('mouseup', finishResize)
-      window.addEventListener('blur', finishResize)
+      window.addEventListener('mouseup', handleMouseUp)
+      window.addEventListener('blur', handleBlur)
     },
     [id, width, height, canvasX, canvasY, zoom, minWidth, minHeight, edge, onResize, aspectRatioResizeMode],
   )

--- a/src/renderer/canvas-bg/useFrameChromeDrag.ts
+++ b/src/renderer/canvas-bg/useFrameChromeDrag.ts
@@ -7,6 +7,11 @@ import {
   type ChromeDragSession,
   type DragCopyPreview,
 } from './canvasGeometry'
+import { selectedGroupDragTargetId } from './groupMembership'
+
+type ChromeDragTarget =
+  | { kind: 'frame'; id: string }
+  | { kind: 'group'; id: string }
 
 export function useFrameChromeDrag({
   api,
@@ -16,32 +21,44 @@ export function useFrameChromeDrag({
   layoutRef: RefObject<LayoutUpdateData>
 }) {
   const chromeDraggingRef = useRef(false)
-  const dragFrameIdRef = useRef<string | null>(null)
+  const dragTargetRef = useRef<ChromeDragTarget | null>(null)
   const chromeDragSessionRef = useRef<ChromeDragSession | null>(null)
   const chromeLastPosRef = useRef({ x: 0, y: 0 })
   const [dragCopyPreview, setDragCopyPreview] = useState<DragCopyPreview[]>([])
   const [isChromeDragging, setIsChromeDragging] = useState(false)
 
   const resetDragState = useCallback(() => {
+    const dragTarget = dragTargetRef.current
     chromeDraggingRef.current = false
     setIsChromeDragging(false)
-    dragFrameIdRef.current = null
+    dragTargetRef.current = null
     chromeDragSessionRef.current = null
     setDragCopyPreview([])
-    api.endDragFrame()
+    if (dragTarget?.kind === 'group') {
+      api.endDragGroup()
+    } else if (dragTarget?.kind === 'frame') {
+      api.endDragFrame()
+    }
   }, [api])
 
   const syncChromeDragCopyMode = useCallback(
     (copyMode: boolean) => {
       const session = chromeDragSessionRef.current
-      const dragFrameId = dragFrameIdRef.current
-      if (!session || session.copyMode === copyMode || !dragFrameId) return
+      const dragTarget = dragTargetRef.current
+      if (
+        !session ||
+        session.copyMode === copyMode ||
+        !dragTarget ||
+        dragTarget.kind !== 'frame'
+      ) {
+        return
+      }
 
       session.copyMode = copyMode
 
       if (copyMode) {
         if (session.totalScreenDx !== 0 || session.totalScreenDy !== 0) {
-          api.dragFrame(dragFrameId, -session.totalScreenDx, -session.totalScreenDy)
+          api.dragFrame(dragTarget.id, -session.totalScreenDx, -session.totalScreenDy)
         }
         setDragCopyPreview(buildDragCopyPreview(session, layoutRef.current))
         return
@@ -49,7 +66,7 @@ export function useFrameChromeDrag({
 
       setDragCopyPreview([])
       if (session.totalScreenDx !== 0 || session.totalScreenDy !== 0) {
-        api.dragFrame(dragFrameId, session.totalScreenDx, session.totalScreenDy)
+        api.dragFrame(dragTarget.id, session.totalScreenDx, session.totalScreenDy)
       }
     },
     [api, layoutRef],
@@ -66,8 +83,13 @@ export function useFrameChromeDrag({
       const dy = event.screenY - chromeLastPosRef.current.y
       chromeLastPosRef.current = { x: event.screenX, y: event.screenY }
       const session = chromeDragSessionRef.current
-      const dragFrameId = dragFrameIdRef.current
-      if (!dragFrameId || !session) return
+      const dragTarget = dragTargetRef.current
+      if (!dragTarget) return
+      if (dragTarget.kind === 'group') {
+        api.dragGroup(dragTarget.id, dx, dy)
+        return
+      }
+      if (!session) return
       if (event.altKey !== session.copyMode) {
         syncChromeDragCopyMode(event.altKey)
       }
@@ -77,7 +99,7 @@ export function useFrameChromeDrag({
         setDragCopyPreview(buildDragCopyPreview(session, layoutRef.current))
         return
       }
-      api.dragFrame(dragFrameId, dx, dy)
+      api.dragFrame(dragTarget.id, dx, dy)
     }
 
     const handleMouseUp = () => {
@@ -135,6 +157,18 @@ export function useFrameChromeDrag({
         event.preventDefault()
         return
       }
+      const selectedGroupTargetId = selectedGroupDragTargetId(layout, frameId)
+      if (selectedGroupTargetId) {
+        api.startDragGroup(selectedGroupTargetId)
+        chromeDraggingRef.current = true
+        setIsChromeDragging(true)
+        dragTargetRef.current = { kind: 'group', id: selectedGroupTargetId }
+        chromeDragSessionRef.current = null
+        chromeLastPosRef.current = { x: event.screenX, y: event.screenY }
+        setDragCopyPreview([])
+        event.preventDefault()
+        return
+      }
       if (!layout.selectedEntityIds.includes(frameId)) {
         api.selectFrame(frameId)
       }
@@ -163,7 +197,7 @@ export function useFrameChromeDrag({
       api.startDragFrame(frameId)
       chromeDraggingRef.current = true
       setIsChromeDragging(true)
-      dragFrameIdRef.current = frameId
+      dragTargetRef.current = { kind: 'frame', id: frameId }
       chromeLastPosRef.current = { x: event.screenX, y: event.screenY }
 
       if (event.altKey && chromeDragSessionRef.current) {

--- a/src/renderer/canvas-bg/useGroupBoundsDrag.ts
+++ b/src/renderer/canvas-bg/useGroupBoundsDrag.ts
@@ -1,63 +1,67 @@
-import { useCallback } from 'react'
-import type { CanvasBgElectronAPI } from '../../shared/types'
+import type { RefObject } from 'react'
+import { useDragGesture } from '../shared/useDragGesture'
 
 const GROUP_DRAG_THRESHOLD_PX = 3
 
-/**
- * Pointer-down handler for group bounds: selects the group, then promotes the
- * gesture to a drag once the cursor moves past a small threshold. Drag is
- * routed back through the IPC API (start/drag/end).
- *
- * Returns a stable callback suitable for `<GroupBoundsLayer onPointerDown>`.
- */
-export function useGroupBoundsDrag(
-  api: CanvasBgElectronAPI,
-): (groupId: string, e: React.PointerEvent) => void {
-  return useCallback(
-    (groupId, e) => {
-      e.stopPropagation()
-      api.selectGroup(groupId)
-      const target = e.currentTarget as HTMLElement
-      const pointerId = e.pointerId
-      const startX = e.clientX
-      const startY = e.clientY
-      let dragging = false
-      try { target.setPointerCapture(pointerId) } catch { /* ignore */ }
-      const onMove = (moveEvent: PointerEvent) => {
-        if (moveEvent.pointerId !== pointerId) return
-        if (!dragging) {
-          const dx = moveEvent.clientX - startX
-          const dy = moveEvent.clientY - startY
-          if (Math.abs(dx) < GROUP_DRAG_THRESHOLD_PX && Math.abs(dy) < GROUP_DRAG_THRESHOLD_PX) return
-          dragging = true
-          api.startDragGroup(groupId)
-        }
-        api.dragGroup(groupId, moveEvent.movementX, moveEvent.movementY)
+type GroupDragToken = {
+  lastDx: number
+  lastDy: number
+}
+
+export function useGroupDragGesture({
+  target,
+  groupId,
+  enabled = true,
+  selectOnBegin = true,
+  selectOnPointerDown = false,
+  onSelectGroup,
+  onStartDragGroup,
+  onDragGroup,
+  onEndDragGroup,
+  filter,
+}: {
+  target: RefObject<HTMLElement | null>
+  groupId: string
+  enabled?: boolean
+  selectOnBegin?: boolean
+  selectOnPointerDown?: boolean
+  onSelectGroup?: (groupId: string) => void
+  onStartDragGroup: (groupId: string) => void
+  onDragGroup: (groupId: string, dx: number, dy: number) => void
+  onEndDragGroup: () => void
+  filter?: (event: PointerEvent) => boolean
+}): void {
+  useDragGesture<GroupDragToken>({
+    target,
+    threshold: GROUP_DRAG_THRESHOLD_PX,
+    stopPropagation: true,
+    filter: (event) => {
+      if (!enabled) return false
+      if (event.button !== 0) return false
+      const targetElement = event.target as HTMLElement | null
+      if (targetElement?.closest('[data-resize-handle], input, textarea, button')) {
+        return false
       }
-      const cleanup = () => {
-        target.removeEventListener('pointermove', onMove)
-        target.removeEventListener('pointerup', onUp)
-        target.removeEventListener('pointercancel', onCancel)
-        target.removeEventListener('lostpointercapture', onCancel)
-        if (target.hasPointerCapture?.(pointerId)) {
-          try { target.releasePointerCapture(pointerId) } catch { /* ignore */ }
-        }
-      }
-      const onUp = (upEvent: PointerEvent) => {
-        if (upEvent.pointerId !== pointerId) return
-        if (dragging) api.endDragGroup()
-        cleanup()
-      }
-      const onCancel = (cancelEvent: PointerEvent) => {
-        if (cancelEvent.pointerId !== pointerId) return
-        if (dragging) api.endDragGroup()
-        cleanup()
-      }
-      target.addEventListener('pointermove', onMove)
-      target.addEventListener('pointerup', onUp)
-      target.addEventListener('pointercancel', onCancel)
-      target.addEventListener('lostpointercapture', onCancel)
+      if (filter && !filter(event)) return false
+      return true
     },
-    [api],
-  )
+    onPointerDown: () => {
+      if (selectOnPointerDown) onSelectGroup?.(groupId)
+    },
+    onBegin: (ctx) => {
+      if (selectOnBegin && !selectOnPointerDown) onSelectGroup?.(groupId)
+      onStartDragGroup(groupId)
+      if (ctx.dx !== 0 || ctx.dy !== 0) onDragGroup(groupId, ctx.dx, ctx.dy)
+      return { lastDx: ctx.dx, lastDy: ctx.dy }
+    },
+    onUpdate: (ctx, token) => {
+      const dx = ctx.dx - token.lastDx
+      const dy = ctx.dy - token.lastDy
+      token.lastDx = ctx.dx
+      token.lastDy = ctx.dy
+      if (dx !== 0 || dy !== 0) onDragGroup(groupId, dx, dy)
+    },
+    onCommit: () => onEndDragGroup(),
+    onCancel: () => onEndDragGroup(),
+  })
 }

--- a/src/renderer/canvas-bg/useMultiSelectionResize.ts
+++ b/src/renderer/canvas-bg/useMultiSelectionResize.ts
@@ -70,10 +70,16 @@ export function useMultiCornerResize({
       let accH = canvasBbox.height
       let accCX = canvasBbox.x
       let accCY = canvasBbox.y
+      let lastButtons = e.buttons || 1
       const flipX = corner === 'top-left' || corner === 'bottom-left' ? -1 : 1
       const flipY = corner === 'top-left' || corner === 'top-right' ? -1 : 1
 
       const handleMouseMove = (moveEvent: MouseEvent) => {
+        lastButtons = moveEvent.buttons
+        if (lastButtons === 0) {
+          finishResize()
+          return
+        }
         const dx = (moveEvent.screenX - lastX) / zoom
         const dy = (moveEvent.screenY - lastY) / zoom
         lastX = moveEvent.screenX
@@ -93,12 +99,19 @@ export function useMultiCornerResize({
 
       const finishResize = () => {
         window.removeEventListener('mousemove', handleMouseMove)
-        window.removeEventListener('mouseup', finishResize)
-        window.removeEventListener('blur', finishResize)
+        window.removeEventListener('mouseup', handleMouseUp)
+        window.removeEventListener('blur', handleBlur)
+      }
+      const handleMouseUp = () => {
+        lastButtons = 0
+        finishResize()
+      }
+      const handleBlur = () => {
+        if (lastButtons === 0) finishResize()
       }
       window.addEventListener('mousemove', handleMouseMove)
-      window.addEventListener('mouseup', finishResize)
-      window.addEventListener('blur', finishResize)
+      window.addEventListener('mouseup', handleMouseUp)
+      window.addEventListener('blur', handleBlur)
     },
     [entities, canvasBbox, zoom, corner, onResize],
   )
@@ -132,10 +145,16 @@ export function useMultiEdgeResize({
       let accH = canvasBbox.height
       let accCX = canvasBbox.x
       let accCY = canvasBbox.y
+      let lastButtons = e.buttons || 1
       const isHorizontal = edge === 'left' || edge === 'right'
       const flip = edge === 'left' || edge === 'top' ? -1 : 1
 
       const handleMouseMove = (moveEvent: MouseEvent) => {
+        lastButtons = moveEvent.buttons
+        if (lastButtons === 0) {
+          finishResize()
+          return
+        }
         const dx = (moveEvent.screenX - lastX) / zoom
         const dy = (moveEvent.screenY - lastY) / zoom
         lastX = moveEvent.screenX
@@ -159,12 +178,19 @@ export function useMultiEdgeResize({
 
       const finishResize = () => {
         window.removeEventListener('mousemove', handleMouseMove)
-        window.removeEventListener('mouseup', finishResize)
-        window.removeEventListener('blur', finishResize)
+        window.removeEventListener('mouseup', handleMouseUp)
+        window.removeEventListener('blur', handleBlur)
+      }
+      const handleMouseUp = () => {
+        lastButtons = 0
+        finishResize()
+      }
+      const handleBlur = () => {
+        if (lastButtons === 0) finishResize()
       }
       window.addEventListener('mousemove', handleMouseMove)
-      window.addEventListener('mouseup', finishResize)
-      window.addEventListener('blur', finishResize)
+      window.addEventListener('mouseup', handleMouseUp)
+      window.addEventListener('blur', handleBlur)
     },
     [entities, canvasBbox, zoom, edge, onResize],
   )

--- a/src/renderer/shared/useDragGesture.ts
+++ b/src/renderer/shared/useDragGesture.ts
@@ -44,6 +44,8 @@ export type DragGestureSpec<T> = {
   onUpdate: (ctx: GestureContext, token: T) => void
   onCommit: (ctx: GestureContext, token: T) => void
   onCancel: (token: T, reason: CancelReason) => void
+  /** Runs after an accepted pointerdown, even when threshold prevents begin. */
+  onPointerDown?: (ctx: GestureContext) => void
   /** Filter pointerdown events before they start a gesture. */
   filter?: (event: PointerEvent) => boolean
   /** Stop propagation of accepted pointerdown events (prevents ancestor gestures). */
@@ -88,8 +90,6 @@ export function useDragGesture<T>(spec: DragGestureSpec<T>): void {
     let token: T | null = null
     let begun = false
     let lastButtons = 0
-    const threshold = spec.threshold ?? 0
-
     const cancel = (reason: CancelReason) => {
       if (token !== null) {
         try { specRef.current.onCancel(token, reason) } catch { /* ignore */ }
@@ -110,7 +110,9 @@ export function useDragGesture<T>(spec: DragGestureSpec<T>): void {
       startX = event.clientX
       startY = event.clientY
       lastButtons = event.buttons
+      specRef.current.onPointerDown?.(contextFrom(event, startX, startY))
       el.setPointerCapture(event.pointerId)
+      const threshold = specRef.current.threshold ?? 0
       if (threshold === 0) {
         const ctx = contextFrom(event, startX, startY)
         const t = specRef.current.onBegin(ctx)
@@ -125,6 +127,7 @@ export function useDragGesture<T>(spec: DragGestureSpec<T>): void {
       lastButtons = event.buttons
       const ctx = contextFrom(event, startX, startY)
       if (!begun) {
+        const threshold = specRef.current.threshold ?? 0
         if (Math.abs(ctx.dx) < threshold && Math.abs(ctx.dy) < threshold) return
         const t = specRef.current.onBegin(ctx)
         if (t === null) { cancel('external'); return }

--- a/tests/unit/group-membership.test.ts
+++ b/tests/unit/group-membership.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import type { CanvasSceneGroupEntity, LayoutUpdateData } from '../../src/shared/types'
+import {
+  descendantIdsForGroup,
+  selectedGroupHasDescendantFrame,
+  selectedGroupDragTargetId,
+} from '../../src/renderer/canvas-bg/groupMembership'
+
+function group(
+  id: string,
+  entityIds: string[],
+  parentGroupId?: string,
+): CanvasSceneGroupEntity {
+  return {
+    kind: 'group',
+    id,
+    label: id,
+    canvasX: 0,
+    canvasY: 0,
+    width: 100,
+    height: 100,
+    screenX: 0,
+    screenY: 0,
+    screenWidth: 100,
+    screenHeight: 100,
+    parentGroupId,
+    groupKind: 'manual',
+    layoutMode: 'freeform',
+    managedLayout: false,
+    entityIds,
+  }
+}
+
+describe('groupMembership', () => {
+  it('collects direct and nested group descendants', () => {
+    const groups = [
+      group('parent', ['frame-1', 'child']),
+      group('child', ['text-1'], 'parent'),
+    ]
+
+    expect(descendantIdsForGroup(groups, 'parent')).toEqual(
+      new Set(['frame-1', 'child', 'text-1']),
+    )
+  })
+
+  it('resolves a selected group drag target for descendants', () => {
+    const groups = [
+      group('parent', ['frame-1', 'child']),
+      group('child', ['file-1'], 'parent'),
+    ]
+
+    expect(selectedGroupDragTargetId({ groups, selectedGroupId: 'parent' }, 'file-1')).toBe(
+      'parent',
+    )
+    expect(selectedGroupDragTargetId({ groups, selectedGroupId: 'parent' }, 'other')).toBeNull()
+    expect(selectedGroupDragTargetId({ groups, selectedGroupId: null }, 'file-1')).toBeNull()
+  })
+
+  it('detects when the selected group owns frame content', () => {
+    const groups = [
+      group('parent', ['child']),
+      group('child', ['frame-1'], 'parent'),
+    ]
+    const entities = [
+      { kind: 'frame', id: 'frame-1' },
+      { kind: 'text', id: 'text-1' },
+    ] as LayoutUpdateData['entities']
+
+    expect(selectedGroupHasDescendantFrame({ entities, groups, selectedGroupId: 'parent' })).toBe(
+      true,
+    )
+    expect(selectedGroupHasDescendantFrame({ entities, groups, selectedGroupId: 'child' })).toBe(
+      true,
+    )
+    expect(selectedGroupHasDescendantFrame({ entities, groups, selectedGroupId: null })).toBe(
+      false,
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Fixes selected group dragging and resizing so group interactions behave consistently across group headers, group backgrounds, child frames, text notes, files, and multi-selection.

## What Changed

- Refactored group drag handling around a shared group membership helper so selected groups drag as a unit, while selected child entities still drag independently.
- Routed selected-group drag gestures through `above-view` when a selected group owns frame content, preventing frame webviews from stealing the drag stream after the first layout tick.
- Mirrored selected-group resize controls into `above-view` only when needed, and suppresses the lower canvas overlay in that case to avoid duplicate handles.
- Marked all resize handles consistently and made resize blur handling resilient to renderer focus handoff during an active mouse drag.
- Added unit coverage for nested group descendant resolution and selected-group frame ownership detection.

## Root Cause

Group interactions were split across canvas-bg, frame chrome, entity shells, and above-view. When selected groups contained frames, the top pointer layer could receive or steal interaction events while the visible selection controls were owned by a lower layer. Resize handles also were not consistently identifiable as resize targets, allowing group drag to win over resize.

## Validation

- `pnpm typecheck`
- `pnpm test:unit`
