### PR TITLE
[codex] Lower canvas zoom floor

### DIFF
--- a/src/main/runtime/viewport-control.ts
+++ b/src/main/runtime/viewport-control.ts
@@ -10,10 +10,11 @@ import {
 } from './runtime-geometry'
 import { scheduleWorkspaceAutosave } from './workspace-autosave'
 import { safeSend } from './safe-send'
+import { clampCanvasZoom } from '../../shared/zoom'
 import type { WorkspaceBounds } from '../../shared/types'
 
 export function setZoom(value: number): void {
-  const nextZoom = Math.max(0.1, Math.min(3.0, value))
+  const nextZoom = clampCanvasZoom(value)
   if (nextZoom === zoom) return
   setZoomState(nextZoom)
   markDirty('canvas', 'toolbar', 'pages')

--- a/src/renderer/toolbar/useToolbarState.ts
+++ b/src/renderer/toolbar/useToolbarState.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import type { AgentPresenceCursor, AnnotationMode, ToolbarSelectionData } from '../../shared/types'
 import { toolbarApi } from './toolbarApi'
 
-export const ZOOM_PRESETS = [2, 10, 25, 50, 75, 100, 150, 200] as const
+export const ZOOM_PRESETS = [10, 25, 50, 75, 100, 150, 200] as const
 
 const EMPTY_SELECTION: ToolbarSelectionData = {
   activeFrameId: null,

--- a/src/renderer/toolbar/useToolbarState.ts
+++ b/src/renderer/toolbar/useToolbarState.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import type { AgentPresenceCursor, AnnotationMode, ToolbarSelectionData } from '../../shared/types'
 import { toolbarApi } from './toolbarApi'
 
-export const ZOOM_PRESETS = [25, 50, 75, 100, 150, 200] as const
+export const ZOOM_PRESETS = [2, 10, 25, 50, 75, 100, 150, 200] as const
 
 const EMPTY_SELECTION: ToolbarSelectionData = {
   activeFrameId: null,

--- a/src/shared/zoom.ts
+++ b/src/shared/zoom.ts
@@ -1,0 +1,6 @@
+export const CANVAS_MIN_ZOOM = 0.02
+export const CANVAS_MAX_ZOOM = 3.0
+
+export function clampCanvasZoom(value: number): number {
+  return Math.max(CANVAS_MIN_ZOOM, Math.min(CANVAS_MAX_ZOOM, value))
+}

--- a/tests/unit/coords.test.ts
+++ b/tests/unit/coords.test.ts
@@ -26,7 +26,7 @@ describe('coords', () => {
   })
 
   it('round-trips at zoom extremes', () => {
-    for (const zoom of [0.1, 0.5, 1, 2, 10]) {
+    for (const zoom of [0.02, 0.5, 1, 2, 10]) {
       const L = layout({ zoom })
       const c = screenPointToCanvasPoint(500, 400, L)
       const s = canvasToScreenPoint(L, c)

--- a/tests/unit/zoom.test.ts
+++ b/tests/unit/zoom.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { CANVAS_MAX_ZOOM, CANVAS_MIN_ZOOM, clampCanvasZoom } from '../../src/shared/zoom'
+
+describe('canvas zoom bounds', () => {
+  it('allows zooming out to 2%', () => {
+    expect(CANVAS_MIN_ZOOM).toBe(0.02)
+    expect(clampCanvasZoom(0.02)).toBe(0.02)
+  })
+
+  it('clamps below the supported zoom floor', () => {
+    expect(clampCanvasZoom(0.01)).toBe(CANVAS_MIN_ZOOM)
+  })
+
+  it('preserves the existing zoom-in ceiling', () => {
+    expect(clampCanvasZoom(4)).toBe(CANVAS_MAX_ZOOM)
+  })
+})


### PR DESCRIPTION
## Summary

Lower the canvas zoom-out floor from 10% to 2% so users can zoom farther out on large spatial canvases.

## Details

- Added shared zoom bounds and a `clampCanvasZoom` helper.
- Updated runtime zoom clamping to use the shared 2% floor while preserving the 300% ceiling.
- Added 10% as the lowest toolbar dropdown preset, without exposing 2% as a preset.
- Added unit coverage for the new zoom bounds and updated coordinate round-trip coverage to include 2%.

## Validation

- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm test:smoke` was attempted locally but Electron aborted before the smoke server became ready in the sandboxed environment.
