### PR TITLE
Fix sticky note resize and edit focus

### DIFF
--- a/src/main/runtime/focus-reconciler.ts
+++ b/src/main/runtime/focus-reconciler.ts
@@ -42,8 +42,9 @@ export function expectedFocus(state: FocusState): FocusTarget {
     case 'dragging-edge':
       return { kind: 'aboveView' }
     case 'editing-text':
-      // Text editing lives in the above-view bundle today (floating-ui).
-      return { kind: 'aboveView' }
+      // Inline canvas editors (sticky notes, markdown files, wireframes)
+      // live in bgView, so keep focus there while typing.
+      return { kind: 'bgView' }
     case 'idle':
       break
   }

--- a/src/main/runtime/gate-predicate.ts
+++ b/src/main/runtime/gate-predicate.ts
@@ -5,7 +5,7 @@
  * needs to intercept pointer input or paint canvas-level UI: during any
  * non-idle gesture, while a non-select tool is armed, while space-pan is
  * held, while a marquee is showing,
- * while a selected text/drawing entity's inline menu is on screen, and
+ * while a selected drawing entity's inline menu is on screen, and
  * while saved drawings are visible above unselected frames.
  *
  * The predicate is pure and testable. Its authority is main: the renderer
@@ -30,7 +30,7 @@ export type GateInputs = {
 }
 
 export function shouldGateBeOpen(inputs: GateInputs): boolean {
-  if (inputs.interactionKind !== 'idle') return true
+  if (interactionOpensGate(inputs.interactionKind)) return true
   if (toolModeOpensGate(inputs.toolMode)) return true
   if (inputs.commentOverlayActive) return true
   if (inputs.spaceHeld) return true
@@ -40,6 +40,10 @@ export function shouldGateBeOpen(inputs: GateInputs): boolean {
   if (hasFloatingMenu(inputs)) return true
   if (hasVisibleSavedDrawings(inputs)) return true
   return false
+}
+
+function interactionOpensGate(interactionKind: GateInputs['interactionKind']): boolean {
+  return interactionKind !== 'idle' && interactionKind !== 'editing-text'
 }
 
 /**
@@ -58,7 +62,9 @@ function hasFloatingMenu(inputs: GateInputs): boolean {
   if (inputs.viewMode !== 'canvas') return false
   if (inputs.selectedEntityIds.length !== 1) return false
   const kind = inputs.selectedEntityKinds[0]
-  return kind === 'text' || kind === 'drawing'
+  // Sticky-note controls render in bgView so text selection can keep
+  // native pointer access to the card and its resize handles.
+  return kind === 'drawing'
 }
 
 /**

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -33,7 +33,7 @@ import {
   RegionSelectComposer,
 } from './CommentsLayer'
 import { MarqueeLayer } from './MarqueeLayer'
-import { FloatingUiLayer, hasFloatingMenu } from './FloatingUiLayer'
+import { FloatingUiLayer } from './FloatingUiLayer'
 import { useAnnotationDrawingGestures } from './useAnnotationDrawingGestures'
 import { useAnnotationDraftState } from './useAnnotationDraftState'
 import { useAnnotationThreadState } from './useAnnotationThreadState'

--- a/src/renderer/above-view/FloatingUiLayer.tsx
+++ b/src/renderer/above-view/FloatingUiLayer.tsx
@@ -3,15 +3,12 @@ import { DRAWING_FEATURE_ENABLED } from '../../shared/featureFlags'
 import type {
   CanvasBgElectronAPI,
   CanvasSceneDrawingEntity,
-  CanvasSceneTextEntity,
   LayoutUpdateData,
 } from '../../shared/types'
-import { SELECTED_FRAME_MENU_SHOW_DELAY_MS } from '../../shared/selectedFrameMenu'
-import { StickyNoteInlineMenu } from '../canvas-bg/InlineEntityMenu'
 import { DrawingInlineMenu } from './DrawingInlineMenu'
 
 /**
- * FloatingUiLayer — inline menus for selected text / drawing entities.
+ * FloatingUiLayer — inline menus for selected drawing entities.
  *
  * Merged from the retired `floating-ui/` bundle. Reads `layoutData`
  * directly (no separate `floating-ui-update` IPC needed — above-view
@@ -29,17 +26,6 @@ export function FloatingUiLayer({
   isDark: boolean
   layoutData: LayoutUpdateData
 }) {
-  const selectedTextEntity = useMemo(() => {
-    if (layoutData.selectedEntityIds.length !== 1) return null
-    const [selectedId] = layoutData.selectedEntityIds
-    return (
-      layoutData.entities.find(
-        (entity): entity is CanvasSceneTextEntity =>
-          entity.kind === 'text' && entity.id === selectedId,
-      ) ?? null
-    )
-  }, [layoutData.entities, layoutData.selectedEntityIds])
-
   const selectedDrawingEntity = useMemo(() => {
     if (layoutData.selectedEntityIds.length !== 1) return null
     const [selectedId] = layoutData.selectedEntityIds
@@ -51,34 +37,9 @@ export function FloatingUiLayer({
     )
   }, [layoutData.entities, layoutData.selectedEntityIds])
 
-  const [delayedTextMenuId, setDelayedTextMenuId] = useState<string | null>(null)
-  const shouldQueueTextMenu =
-    layoutData.viewMode === 'canvas' &&
-    layoutData.interaction.kind === 'idle' &&
-    selectedTextEntity !== null
-
-  useEffect(() => {
-    if (!shouldQueueTextMenu || !selectedTextEntity) {
-      setDelayedTextMenuId(null)
-      return
-    }
-    const timeoutId = window.setTimeout(() => {
-      setDelayedTextMenuId(selectedTextEntity.id)
-    }, SELECTED_FRAME_MENU_SHOW_DELAY_MS)
-    return () => window.clearTimeout(timeoutId)
-  }, [selectedTextEntity, shouldQueueTextMenu])
-
   // Menus position themselves by screen coords. above-view's WCV starts
   // at y=canvasOrigin.y; translate screenY into within-WCV space.
   const originY = layoutData.canvasOrigin.y
-
-  const textNote = useMemo(() => {
-    if (!selectedTextEntity) return null
-    return {
-      ...selectedTextEntity,
-      screenY: selectedTextEntity.screenY - originY,
-    }
-  }, [selectedTextEntity, originY])
 
   const drawing = useMemo(() => {
     if (!selectedDrawingEntity) return null
@@ -88,21 +49,10 @@ export function FloatingUiLayer({
     }
   }, [selectedDrawingEntity, originY])
 
-  const showTextEntityMenu = textNote !== null && delayedTextMenuId === textNote.id
-
-  if (!showTextEntityMenu && !(DRAWING_FEATURE_ENABLED && drawing)) return null
+  if (!(DRAWING_FEATURE_ENABLED && drawing)) return null
 
   return (
     <>
-      {showTextEntityMenu && textNote ? (
-        <StickyNoteInlineMenu
-          isDark={isDark}
-          note={textNote}
-          onDuplicate={() => api.duplicateTextEntity(textNote.id)}
-          onDelete={() => api.deleteTextEntity(textNote.id)}
-          onSelectColor={(color) => api.updateTextEntity(textNote.id, { color })}
-        />
-      ) : null}
       {DRAWING_FEATURE_ENABLED && drawing ? (
         <DrawingInlineMenu
           drawing={drawing}
@@ -120,6 +70,6 @@ export function hasFloatingMenu(layoutData: LayoutUpdateData): boolean {
   if (layoutData.selectedEntityIds.length !== 1) return false
   const [id] = layoutData.selectedEntityIds
   return layoutData.entities.some(
-    (e) => e.id === id && (e.kind === 'text' || e.kind === 'drawing'),
+    (e) => e.id === id && e.kind === 'drawing',
   )
 }

--- a/src/renderer/canvas-bg/App.tsx
+++ b/src/renderer/canvas-bg/App.tsx
@@ -27,12 +27,13 @@ import { FileChromeLayer } from './FileChromeLayer'
 import { GroupBoundsLayer } from './GroupBoundsLayer'
 import { ActiveFrameHighlightLayer } from './AgentCursorLayer'
 import { EdgeLayer } from './EdgeLayer'
-import { GroupInlineMenu } from './InlineEntityMenu'
+import { GroupInlineMenu, StickyNoteInlineMenu } from './InlineEntityMenu'
 import { useCanvasLayoutState } from './useCanvasLayoutState'
 import { usePendingPlacementState } from './usePendingPlacementState'
 import { useCanvasViewportGestures } from './useCanvasViewportGestures'
 import { useFrameChromeDrag } from './useFrameChromeDrag'
 import { descendantIdsForGroup, selectedGroupHasDescendantFrame } from './groupMembership'
+import { SELECTED_FRAME_MENU_SHOW_DELAY_MS } from '../../shared/selectedFrameMenu'
 
 const api = (window as unknown as { electronAPI: CanvasBgElectronAPI }).electronAPI
 const GROUP_MENU_DELAY_MS = 150
@@ -116,12 +117,34 @@ export default function App({
     if (!layoutData.selectedGroupId) return null
     return (layoutData.groups ?? []).find((group) => group.id === layoutData.selectedGroupId) ?? null
   }, [layoutData.groups, layoutData.selectedGroupId])
+  const selectedTextEntity = useMemo(() => {
+    if (layoutData.selectedEntityIds.length !== 1) return null
+    const [selectedId] = layoutData.selectedEntityIds
+    return textEntities.find((entity) => entity.id === selectedId) ?? null
+  }, [layoutData.selectedEntityIds, textEntities])
   const selectedGroupDescendantIds = useMemo(() => {
     if (!layoutData.selectedGroupId) return new Set<string>()
     return descendantIdsForGroup(layoutData.groups ?? [], layoutData.selectedGroupId)
   }, [layoutData.groups, layoutData.selectedGroupId])
   const selectedGroupControlsMirroredToAboveView = selectedGroupHasDescendantFrame(layoutData)
+  const [delayedSelectedTextMenuId, setDelayedSelectedTextMenuId] = useState<string | null>(null)
   const [delayedSelectedGroupMenuId, setDelayedSelectedGroupMenuId] = useState<string | null>(null)
+  const shouldQueueSelectedTextMenu =
+    layoutData.viewMode === 'canvas' &&
+    layoutData.interaction.kind === 'idle' &&
+    selectedTextEntity !== null
+  useEffect(() => {
+    if (!shouldQueueSelectedTextMenu || !selectedTextEntity) {
+      setDelayedSelectedTextMenuId(null)
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setDelayedSelectedTextMenuId(selectedTextEntity.id)
+    }, SELECTED_FRAME_MENU_SHOW_DELAY_MS)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [selectedTextEntity, shouldQueueSelectedTextMenu])
   const shouldQueueSelectedGroupMenu =
     layoutData.viewMode === 'canvas' &&
     layoutData.interaction.kind === 'idle' &&
@@ -138,6 +161,8 @@ export default function App({
 
     return () => window.clearTimeout(timeoutId)
   }, [selectedGroupEntity, shouldQueueSelectedGroupMenu])
+  const showSelectedTextMenu =
+    selectedTextEntity !== null && delayedSelectedTextMenuId === selectedTextEntity.id
   const showSelectedGroupMenu =
     selectedGroupEntity !== null && delayedSelectedGroupMenuId === selectedGroupEntity.id
   const hoveredEntityId = layoutData.hover?.id ?? null
@@ -361,6 +386,18 @@ export default function App({
         ) : null}
 
       </div>
+
+      {showSelectedTextMenu ? (
+        selectedTextEntity ? (
+          <StickyNoteInlineMenu
+            isDark={isDark}
+            note={selectedTextEntity}
+            onDuplicate={() => api.duplicateTextEntity(selectedTextEntity.id)}
+            onDelete={() => api.deleteTextEntity(selectedTextEntity.id)}
+            onSelectColor={(color) => api.updateTextEntity(selectedTextEntity.id, { color })}
+          />
+        ) : null
+      ) : null}
 
       {showSelectedGroupMenu ? (
         selectedGroupEntity ? (

--- a/src/renderer/canvas-bg/CanvasSelectionLayers.tsx
+++ b/src/renderer/canvas-bg/CanvasSelectionLayers.tsx
@@ -159,6 +159,7 @@ function EntitySelectionOverlay({
   const aspectRatioResizeMode =
     entity.kind === 'file' ? aspectRatioResizeModeForCanvasFile(entity.file) : 'off'
   const zoom = entity.width > 0 ? entity.screenWidth / entity.width : 1
+  const overlayOwnsResizeHandles = entity.kind === 'drawing'
 
   return (
     <div
@@ -170,7 +171,7 @@ function EntitySelectionOverlay({
         height: entity.screenHeight + 4,
         borderColor: selectionColor(isDark),
         borderRadius,
-        pointerEvents: isSelected ? 'auto' : 'none',
+        pointerEvents: isSelected && overlayOwnsResizeHandles ? 'auto' : 'none',
         cursor: isSelected && entity.kind === 'drawing' ? 'grab' : undefined,
       }}
       data-overlay-ui
@@ -180,7 +181,7 @@ function EntitySelectionOverlay({
         onMouseDown(entity.id, event)
       }}
     >
-      {isSelected && showResizeHandles ? (
+      {isSelected && showResizeHandles && overlayOwnsResizeHandles ? (
         <SelectionResizeGrid
           id={entity.id}
           width={entity.width}

--- a/src/renderer/canvas-bg/FileBlockLayer.tsx
+++ b/src/renderer/canvas-bg/FileBlockLayer.tsx
@@ -186,7 +186,6 @@ function FileBlockCard({
       onGroupDragStart={onGroupDragStart}
       onGroupDrag={onGroupDrag}
       onGroupDragEnd={onGroupDragEnd}
-      showResizeHandles={false}
       aspectRatioResizeMode={aspectRatioResizeModeForCanvasFile(entity.file)}
       shouldStartDrag={(event) => {
         if (canEdit && (isMarkdown || isVideo || isWireframe)) return false

--- a/src/renderer/canvas-bg/TextBlockLayer.tsx
+++ b/src/renderer/canvas-bg/TextBlockLayer.tsx
@@ -93,7 +93,6 @@ function TextBlockCard({
       onGroupDragStart={onGroupDragStart}
       onGroupDrag={onGroupDrag}
       onGroupDragEnd={onGroupDragEnd}
-      showResizeHandles={false}
       shouldStartDrag={(event) => {
         if (canEdit) return false
         const target = event.target as HTMLElement | null

--- a/src/renderer/canvas-bg/TextBlockLayer.tsx
+++ b/src/renderer/canvas-bg/TextBlockLayer.tsx
@@ -117,11 +117,13 @@ function TextBlockCard({
         />
         {canEdit ? (
           <textarea
-            className="text-block-textarea flex-1 w-full resize-none border-none outline-none bg-transparent px-2 pb-2"
+            className="text-block-textarea flex-1 w-full resize-none border-none outline-none bg-transparent px-2.5 pb-2"
             style={{
+              boxSizing: 'border-box',
               fontSize: 12,
               color: 'rgb(0, 0, 0)',
               fontFamily: 'system-ui, sans-serif',
+              paddingTop: '0.3em',
             }}
             value={localText}
             placeholder="Type a note..."

--- a/tests/unit/focus-reconciler.test.ts
+++ b/tests/unit/focus-reconciler.test.ts
@@ -34,9 +34,9 @@ describe('expectedFocus', () => {
     })
   }
 
-  it('editing-text routes to aboveView', () => {
+  it('editing-text routes to bgView', () => {
     expect(expectedFocus(state({ interactionMode: 'editing-text', editingTextEntityId: 'e1' })))
-      .toEqual({ kind: 'aboveView' })
+      .toEqual({ kind: 'bgView' })
   })
 
   it('routes to aboveView when comment overlay is active', () => {

--- a/tests/unit/gate-predicate.test.ts
+++ b/tests/unit/gate-predicate.test.ts
@@ -28,9 +28,12 @@ describe('shouldGateBeOpen', () => {
     'dragging-entities',
     'resizing-entity',
     'dragging-edge',
-    'editing-text',
   ] as const)('open when interaction is %s', (kind) => {
     expect(shouldGateBeOpen({ ...base(), interactionKind: kind })).toBe(true)
+  })
+
+  it('stays closed while inline text is being edited', () => {
+    expect(shouldGateBeOpen({ ...base(), interactionKind: 'editing-text' })).toBe(false)
   })
 
   it.each(['annotate-draw', 'annotate-region-select'] as const)(
@@ -72,14 +75,14 @@ describe('shouldGateBeOpen', () => {
     ).toBe(true)
   })
 
-  it('open for single text selection (floating menu)', () => {
+  it('closed for single text selection (menu stays in bgView)', () => {
     expect(
       shouldGateBeOpen({
         ...base(),
         selectedEntityIds: ['t1'],
         selectedEntityKinds: ['text'],
       }),
-    ).toBe(true)
+    ).toBe(false)
   })
 
   it('open for single drawing selection (floating menu)', () => {


### PR DESCRIPTION
## Summary
- Move sticky note selection/menu handling fully into `canvas-bg` so note resize handles stay interactive.
- Keep inline text editing focused in `bgView` instead of reopening the `aboveView` gate.
- Update selection/focus tests to cover the corrected sticky note behavior.

## Testing
- `pnpm typecheck`
- `pnpm test:unit`
- Local UI verification of sticky note resize and double-click edit behavior