### PR TITLE
Fix cursor video recording: include cursor overlay, 1:1 native capture

### DIFF
--- a/src/main/runtime/frame-compositor.ts
+++ b/src/main/runtime/frame-compositor.ts
@@ -1,14 +1,17 @@
 /**
  * Shared compositing helper — captures a frame's page content with its
- * comment/annotation overlay alpha-blended on top.
+ * overlays alpha-blended on top, in z-order:
+ *   1. page webContents
+ *   2. aboveView (comments, annotations, drawing, marquee, floating UI)
+ *   3. cursorOverlayWindow (agent presence cursors + particle trails)
  *
  * Used by video-recorder.ts (per-frame capture loop) and
  * app-control-server.ts (/frames/screenshot-composite endpoint).
  */
 
 import { screen as electronScreen } from 'electron'
-import type { NativeImage, WebContentsView } from 'electron'
-import { aboveView } from './view-refs'
+import type { NativeImage, WebContents, WebContentsView } from 'electron'
+import { aboveView, cursorOverlayWindow } from './view-refs'
 import type { Page } from './runtime-entities'
 import { win } from './window-shell'
 import { boundScreenBoundsForPage } from './runtime-geometry'
@@ -45,60 +48,77 @@ export async function captureFrameComposited(
       ? electronScreen.getDisplayMatching(win.getBounds()).scaleFactor
       : 1)
 
-  // Capture and crop the overlay (cursor, annotations) to the page region.
-  let croppedOverlay: NativeImage | null = null
-  const overlayWc = aboveView?.webContents
-  if (overlayWc && !overlayWc.isDestroyed() && win && !win.isDestroyed()) {
-    const bounds = boundScreenBoundsForPage(page)
-    const overlayBounds = aboveView!.getBounds()
-    const cropX = Math.round(Math.max(0, bounds.page.x - overlayBounds.x) * dpr)
-    const cropY = Math.round(Math.max(0, bounds.page.y - overlayBounds.y) * dpr)
-    const cropW = Math.round(
-      Math.min(bounds.page.width, overlayBounds.width - (bounds.page.x - overlayBounds.x)) * dpr,
-    )
-    const cropH = Math.round(
-      Math.min(bounds.page.height, overlayBounds.height - (bounds.page.y - overlayBounds.y)) * dpr,
-    )
-    if (cropW > 0 && cropH > 0) {
-      const fullOverlay = await overlayWc.capturePage()
-      if (!fullOverlay.isEmpty()) {
-        const fullSize = fullOverlay.getSize()
-        const safeW = Math.min(cropW, fullSize.width - cropX)
-        const safeH = Math.min(cropH, fullSize.height - cropY)
-        if (safeW > 0 && safeH > 0) {
-          croppedOverlay = fullOverlay.crop({
-            x: cropX,
-            y: cropY,
-            width: safeW,
-            height: safeH,
-          })
-        }
-      }
-    }
-  }
-
-  // Alpha-blend overlay onto page content.
+  // Capture the annotations/comments overlay (aboveView WCV) and the agent
+  // presence cursor overlay (a child BrowserWindow — lives outside the WCV
+  // stack for click-through, see view-refs.ts). Crop each to the page region
+  // and alpha-blend in z-order: page < aboveView < cursor overlay.
   const baseBitmap = pageImage.toBitmap()
-  if (croppedOverlay && !croppedOverlay.isEmpty()) {
-    const overlaySize = croppedOverlay.getSize()
-    if (overlaySize.width === pageSize.width && overlaySize.height === pageSize.height) {
-      const overBitmap = croppedOverlay.toBitmap()
-      for (let i = 0; i < baseBitmap.length; i += 4) {
-        const alpha = overBitmap[i + 3] / 255
-        if (alpha === 0) continue
-        baseBitmap[i] = Math.round(overBitmap[i] * alpha + baseBitmap[i] * (1 - alpha))
-        baseBitmap[i + 1] = Math.round(
-          overBitmap[i + 1] * alpha + baseBitmap[i + 1] * (1 - alpha),
-        )
-        baseBitmap[i + 2] = Math.round(
-          overBitmap[i + 2] * alpha + baseBitmap[i + 2] * (1 - alpha),
-        )
-        baseBitmap[i + 3] = Math.max(baseBitmap[i + 3], overBitmap[i + 3])
-      }
-    }
-  }
+  const canCapture = win && !win.isDestroyed()
+  const aboveCursor =
+    canCapture && aboveView && !aboveView.webContents.isDestroyed()
+      ? await captureAndCropToPage(aboveView.webContents, aboveView.getBounds(), page, dpr)
+      : null
+  blendOnto(baseBitmap, aboveCursor, pageSize)
+
+  const cursorWc = cursorOverlayWindow?.webContents
+  const cursorOverlay =
+    canCapture && cursorWc && !cursorWc.isDestroyed() && cursorOverlayWindow
+      ? await captureAndCropToPage(cursorWc, cursorOverlayWindow.getBounds(), page, dpr)
+      : null
+  blendOnto(baseBitmap, cursorOverlay, pageSize)
 
   return { bitmap: baseBitmap, width: pageSize.width, height: pageSize.height }
+}
+
+/**
+ * Capture an overlay WebContents and crop the result to the given page's
+ * on-screen rect. Works for both WebContentsView overlays (aboveView) and
+ * child BrowserWindow overlays (cursorOverlayWindow) — both expose getBounds()
+ * in the same window coordinate space.
+ */
+async function captureAndCropToPage(
+  wc: WebContents,
+  overlayBounds: { x: number; y: number; width: number; height: number },
+  page: Page,
+  dpr: number,
+): Promise<NativeImage | null> {
+  const bounds = boundScreenBoundsForPage(page)
+  const cropX = Math.round(Math.max(0, bounds.page.x - overlayBounds.x) * dpr)
+  const cropY = Math.round(Math.max(0, bounds.page.y - overlayBounds.y) * dpr)
+  const cropW = Math.round(
+    Math.min(bounds.page.width, overlayBounds.width - (bounds.page.x - overlayBounds.x)) * dpr,
+  )
+  const cropH = Math.round(
+    Math.min(bounds.page.height, overlayBounds.height - (bounds.page.y - overlayBounds.y)) * dpr,
+  )
+  if (cropW <= 0 || cropH <= 0) return null
+
+  const full = await wc.capturePage()
+  if (full.isEmpty()) return null
+  const fullSize = full.getSize()
+  const safeW = Math.min(cropW, fullSize.width - cropX)
+  const safeH = Math.min(cropH, fullSize.height - cropY)
+  if (safeW <= 0 || safeH <= 0) return null
+  return full.crop({ x: cropX, y: cropY, width: safeW, height: safeH })
+}
+
+function blendOnto(
+  baseBitmap: Buffer,
+  overlay: NativeImage | null,
+  pageSize: { width: number; height: number },
+): void {
+  if (!overlay || overlay.isEmpty()) return
+  const overlaySize = overlay.getSize()
+  if (overlaySize.width !== pageSize.width || overlaySize.height !== pageSize.height) return
+  const overBitmap = overlay.toBitmap()
+  for (let i = 0; i < baseBitmap.length; i += 4) {
+    const alpha = overBitmap[i + 3] / 255
+    if (alpha === 0) continue
+    baseBitmap[i] = Math.round(overBitmap[i] * alpha + baseBitmap[i] * (1 - alpha))
+    baseBitmap[i + 1] = Math.round(overBitmap[i + 1] * alpha + baseBitmap[i + 1] * (1 - alpha))
+    baseBitmap[i + 2] = Math.round(overBitmap[i + 2] * alpha + baseBitmap[i + 2] * (1 - alpha))
+    baseBitmap[i + 3] = Math.max(baseBitmap[i + 3], overBitmap[i + 3])
+  }
 }
 
 /**

--- a/src/main/runtime/frame-compositor.ts
+++ b/src/main/runtime/frame-compositor.ts
@@ -35,13 +35,6 @@ export async function captureFrameComposited(
 ): Promise<CompositedCapture | null> {
   if (page.pageView.webContents.isDestroyed()) return null
 
-  const pageImage = await page.pageView.webContents.capturePage()
-  if (pageImage.isEmpty()) return null
-
-  const pageSize = pageImage.getSize()
-  if (pageSize.width === 0 || pageSize.height === 0) return null
-
-  // Resolve device pixel ratio.
   const dpr =
     opts?.dpr ??
     (win && !win.isDestroyed()
@@ -50,57 +43,73 @@ export async function captureFrameComposited(
 
   // Capture the annotations/comments overlay (aboveView WCV) and the agent
   // presence cursor overlay (a child BrowserWindow — lives outside the WCV
-  // stack for click-through, see view-refs.ts). Crop each to the page region
-  // and alpha-blend in z-order: page < aboveView < cursor overlay.
-  const baseBitmap = pageImage.toBitmap()
+  // stack for click-through, see view-refs.ts). All three captures run in
+  // parallel; we then alpha-blend in z-order: page < aboveView < cursor overlay.
   const canCapture = win && !win.isDestroyed()
-  const aboveCursor =
-    canCapture && aboveView && !aboveView.webContents.isDestroyed()
-      ? await captureAndCropToPage(aboveView.webContents, aboveView.getBounds(), page, dpr)
-      : null
-  blendOnto(baseBitmap, aboveCursor, pageSize)
+  const pageRect = boundScreenBoundsForPage(page).page
 
+  const abovePromise =
+    canCapture && aboveView && !aboveView.webContents.isDestroyed()
+      ? captureAndCropToRect(aboveView.webContents, aboveView.getBounds(), pageRect, dpr)
+      : Promise.resolve(null)
+
+  // BrowserWindow.getBounds() is in screen coords; aboveView.getBounds() is
+  // window-relative. Translate to window-relative so both overlays share the
+  // coordinate space pageRect uses.
   const cursorWc = cursorOverlayWindow?.webContents
-  let cursorOverlay: NativeImage | null = null
+  let cursorPromise: Promise<NativeImage | null> = Promise.resolve(null)
   if (canCapture && cursorWc && !cursorWc.isDestroyed() && cursorOverlayWindow) {
-    // BrowserWindow.getBounds() is in screen coords; aboveView.getBounds()
-    // is window-relative. Translate to window-relative so both overlays
-    // share the coordinate space bounds.page.* uses.
     const contentBounds = win!.getContentBounds()
     const cursorScreenBounds = cursorOverlayWindow.getBounds()
-    const cursorBounds = {
-      x: cursorScreenBounds.x - contentBounds.x,
-      y: cursorScreenBounds.y - contentBounds.y,
-      width: cursorScreenBounds.width,
-      height: cursorScreenBounds.height,
-    }
-    cursorOverlay = await captureAndCropToPage(cursorWc, cursorBounds, page, dpr)
+    cursorPromise = captureAndCropToRect(
+      cursorWc,
+      {
+        x: cursorScreenBounds.x - contentBounds.x,
+        y: cursorScreenBounds.y - contentBounds.y,
+        width: cursorScreenBounds.width,
+        height: cursorScreenBounds.height,
+      },
+      pageRect,
+      dpr,
+    )
   }
+
+  const [pageImage, aboveOverlay, cursorOverlay] = await Promise.all([
+    page.pageView.webContents.capturePage(),
+    abovePromise,
+    cursorPromise,
+  ])
+
+  if (pageImage.isEmpty()) return null
+  const pageSize = pageImage.getSize()
+  if (pageSize.width === 0 || pageSize.height === 0) return null
+
+  const baseBitmap = pageImage.toBitmap()
+  blendOnto(baseBitmap, aboveOverlay, pageSize)
   blendOnto(baseBitmap, cursorOverlay, pageSize)
 
   return { bitmap: baseBitmap, width: pageSize.width, height: pageSize.height }
 }
 
 /**
- * Capture an overlay WebContents and crop the result to the given page's
- * on-screen rect. Works for both WebContentsView overlays (aboveView) and
- * child BrowserWindow overlays (cursorOverlayWindow) — both expose getBounds()
- * in the same window coordinate space.
+ * Capture an overlay WebContents and crop to the given target rect (in the
+ * overlay's coordinate space). Works for both WebContentsView overlays and
+ * child BrowserWindow overlays — callers pass each overlay's bounds in the
+ * same coordinate space as `targetRect`.
  */
-async function captureAndCropToPage(
+async function captureAndCropToRect(
   wc: WebContents,
   overlayBounds: { x: number; y: number; width: number; height: number },
-  page: Page,
+  targetRect: { x: number; y: number; width: number; height: number },
   dpr: number,
 ): Promise<NativeImage | null> {
-  const bounds = boundScreenBoundsForPage(page)
-  const cropX = Math.round(Math.max(0, bounds.page.x - overlayBounds.x) * dpr)
-  const cropY = Math.round(Math.max(0, bounds.page.y - overlayBounds.y) * dpr)
+  const cropX = Math.round(Math.max(0, targetRect.x - overlayBounds.x) * dpr)
+  const cropY = Math.round(Math.max(0, targetRect.y - overlayBounds.y) * dpr)
   const cropW = Math.round(
-    Math.min(bounds.page.width, overlayBounds.width - (bounds.page.x - overlayBounds.x)) * dpr,
+    Math.min(targetRect.width, overlayBounds.width - (targetRect.x - overlayBounds.x)) * dpr,
   )
   const cropH = Math.round(
-    Math.min(bounds.page.height, overlayBounds.height - (bounds.page.y - overlayBounds.y)) * dpr,
+    Math.min(targetRect.height, overlayBounds.height - (targetRect.y - overlayBounds.y)) * dpr,
   )
   if (cropW <= 0 || cropH <= 0) return null
 

--- a/src/main/runtime/frame-compositor.ts
+++ b/src/main/runtime/frame-compositor.ts
@@ -61,10 +61,21 @@ export async function captureFrameComposited(
   blendOnto(baseBitmap, aboveCursor, pageSize)
 
   const cursorWc = cursorOverlayWindow?.webContents
-  const cursorOverlay =
-    canCapture && cursorWc && !cursorWc.isDestroyed() && cursorOverlayWindow
-      ? await captureAndCropToPage(cursorWc, cursorOverlayWindow.getBounds(), page, dpr)
-      : null
+  let cursorOverlay: NativeImage | null = null
+  if (canCapture && cursorWc && !cursorWc.isDestroyed() && cursorOverlayWindow) {
+    // BrowserWindow.getBounds() is in screen coords; aboveView.getBounds()
+    // is window-relative. Translate to window-relative so both overlays
+    // share the coordinate space bounds.page.* uses.
+    const contentBounds = win!.getContentBounds()
+    const cursorScreenBounds = cursorOverlayWindow.getBounds()
+    const cursorBounds = {
+      x: cursorScreenBounds.x - contentBounds.x,
+      y: cursorScreenBounds.y - contentBounds.y,
+      width: cursorScreenBounds.width,
+      height: cursorScreenBounds.height,
+    }
+    cursorOverlay = await captureAndCropToPage(cursorWc, cursorBounds, page, dpr)
+  }
   blendOnto(baseBitmap, cursorOverlay, pageSize)
 
   return { bitmap: baseBitmap, width: pageSize.width, height: pageSize.height }

--- a/src/main/runtime/video-recorder.ts
+++ b/src/main/runtime/video-recorder.ts
@@ -8,6 +8,10 @@ import type { Page } from './runtime-entities'
 import { win } from './window-shell'
 import { VideoActivityTracker, type ActivitySegment } from './video-activity-tracker'
 import { captureFrameComposited } from './frame-compositor'
+import { getZoom, pan } from './runtime-context'
+import { focusCanvasBounds, requestLayout, setPan, setZoom } from './viewport-control'
+import { layoutAllViews } from './layout-engine'
+import { pageCanvasBounds } from './runtime-geometry'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -66,6 +70,7 @@ class VideoRecorderInstance {
   private captureHeight = 0
   private dpr = 1
   private stopped = false
+  private savedCamera: { zoom: number; panX: number; panY: number } | null = null
 
   constructor(options: RecordingOptions) {
     this.recordingId = randomUUID()
@@ -87,14 +92,32 @@ class VideoRecorderInstance {
       throw new Error('Window not available')
     }
 
-    const display = electronScreen.getDisplayMatching(w.getBounds())
-    this.dpr = display.scaleFactor
-    const pageBounds = this.page.pageView.getBounds()
-    this.captureWidth = Math.round(pageBounds.width * this.dpr)
-    this.captureHeight = Math.round(pageBounds.height * this.dpr)
+    // Canvas zoom is wired into Chromium's device emulation `scale` in
+    // computeApplyEmulation — the page is actually rendered into only the
+    // scaled sub-region of its emulated viewport. To capture at native size,
+    // the page must be rendered at native size, which means forcing canvas
+    // zoom to 1 for the duration of the recording.
+    this.savedCamera = { zoom: getZoom(), panX: pan.x, panY: pan.y }
+    try {
+      if (getZoom() !== 1) setZoom(1)
+      focusCanvasBounds(pageCanvasBounds(this.page))
+      layoutAllViews()
+      // Chromium re-rasters on the next frame after enableDeviceEmulation.
+      // Give it room so the first captured frames aren't mid-transition.
+      await new Promise((r) => setTimeout(r, 250))
 
-    if (this.captureWidth === 0 || this.captureHeight === 0) {
-      throw new Error('Canvas view has zero dimensions')
+      const display = electronScreen.getDisplayMatching(w.getBounds())
+      this.dpr = display.scaleFactor
+      const pageBounds = this.page.pageView.getBounds()
+      this.captureWidth = Math.round(pageBounds.width * this.dpr)
+      this.captureHeight = Math.round(pageBounds.height * this.dpr)
+
+      if (this.captureWidth === 0 || this.captureHeight === 0) {
+        throw new Error('Canvas view has zero dimensions')
+      }
+    } catch (error) {
+      this.restoreCamera()
+      throw error
     }
 
     // Spawn ffmpeg to accept raw BGRA frames on stdin.
@@ -190,6 +213,11 @@ class VideoRecorderInstance {
     this.activityTracker.stop()
     const segments = this.activityTracker.getSegments()
 
+    // Restore pre-recording camera. Done before ffmpeg flush so the user's
+    // canvas snaps back immediately; the video finishes encoding in the
+    // background.
+    this.restoreCamera()
+
     // Write segments metadata alongside the video.
     const segmentsPath = this.outputPath.replace(/\.webm$/, '-segments.json')
     writeFileSync(segmentsPath, JSON.stringify({ segments }, null, 2))
@@ -217,6 +245,15 @@ class VideoRecorderInstance {
       droppedFrames: this.droppedFrames,
       segments,
     }
+  }
+
+  private restoreCamera(): void {
+    if (!this.savedCamera) return
+    const saved = this.savedCamera
+    this.savedCamera = null
+    if (getZoom() !== saved.zoom) setZoom(saved.zoom)
+    setPan(saved.panX, saved.panY)
+    requestLayout()
   }
 
   getState(): RecordingState {

--- a/src/main/runtime/video-recorder.ts
+++ b/src/main/runtime/video-recorder.ts
@@ -115,49 +115,49 @@ class VideoRecorderInstance {
       if (this.captureWidth === 0 || this.captureHeight === 0) {
         throw new Error('Canvas view has zero dimensions')
       }
+
+      // Spawn ffmpeg to accept raw BGRA frames on stdin.
+      // Use VP9 with realtime deadline for fast encoding at high resolution.
+      this.ffmpeg = spawn('ffmpeg', [
+        '-y',
+        '-f', 'rawvideo',
+        '-pixel_format', 'bgra',
+        '-video_size', `${this.captureWidth}x${this.captureHeight}`,
+        '-framerate', String(this.fps),
+        '-i', 'pipe:0',
+        '-c:v', 'libvpx-vp9',
+        '-crf', String(this.crf),
+        '-b:v', '0',
+        '-deadline', 'realtime',
+        '-cpu-used', '8',
+        '-row-mt', '1',
+        this.outputPath,
+      ], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+
+      this.ffmpeg.on('error', (err) => {
+        console.error('[video-recorder] ffmpeg error:', err.message)
+      })
+
+      this.ffmpeg.stderr?.on('data', (chunk: Buffer) => {
+        // Log ffmpeg progress/errors but don't spam.
+        const msg = chunk.toString().trim()
+        if (msg.includes('Error') || msg.includes('error')) {
+          console.error('[video-recorder] ffmpeg:', msg)
+        }
+      })
+
+      this.startedAt = Date.now()
+      this.activityTracker.start()
+
+      // Start the capture loop.
+      const intervalMs = Math.round(1000 / this.fps)
+      this.captureTimer = setInterval(() => this.captureFrame(), intervalMs)
     } catch (error) {
       this.restoreCamera()
       throw error
     }
-
-    // Spawn ffmpeg to accept raw BGRA frames on stdin.
-    // Use VP9 with realtime deadline for fast encoding at high resolution.
-    this.ffmpeg = spawn('ffmpeg', [
-      '-y',
-      '-f', 'rawvideo',
-      '-pixel_format', 'bgra',
-      '-video_size', `${this.captureWidth}x${this.captureHeight}`,
-      '-framerate', String(this.fps),
-      '-i', 'pipe:0',
-      '-c:v', 'libvpx-vp9',
-      '-crf', String(this.crf),
-      '-b:v', '0',
-      '-deadline', 'realtime',
-      '-cpu-used', '8',
-      '-row-mt', '1',
-      this.outputPath,
-    ], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    })
-
-    this.ffmpeg.on('error', (err) => {
-      console.error('[video-recorder] ffmpeg error:', err.message)
-    })
-
-    this.ffmpeg.stderr?.on('data', (chunk: Buffer) => {
-      // Log ffmpeg progress/errors but don't spam.
-      const msg = chunk.toString().trim()
-      if (msg.includes('Error') || msg.includes('error')) {
-        console.error('[video-recorder] ffmpeg:', msg)
-      }
-    })
-
-    this.startedAt = Date.now()
-    this.activityTracker.start()
-
-    // Start the capture loop.
-    const intervalMs = Math.round(1000 / this.fps)
-    this.captureTimer = setInterval(() => this.captureFrame(), intervalMs)
   }
 
   private async captureFrame(): Promise<void> {

--- a/src/main/runtime/view-refs.ts
+++ b/src/main/runtime/view-refs.ts
@@ -11,7 +11,8 @@ export let devtoolsBackgroundView: WebContentsView | null = null
 export let devtoolsHeaderView: WebContentsView | null = null
 export let devtoolsView: WebContentsView | null = null
 export let devtoolsResizeHandleView: WebContentsView | null = null
-/** Consolidated above-pages WCV: input gate + marquee + comments + presence + annotations + drawing + floating-ui. */
+/** Consolidated above-pages WCV: input gate + marquee + comments + annotations + drawing + floating-ui.
+ *  Agent-presence cursors render in cursorOverlayWindow (below), not here. */
 export let aboveView: WebContentsView | null = null
 /** Child BrowserWindow sibling of `win` — transparent, frameless, mouse-inert.
  *  Hosts agent-presence cursors only. Lives outside the WCV stack because


### PR DESCRIPTION
## Summary

Fixes video recording so recorded frames faithfully reproduce what's on screen — agent presence cursors are included, overlays land in the right place, and pages capture at native resolution regardless of canvas zoom.

- **Include agent presence cursors in captured frames.** `frame-compositor.ts` now composites three layers in z-order — page content, `aboveView` (comments, annotations, drawing, marquee, floating UI), and `cursorOverlayWindow` (the transparent child `BrowserWindow` that hosts presence cursors + particle trails). Previously only `aboveView` was composited.
- **Translate cursor overlay screen bounds to window-relative.** `cursorOverlayWindow.getBounds()` is in screen coords while `aboveView.getBounds()` is window-relative. The crop math assumed a single coordinate space, so without translation the cursor overlay was blended against the wrong rect.
- **Force canvas zoom=1 during recording.** Canvas zoom is wired into Chromium's device emulation `scale`, so at zoom<1 the page renders into only a sub-region of its emulated viewport. Recording now saves the camera, sets zoom=1, focuses the page, and restores on stop so captures are always 1:1 native.
- **Parallelize overlay captures and harden init.** The three `capturePage()` calls now run concurrently, `boundScreenBoundsForPage` is hoisted out of the inner helper, and the ffmpeg spawn is inside the init try/catch so `savedCamera` is always restored on failure.

## Test plan

- [ ] Record a short video at canvas zoom < 1 and confirm the output is native resolution (not a shrunken sub-region)
- [ ] Record a video with an agent driving the canvas; confirm the presence cursor + particle trail appear in the output
- [ ] Record while a comment / annotation / drawing is visible and confirm they still appear
- [ ] Confirm canvas zoom + pan snap back to pre-recording state on stop
- [ ] Confirm recording still cleans up if ffmpeg spawn fails (e.g., kill \`ffmpeg\` on PATH and start recording — zoom should restore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)