### PR TITLE
fix(drawing): keep stroke width uniform regardless of velocity

### DIFF
--- a/src/renderer/above-view/DrawingsLayer.tsx
+++ b/src/renderer/above-view/DrawingsLayer.tsx
@@ -9,9 +9,10 @@ function freehandPathD(points: { x: number; y: number }[], size: number): string
     points.map((p) => [p.x, p.y]),
     {
       size: size * 1.6,
-      thinning: 0.5,
+      thinning: 0,
       smoothing: 0.8,
       streamline: 0.75,
+      simulatePressure: false,
       last: true,
     },
   )


### PR DESCRIPTION
## Summary

- Disable perfect-freehand's velocity-based thinning (`thinning: 0`) and turn off `simulatePressure` in `DrawingsLayer.freehandPathD` so drawn strokes render at a consistent width.

## Test plan

- [ ] Draw fast and slow strokes — width stays uniform along each stroke
- [ ] Stroke width still respects the selected size and zoom level