### PR TITLE
fix: scale edge hit targets with zoom

### DIFF
--- a/src/renderer/canvas-bg/EdgeLayer.tsx
+++ b/src/renderer/canvas-bg/EdgeLayer.tsx
@@ -8,6 +8,7 @@ import type {
 } from '../../shared/types'
 import { resolveCanvasColor } from '../../shared/canvas-colors'
 import { selectionColor, EDGE_COLOR_DEFAULT } from './canvasBgConstants'
+import { scaleEdgeHitTargetSize } from './edgeHitSizing'
 
 // --- Constants ---
 
@@ -18,6 +19,7 @@ const DOT_OFFSET = 8
 const SNAP_DISTANCE = 48
 const CONTROL_POINT_MIN = 40
 const CONTROL_POINT_MAX = 200
+const EDGE_SELECTION_HIT_WIDTH = 14
 
 // --- Geometry helpers ---
 
@@ -122,6 +124,7 @@ function AnchorDots({
   onHoverEntity: (entityId: string | null) => void
 }) {
   const [hoveredSide, setHoveredSide] = useState<EdgeSide | null>(null)
+  const dotHitRadius = scaleEdgeHitTargetSize(DOT_HIT_RADIUS, zoom)
 
   useEffect(() => {
     if (!isDragging) setHoveredSide(null)
@@ -144,12 +147,12 @@ function AnchorDots({
                 strokeWidth={1}
               />
             ) : null}
-            {/* Smaller interaction target */}
+            {/* Zoom-scaled interaction target */}
             <circle
               cx={pt.x}
               cy={pt.y}
               fill="transparent"
-              r={DOT_HIT_RADIUS}
+              r={dotHitRadius}
               style={{ cursor: 'crosshair', pointerEvents: 'all' }}
               onMouseDown={(e) => {
                 e.stopPropagation()
@@ -225,6 +228,7 @@ export function EdgeLayer({
   const dragListenersRef = useRef<{ move: (e: MouseEvent) => void; up: (e: MouseEvent) => void } | null>(null)
   const zoomRef = useRef(zoom)
   zoomRef.current = zoom
+  const edgeSelectionHitWidth = scaleEdgeHitTargetSize(EDGE_SELECTION_HIT_WIDTH, zoom)
 
   // Clean up drag listeners on unmount
   useEffect(() => {
@@ -243,7 +247,14 @@ export function EdgeLayer({
       onBeginEdgeDrag(entityId, side)
 
       const handleMove = (e: MouseEvent) => {
-        const bestTarget = findClosestAnchorTarget(entityMap, entityId, e.clientX, e.clientY, SNAP_DISTANCE, zoomRef.current)
+        const bestTarget = findClosestAnchorTarget(
+          entityMap,
+          entityId,
+          e.clientX,
+          e.clientY,
+          scaleEdgeHitTargetSize(SNAP_DISTANCE, zoomRef.current),
+          zoomRef.current,
+        )
         const nextHoveredEntityId = bestTarget?.entityId ?? null
         if (hoveredDragEntityIdRef.current !== nextHoveredEntityId) {
           hoveredDragEntityIdRef.current = nextHoveredEntityId
@@ -261,7 +272,14 @@ export function EdgeLayer({
         window.removeEventListener('mouseup', handleUp)
         dragListenersRef.current = null
 
-        const bestTarget = findClosestAnchorTarget(entityMap, entityId, e.clientX, e.clientY, SNAP_DISTANCE, zoomRef.current)
+        const bestTarget = findClosestAnchorTarget(
+          entityMap,
+          entityId,
+          e.clientX,
+          e.clientY,
+          scaleEdgeHitTargetSize(SNAP_DISTANCE, zoomRef.current),
+          zoomRef.current,
+        )
 
         if (bestTarget) {
           onCommitEdgeDrag(entityId, bestTarget.entityId, side, bestTarget.side)
@@ -400,12 +418,12 @@ export function EdgeLayer({
             stroke={edgeColor}
             strokeWidth={1.5}
           />
-          {/* Fat invisible hit target */}
+          {/* Zoom-scaled invisible hit target */}
           <path
             d={d}
             fill="none"
             stroke="transparent"
-            strokeWidth={14}
+            strokeWidth={edgeSelectionHitWidth}
             style={{ cursor: 'pointer', pointerEvents: 'stroke' }}
             onClick={(e) => {
               e.stopPropagation()

--- a/src/renderer/canvas-bg/edgeHitSizing.ts
+++ b/src/renderer/canvas-bg/edgeHitSizing.ts
@@ -1,0 +1,10 @@
+const EDGE_HIT_TARGET_MIN_SCALE = 0.35
+
+/**
+ * Edge hit targets are drawn in screen-space, so their 1x tuned sizes need to
+ * shrink as the canvas zooms out or they start intercepting too much input.
+ */
+export function scaleEdgeHitTargetSize(basePx: number, zoom: number): number {
+  const scale = Math.max(EDGE_HIT_TARGET_MIN_SCALE, Math.min(zoom, 1))
+  return basePx * scale
+}

--- a/tests/unit/edge-hit-sizing.test.ts
+++ b/tests/unit/edge-hit-sizing.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { scaleEdgeHitTargetSize } from '../../src/renderer/canvas-bg/edgeHitSizing'
+
+describe('scaleEdgeHitTargetSize', () => {
+  it('preserves the tuned size at 1x zoom', () => {
+    expect(scaleEdgeHitTargetSize(24, 1)).toBe(24)
+  })
+
+  it('does not enlarge hit targets above their 1x size', () => {
+    expect(scaleEdgeHitTargetSize(24, 2)).toBe(24)
+  })
+
+  it('shrinks hit targets as the canvas zooms out', () => {
+    expect(scaleEdgeHitTargetSize(24, 0.5)).toBe(12)
+    expect(scaleEdgeHitTargetSize(48, 0.5)).toBe(24)
+  })
+
+  it('clamps the zoomed-out floor so targets stay usable', () => {
+    expect(scaleEdgeHitTargetSize(24, 0.02)).toBeCloseTo(8.4)
+    expect(scaleEdgeHitTargetSize(14, 0.02)).toBeCloseTo(4.9)
+  })
+})


### PR DESCRIPTION
## Summary

- Edge selection hit paths and anchor dots were drawn at fixed pixel sizes in screen space, so they intercepted far more canvas area than intended when zoomed out.
- New `scaleEdgeHitTargetSize(basePx, zoom)` helper clamps the scale between 0.35 and 1.0 — hit targets shrink as you zoom out but stay usable at the 2% floor.
- Also scales `SNAP_DISTANCE` passed into `findClosestAnchorTarget` during edge drags so snapping feels consistent across zoom levels.

## Test plan

- [x] `pnpm test:unit` — new `edge-hit-sizing.test.ts` covers 1x, above-1x clamp, zoomed-out scaling, and floor clamp
- [x] `pnpm typecheck`
- [ ] Manual: zoom the canvas to 10%, 50%, 100%, and 200% and confirm edge clicks + anchor drags land only when actually near the target
- [ ] Manual: drag a new edge at low zoom and confirm snap distance feels right