### PR TITLE
feat(shape): add rectangle, ellipse, and diamond shape entities

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -40,6 +40,7 @@ import { workspaceGroups, workspaceEdges, workspaceAnnotations, workspaceTabs, a
 import { textEntities } from './runtime/text-entity-state'
 import { fileEntities } from './runtime/file-entity-state'
 import { drawingEntities } from './runtime/drawing-entity-state'
+import { shapeEntities } from './runtime/shape-entity-state'
 import { getUiState, setSelection } from './ui-state'
 import { destroyActivePages } from './runtime/runtime-core'
 import { initAutoUpdater } from './auto-updater'
@@ -194,6 +195,7 @@ app.whenReady().then(async () => {
     textEntities,
     fileEntities,
     drawingEntities,
+    shapeEntities,
     workspaceGroups,
     workspaceEdges,
     workspaceAnnotations,

--- a/src/main/ipc/register-canvas-drag-ipc.ts
+++ b/src/main/ipc/register-canvas-drag-ipc.ts
@@ -30,6 +30,7 @@ import {
 import { setSelectionOverlayRect } from '../runtime/window-shell'
 import { resolveEntityKind, selectNone, selectedDragEntityIds } from '../runtime/selection-controller'
 import { createEdges } from '../workspace-edges'
+import { deleteEdge, updateEdge } from '../runtime/document-commands'
 import {
   copyableFramePayload,
   copyableSelectionPayload,
@@ -307,6 +308,43 @@ export function registerCanvasDragIpc(): void {
         return
       }
       selectNone()
+    },
+  )
+
+  ipcMain.on(
+    'canvas-edge-edit-commit',
+    (
+      _event,
+      {
+        edgeId,
+        movingEnd,
+        targetEntityId,
+        targetSide,
+      }: {
+        edgeId: string
+        movingEnd: 'from' | 'to'
+        targetEntityId: string
+        targetSide: EdgeSide
+      },
+    ) => {
+      if (movingEnd === 'from') {
+        updateEdge(edgeId, { fromEntityId: targetEntityId, fromSide: targetSide })
+      } else {
+        updateEdge(edgeId, { toEntityId: targetEntityId, toSide: targetSide })
+      }
+      commitActive()
+      setHoverEntity(null)
+      layoutAllViews()
+    },
+  )
+
+  ipcMain.on(
+    'canvas-edge-edit-discard',
+    (_event, { edgeId }: { edgeId: string }) => {
+      deleteEdge(edgeId)
+      cancelActive('escape')
+      setHoverEntity(null)
+      layoutAllViews()
     },
   )
 }

--- a/src/main/ipc/register-canvas-entity-ipc.ts
+++ b/src/main/ipc/register-canvas-entity-ipc.ts
@@ -7,17 +7,20 @@ import type {
   ClipboardEntitySelectionPayload,
 } from '../../shared/types'
 import { pages } from '../runtime/page-runtime'
-import { aboveView } from '../runtime/view-refs'
+import { aboveView, bgView } from '../runtime/view-refs'
 import { setPendingFocus } from '../runtime/runtime-context'
 import { executeRegionSelect } from '../runtime/region-select'
 import { setCommentOverlayActive } from '../runtime/runtime-core'
 import { textEntities } from '../runtime/text-entity-state'
 import { fileEntities } from '../runtime/file-entity-state'
 import { drawingEntities, createDrawingEntity as createDrawingEntityInState } from '../runtime/drawing-entity-state'
+import { shapeEntities } from '../runtime/shape-entity-state'
 import {
   createFileEntity,
+  createShapeEntity,
   createTextEntity,
   deleteDrawingEntity,
+  deleteShapeEntity,
   deleteTextEntity,
   deleteFileEntity,
   setFrameCustom,
@@ -25,6 +28,7 @@ import {
   updateDrawingEntity,
   updateFileEntity,
   updateGroupEntity,
+  updateShapeEntity,
   updateTextEntity,
   resizeMultiSelection,
   groupSelectedEntities,
@@ -131,7 +135,16 @@ function parseClipboardSelection(
 export function registerCanvasEntityIpc(): void {
   ipcMain.on(
     'canvas-place-pending-entity',
-    (_event, { canvasX, canvasY }: { canvasX: number; canvasY: number }) => {
+    (
+      _event,
+      payload: {
+        canvasX: number
+        canvasY: number
+        dragRect?: { x: number; y: number; width: number; height: number } | null
+      },
+    ) => {
+      const { canvasX, canvasY } = payload
+      const dragRect = payload.dragRect ?? null
       const placement = pendingPlacement()
       if (!placement) return
       if (placement.entityKind === 'text') {
@@ -142,6 +155,21 @@ export function registerCanvasEntityIpc(): void {
           createFileEntity({ canvasX, canvasY, file: filePath, width: 300, height: 300 })
         } catch (error) {
           console.error('Failed to create note file:', error)
+        }
+      } else if (placement.entityKind === 'shape') {
+        const shapeKind = placement.shapeKind ?? 'rectangle'
+        const created = dragRect
+          ? createShapeEntity({
+              canvasX: dragRect.x,
+              canvasY: dragRect.y,
+              width: dragRect.width,
+              height: dragRect.height,
+              shapeKind,
+            })
+          : createShapeEntity({ canvasX, canvasY, shapeKind })
+        selectEntity(created.id, 'shape')
+        if (bgView && !bgView.webContents.isDestroyed()) {
+          bgView.webContents.send('shape-begin-edit', { entityId: created.id })
         }
       } else {
         createFrameAtPosition({
@@ -177,10 +205,12 @@ export function registerCanvasEntityIpc(): void {
     const textIds = entityIds.filter((id) => textEntities.some((n) => n.id === id))
     const fileIds = entityIds.filter((id) => fileEntities.some((f) => f.id === id))
     const drawingIds = entityIds.filter((id) => drawingEntities.some((d) => d.id === id))
+    const shapeIds = entityIds.filter((id) => shapeEntities.some((s) => s.id === id))
     if (frameIds.length) deleteFrames({ frameIds })
     for (const id of textIds) deleteTextEntity(id)
     for (const id of fileIds) deleteFileEntity(id)
     for (const id of drawingIds) deleteDrawingEntity(id)
+    for (const id of shapeIds) deleteShapeEntity(id)
   })
 
   ipcMain.on('canvas-delete-frame', (_event, { frameId }: { frameId: string }) => {
@@ -228,7 +258,8 @@ export function registerCanvasEntityIpc(): void {
       const te = textEntities.find((t) => t.id === entityId)
       const fe = fileEntities.find((f) => f.id === entityId)
       const de = drawingEntities.find((d) => d.id === entityId)
-      const entity = te ?? fe ?? de
+      const se = shapeEntities.find((s) => s.id === entityId)
+      const entity = te ?? fe ?? de ?? se
       if (entity) {
         focusCanvasBounds({ x: entity.canvasX, y: entity.canvasY, width: entity.width, height: entity.height })
       }
@@ -244,6 +275,8 @@ export function registerCanvasEntityIpc(): void {
         deleteFileEntity(entityId)
       } else if (entityKind === 'drawing') {
         deleteDrawingEntity(entityId)
+      } else if (entityKind === 'shape') {
+        deleteShapeEntity(entityId)
       }
       layoutAllViews()
     },
@@ -559,6 +592,38 @@ export function registerCanvasEntityIpc(): void {
 
   ipcMain.on('canvas-duplicate-text-entity', (_event, { id }: { id: string }) => {
     duplicateEntity({ entityId: id, focus: true })
+  })
+
+  // --- Shape Entity IPC ---
+
+  ipcMain.on(
+    'canvas-update-shape',
+    (
+      _event,
+      {
+        id,
+        patch,
+      }: {
+        id: string
+        patch: Partial<{
+          shapeKind: 'rectangle' | 'ellipse' | 'diamond'
+          text: string
+          color: string
+          strokeWidth: number
+          theme: string
+          width: number
+          height: number
+          canvasX: number
+          canvasY: number
+        }>
+      },
+    ) => {
+      updateShapeEntity(id, patch)
+    },
+  )
+
+  ipcMain.on('canvas-delete-shape', (_event, { id }: { id: string }) => {
+    deleteShapeEntity(id)
   })
 
   // --- File Entity IPC ---

--- a/src/main/ipc/register-canvas-ipc.ts
+++ b/src/main/ipc/register-canvas-ipc.ts
@@ -4,7 +4,7 @@ import type { CanvasEntityKind, SelectionModifiers } from '../../shared/types'
 import type { EdgeSide } from '../../shared/types'
 import { selectionMutationMode } from '../../shared/selection-modifiers'
 import { pages } from '../runtime/page-runtime'
-import { aboveView } from '../runtime/view-refs'
+import { aboveView, bgView } from '../runtime/view-refs'
 import { setCommentOverlayActive } from '../runtime/runtime-core'
 import { setHoverEntity, setHoveredFrame } from '../runtime/runtime-core'
 import { annotationMode as uiAnnotationMode, selectedCanvasTargets as uiSelectedCanvasTargets } from '../ui-state'
@@ -168,8 +168,20 @@ export function registerCanvasIpc(): void {
   })
 
   const VALID_ENTITY_KINDS: ReadonlySet<CanvasEntityKind> = new Set<CanvasEntityKind>(
-    DRAWING_FEATURE_ENABLED ? ['frame', 'text', 'file', 'drawing', 'edge'] : ['frame', 'text', 'file', 'edge'],
+    DRAWING_FEATURE_ENABLED
+      ? ['frame', 'text', 'file', 'drawing', 'shape', 'edge']
+      : ['frame', 'text', 'file', 'shape', 'edge'],
   )
+  const INLINE_TEXT_EDIT_ENTITY_KINDS: ReadonlySet<CanvasEntityKind> = new Set<CanvasEntityKind>([
+    'frame',
+    'text',
+    'file',
+    'shape',
+  ])
+  const selectedInlineTextEditEntityId = () =>
+    uiSelectedCanvasTargets().find((target) =>
+      INLINE_TEXT_EDIT_ENTITY_KINDS.has(target.kind)
+    )?.id ?? null
 
   ipcMain.on(
     'canvas-select-entity',
@@ -208,12 +220,13 @@ export function registerCanvasIpc(): void {
 
   ipcMain.on('canvas-set-text-editing', (event, { active }: { active: boolean }) => {
     setTextEditingActive(event.sender, active)
-    if (active) {
-      const selectedTextId = uiSelectedCanvasTargets().find((target) => target.kind === 'text')?.id
-      if (selectedTextId) tryEnter({ kind: 'editing-text', entityId: selectedTextId })
-    } else {
-      commitActive()
+    const isCanvasBgEditor = bgView?.webContents === event.sender
+    if (active && isCanvasBgEditor) {
+      const selectedEntityId = selectedInlineTextEditEntityId()
+      if (selectedEntityId) tryEnter({ kind: 'editing-text', entityId: selectedEntityId })
+      return
     }
+    if (!active) commitActive()
   })
 
   // --- Browser mode ---

--- a/src/main/ipc/register-toolbar-ipc.ts
+++ b/src/main/ipc/register-toolbar-ipc.ts
@@ -201,4 +201,14 @@ export function registerToolbarIpc(): void {
       entityKind: 'file',
     })
   })
+
+  ipcMain.on(
+    'toolbar-add-shape',
+    (_event, payload: { shapeKind: 'rectangle' | 'ellipse' | 'diamond' }) => {
+      startPendingPlacement({
+        entityKind: 'shape',
+        shapeKind: payload?.shapeKind ?? 'rectangle',
+      })
+    },
+  )
 }

--- a/src/main/runtime/canvas-layout-data.ts
+++ b/src/main/runtime/canvas-layout-data.ts
@@ -86,6 +86,12 @@ import {
   drawingEntitiesForUi,
   buildDrawingEntitySceneEntity,
 } from './drawing-entity-state'
+import {
+  shapeEntities,
+  buildShapeEntitySceneEntity,
+  DEFAULT_SHAPE_WIDTH,
+  DEFAULT_SHAPE_HEIGHT,
+} from './shape-entity-state'
 import { buildGroupSceneEntity } from './group-entity-state'
 import type { Page } from './runtime-entities'
 import { workspaceTabSummaries } from './workspace-tabs'
@@ -265,6 +271,7 @@ function buildUserGroupSceneEntities(
         ...textEntities.filter((entity) => entity.parentGroupId === g.id).map((entity) => entity.id),
         ...fileEntities.filter((entity) => entity.parentGroupId === g.id).map((entity) => entity.id),
         ...drawingEntitiesForUi().filter((entity) => entity.parentGroupId === g.id).map((entity) => entity.id),
+        ...shapeEntities.filter((entity) => entity.parentGroupId === g.id).map((entity) => entity.id),
         ...workspaceGroups.filter((candidate) => candidate.parentGroupId === g.id).map((group) => group.id),
       ]
       return buildGroupSceneEntity(g, zoom, pan, origin, entityIds)
@@ -284,8 +291,9 @@ export function buildCanvasLayoutData(
       ? (() => {
           const isText = pending.entityKind === 'text'
           const isFile = pending.entityKind === 'file'
+          const isShape = pending.entityKind === 'shape'
           const sourcePage = pending.sourceFrameId ? findPageById(pending.sourceFrameId) : null
-          const preset = (isText || isFile) ? null : viewportPresetForIndex(pending.presetIndex ?? 0)
+          const preset = (isText || isFile || isShape) ? null : viewportPresetForIndex(pending.presetIndex ?? 0)
           const customSize = sourcePage ? pageContentSize(sourcePage) : localFillBrowserViewportSize()
           const contentBounds = mainWindowContentBounds()
           const cursor = screen.getCursorScreenPoint()
@@ -304,20 +312,25 @@ export function buildCanvasLayoutData(
           return {
             entityKind: pending.entityKind,
             presetIndex: pending.presetIndex,
+            shapeKind: pending.shapeKind,
             width: isText
               ? DEFAULT_TEXT_WIDTH
               : isFile
                 ? DEFAULT_FILE_WIDTH
-                : pending.customSize
-                  ? customSize.width
-                  : (preset?.width ?? 0),
+                : isShape
+                  ? DEFAULT_SHAPE_WIDTH
+                  : pending.customSize
+                    ? customSize.width
+                    : (preset?.width ?? 0),
             height: isText
               ? DEFAULT_TEXT_HEIGHT
               : isFile
                 ? DEFAULT_FILE_HEIGHT
-                : pending.customSize
-                  ? customSize.height
-                  : (preset?.height ?? 0),
+                : isShape
+                  ? DEFAULT_SHAPE_HEIGHT
+                  : pending.customSize
+                    ? customSize.height
+                    : (preset?.height ?? 0),
             initialClientX,
             initialClientY,
           }
@@ -339,6 +352,9 @@ export function buildCanvasLayoutData(
       ),
       ...drawingEntitiesForUi().map((de) =>
         buildDrawingEntitySceneEntity(de, zoom, pan, origin)
+      ),
+      ...shapeEntities.map((se) =>
+        buildShapeEntitySceneEntity(se, zoom, pan, origin)
       ),
       ...groupEntities,
     ] as CanvasSceneEntity[],

--- a/src/main/runtime/canvas-layout-data.ts
+++ b/src/main/runtime/canvas-layout-data.ts
@@ -89,8 +89,7 @@ import {
 import {
   shapeEntities,
   buildShapeEntitySceneEntity,
-  DEFAULT_SHAPE_WIDTH,
-  DEFAULT_SHAPE_HEIGHT,
+  defaultShapeSize,
 } from './shape-entity-state'
 import { buildGroupSceneEntity } from './group-entity-state'
 import type { Page } from './runtime-entities'
@@ -309,6 +308,9 @@ export function buildCanvasLayoutData(
             cursor.y <= contentBounds.y + contentBounds.height
               ? cursor.y - contentBounds.y
               : null
+          const shapeDefault = isShape
+            ? defaultShapeSize(pending.shapeKind ?? 'rectangle')
+            : null
           return {
             entityKind: pending.entityKind,
             presetIndex: pending.presetIndex,
@@ -317,8 +319,8 @@ export function buildCanvasLayoutData(
               ? DEFAULT_TEXT_WIDTH
               : isFile
                 ? DEFAULT_FILE_WIDTH
-                : isShape
-                  ? DEFAULT_SHAPE_WIDTH
+                : shapeDefault
+                  ? shapeDefault.width
                   : pending.customSize
                     ? customSize.width
                     : (preset?.width ?? 0),
@@ -326,8 +328,8 @@ export function buildCanvasLayoutData(
               ? DEFAULT_TEXT_HEIGHT
               : isFile
                 ? DEFAULT_FILE_HEIGHT
-                : isShape
-                  ? DEFAULT_SHAPE_HEIGHT
+                : shapeDefault
+                  ? shapeDefault.height
                   : pending.customSize
                     ? customSize.height
                     : (preset?.height ?? 0),

--- a/src/main/runtime/document-commands.ts
+++ b/src/main/runtime/document-commands.ts
@@ -72,6 +72,13 @@ import {
   textEntities,
   type TextEntity,
 } from './text-entity-state'
+import {
+  createShapeEntity as createShapeEntityInState,
+  updateShapeEntity as updateShapeEntityInState,
+  deleteShapeEntity as deleteShapeEntityInState,
+  shapeEntities,
+  type ShapeEntity,
+} from './shape-entity-state'
 import { workspaceEdges, workspaceGroups } from './workspace-model'
 import { beginBatch, endBatch } from './workspace-observers'
 import { scheduleWorkspaceAutosave } from './workspace-session'
@@ -104,6 +111,8 @@ function findMovableEntity(id: string): { canvasX: number; canvasY: number } | n
   if (fe) return fe
   const de = drawingEntities.find((e) => e.id === id)
   if (de) return de
+  const se = shapeEntities.find((e) => e.id === id)
+  if (se) return se
   const group = workspaceGroups.find((candidate) => candidate.id === id)
   if (group) return group
   return null
@@ -364,6 +373,57 @@ export function deleteDrawingEntity(id: string): boolean {
   return deleted
 }
 
+// --- Shape Entity Commands ---
+
+export function createShapeEntity(input: {
+  canvasX: number
+  canvasY: number
+  shapeKind?: ShapeEntity['shapeKind']
+  width?: number
+  height?: number
+  text?: string
+  color?: string
+  strokeWidth?: number
+  id?: string
+}): ShapeEntity {
+  const entity = createShapeEntityInState(input)
+  scheduleWorkspaceAutosave()
+  requestLayout()
+  return entity
+}
+
+export function updateShapeEntity(
+  id: string,
+  patch: Partial<Omit<ShapeEntity, 'id'>>,
+): ShapeEntity | null {
+  const snapped = { ...patch }
+  if (snapped.width !== undefined) snapped.width = snapToGrid(snapped.width)
+  if (snapped.height !== undefined) snapped.height = snapToGrid(snapped.height)
+  if (snapped.canvasX !== undefined) snapped.canvasX = snapToGrid(snapped.canvasX)
+  if (snapped.canvasY !== undefined) snapped.canvasY = snapToGrid(snapped.canvasY)
+  const entity = updateShapeEntityInState(id, snapped)
+  if (entity) {
+    scheduleWorkspaceAutosave()
+    requestLayout()
+  }
+  return entity
+}
+
+export function deleteShapeEntity(id: string): boolean {
+  const deleted = deleteShapeEntityInState(id)
+  if (deleted) {
+    removeEdgesTouchingEntities(new Set([id]))
+    updateSelectionForRemovedEntity(id)
+    scheduleWorkspaceAutosave()
+    requestLayout()
+  }
+  return deleted
+}
+
+export function getShapeEntities(): ShapeEntity[] {
+  return [...shapeEntities]
+}
+
 export function updateGroupEntity(
   id: string,
   patch: Partial<Omit<WorkspaceGroup, 'id' | 'kind'>>,
@@ -385,7 +445,7 @@ export function updateGroupEntity(
 
 export interface MultiResizeEntry {
   id: string
-  kind: 'frame' | 'text' | 'file' | 'drawing'
+  kind: 'frame' | 'text' | 'file' | 'drawing' | 'shape'
   width: number
   height: number
   canvasX: number
@@ -430,6 +490,14 @@ export function resizeMultiSelection(entries: MultiResizeEntry[]): void {
       if (entity) changed = true
     } else if (entry.kind === 'drawing') {
       const entity = updateDrawingEntityInState(entry.id, {
+        width: entry.width,
+        height: entry.height,
+        canvasX: entry.canvasX,
+        canvasY: entry.canvasY,
+      })
+      if (entity) changed = true
+    } else if (entry.kind === 'shape') {
+      const entity = updateShapeEntityInState(entry.id, {
         width: entry.width,
         height: entry.height,
         canvasX: entry.canvasX,

--- a/src/main/runtime/document-commands.ts
+++ b/src/main/runtime/document-commands.ts
@@ -220,10 +220,21 @@ export {
 
 export function updateEdge(
   id: string,
-  patch: { fromEnd?: EdgeEnd; toEnd?: EdgeEnd; fromSide?: EdgeSide; toSide?: EdgeSide; color?: string; label?: string },
+  patch: {
+    fromEntityId?: string
+    toEntityId?: string
+    fromEnd?: EdgeEnd
+    toEnd?: EdgeEnd
+    fromSide?: EdgeSide
+    toSide?: EdgeSide
+    color?: string
+    label?: string
+  },
 ): boolean {
   const edge = workspaceEdges.find((e) => e.id === id)
   if (!edge) return false
+  if (patch.fromEntityId !== undefined) edge.fromEntityId = patch.fromEntityId
+  if (patch.toEntityId !== undefined) edge.toEntityId = patch.toEntityId
   if (patch.fromEnd !== undefined) edge.fromEnd = patch.fromEnd
   if (patch.toEnd !== undefined) edge.toEnd = patch.toEnd
   if (patch.fromSide !== undefined) edge.fromSide = patch.fromSide

--- a/src/main/runtime/group-descendants.ts
+++ b/src/main/runtime/group-descendants.ts
@@ -1,6 +1,7 @@
 import { drawingEntities } from './drawing-entity-state'
 import { fileEntities } from './file-entity-state'
 import { pages } from './page-runtime'
+import { shapeEntities } from './shape-entity-state'
 import { textEntities } from './text-entity-state'
 import { workspaceGroups } from './workspace-model'
 
@@ -17,6 +18,7 @@ export function descendantEntityIdsForGroup(groupId: string): string[] {
       ...textEntities.filter((entity) => entity.parentGroupId === parentId).map((entity) => entity.id),
       ...fileEntities.filter((entity) => entity.parentGroupId === parentId).map((entity) => entity.id),
       ...drawingEntities.filter((entity) => entity.parentGroupId === parentId).map((entity) => entity.id),
+      ...shapeEntities.filter((entity) => entity.parentGroupId === parentId).map((entity) => entity.id),
       ...childGroupIds,
     )
 

--- a/src/main/runtime/inspect-session.ts
+++ b/src/main/runtime/inspect-session.ts
@@ -19,6 +19,7 @@ import type {
   PanelGroupEntityDetail,
   PanelMode,
   PanelMultiEntitySummary,
+  PanelShapeEntityDetail,
   PanelTextEntityDetail,
   SourceLocation,
 } from '../../shared/types'
@@ -60,6 +61,7 @@ import {
 import { textEntities } from './text-entity-state'
 import { fileEntities } from './file-entity-state'
 import { drawingEntities } from './drawing-entity-state'
+import { shapeEntities } from './shape-entity-state'
 import { getRendererTagFor } from '../plugins/registry'
 import {
   annotationMode as uiAnnotationMode,
@@ -325,6 +327,20 @@ function buildDrawingEntityDetail(entityId: string): PanelDrawingEntityDetail | 
   }
 }
 
+function buildShapeEntityDetail(entityId: string): PanelShapeEntityDetail | undefined {
+  const entity = shapeEntities.find((e) => e.id === entityId)
+  if (!entity) return undefined
+  return {
+    id: entity.id,
+    shapeKind: entity.shapeKind,
+    text: entity.text,
+    color: entity.color,
+    strokeWidth: entity.strokeWidth,
+    width: entity.width,
+    height: entity.height,
+  }
+}
+
 function buildEdgeEntityDetail(entityId: string): PanelEdgeEntityDetail | undefined {
   const edge = workspaceEdges.find((e) => e.id === entityId)
   if (!edge) return undefined
@@ -366,6 +382,8 @@ function resolveEntityLabel(entityId: string): string {
   if (file) return file.file.split('/').pop() ?? 'File'
   const drawing = drawingEntities.find((e) => e.id === entityId)
   if (drawing) return `Drawing (${drawing.strokes.length} stroke${drawing.strokes.length === 1 ? '' : 's'})`
+  const shape = shapeEntities.find((e) => e.id === entityId)
+  if (shape) return shape.text.slice(0, 30) || shape.shapeKind
   const group = workspaceGroups.find((g) => g.id === entityId)
   if (group) return group.label || 'Group'
   return entityId.slice(0, 8)
@@ -381,11 +399,12 @@ function buildMultiEntitySummaries(entityIds: string[]): PanelMultiEntitySummary
   }))
 }
 
-function buildEntityDetails(mode: PanelMode): Partial<Pick<DevtoolsPanelData, 'textEntity' | 'fileEntity' | 'drawingEntity' | 'edgeEntity' | 'groupEntity' | 'multiEntities'>> {
+function buildEntityDetails(mode: PanelMode): Partial<Pick<DevtoolsPanelData, 'textEntity' | 'fileEntity' | 'drawingEntity' | 'shapeEntity' | 'edgeEntity' | 'groupEntity' | 'multiEntities'>> {
   switch (mode.kind) {
     case 'text': return { textEntity: buildTextEntityDetail(mode.entityId) }
     case 'file': return { fileEntity: buildFileEntityDetail(mode.entityId) }
     case 'drawing': return { drawingEntity: buildDrawingEntityDetail(mode.entityId) }
+    case 'shape': return { shapeEntity: buildShapeEntityDetail(mode.entityId) }
     case 'edge': return { edgeEntity: buildEdgeEntityDetail(mode.entityId) }
     case 'group': return { groupEntity: buildGroupEntityDetail(mode.entityId) }
     case 'multi': return { multiEntities: buildMultiEntitySummaries(mode.entityIds) }

--- a/src/main/runtime/json-canvas-serializer.ts
+++ b/src/main/runtime/json-canvas-serializer.ts
@@ -14,6 +14,7 @@ import type {
   PersistedFileEntity,
   PersistedFrameEntity,
   PersistedGroupEntity,
+  PersistedShapeEntity,
   PersistedTextEntity,
   WorkspaceEdge,
   WorkspaceGroup,
@@ -27,6 +28,7 @@ import type {
   JsonCanvasGroupNode,
   JsonCanvasLinkNode,
   JsonCanvasNode,
+  JsonCanvasShapeNode,
   JsonCanvasTextNode,
   JsonCanvasAppState,
 } from '../../shared/json-canvas-types'
@@ -84,6 +86,8 @@ export function serializeToJsonCanvas(
       nodes.push(serializeGroupEntityToGroupNode(entity))
     } else if (entity.kind === 'drawing') {
       nodes.push(serializeDrawingToDrawingNode(entity))
+    } else if (entity.kind === 'shape') {
+      nodes.push(serializeShapeToShapeNode(entity))
     }
   }
 
@@ -155,6 +159,24 @@ function serializeFileToFileNode(entity: PersistedFileEntity): JsonCanvasFileNod
     objectFit: entity.objectFit,
     presetIndex: entity.presetIndex,
     metadata: entity.metadata,
+  }
+}
+
+function serializeShapeToShapeNode(entity: PersistedShapeEntity): JsonCanvasShapeNode {
+  return {
+    id: entity.id,
+    type: 'shape',
+    x: entity.canvasX,
+    y: entity.canvasY,
+    width: entity.width,
+    height: entity.height,
+    shapeKind: entity.shapeKind,
+    text: entity.text,
+    color: entity.color,
+    strokeWidth: entity.strokeWidth,
+    theme: entity.theme,
+    label: entity.label,
+    parentGroupId: entity.parentGroupId,
   }
 }
 
@@ -252,6 +274,10 @@ export function deserializeFromJsonCanvas(doc: JsonCanvasDocument): {
       const entity = deserializeDrawingNodeToDrawing(node)
       entities[entity.id] = entity
       entityOrder.push(entity.id)
+    } else if (node.type === 'shape') {
+      const entity = deserializeShapeNodeToShape(node)
+      entities[entity.id] = entity
+      entityOrder.push(entity.id)
     }
   }
 
@@ -323,6 +349,24 @@ function deserializeFileNodeToFile(node: JsonCanvasFileNode): PersistedFileEntit
     objectFit: node.objectFit,
     presetIndex: node.presetIndex,
     metadata: node.metadata,
+  }
+}
+
+function deserializeShapeNodeToShape(node: JsonCanvasShapeNode): PersistedShapeEntity {
+  return {
+    kind: 'shape',
+    id: node.id,
+    shapeKind: node.shapeKind,
+    text: node.text ?? '',
+    color: node.color,
+    strokeWidth: node.strokeWidth,
+    theme: node.theme,
+    canvasX: node.x,
+    canvasY: node.y,
+    width: node.width,
+    height: node.height,
+    label: node.label,
+    parentGroupId: node.parentGroupId,
   }
 }
 

--- a/src/main/runtime/selection-controller.ts
+++ b/src/main/runtime/selection-controller.ts
@@ -24,6 +24,7 @@ import { sendInteractiveState } from './overlay-manager'
 import { savePreferences } from './preferences'
 import { drawingEntities } from './drawing-entity-state'
 import { fileEntities } from './file-entity-state'
+import { shapeEntities } from './shape-entity-state'
 import { textEntities } from './text-entity-state'
 import { breadcrumb } from '../sentry-context'
 import { descendantEntityIdsForGroup } from './group-descendants'
@@ -66,6 +67,7 @@ export function resolveEntityKind(entityId: string): CanvasEntityKind {
   if (textEntities.some((entity) => entity.id === entityId)) return 'text'
   if (fileEntities.some((entity) => entity.id === entityId)) return 'file'
   if (drawingEntities.some((entity) => entity.id === entityId)) return 'drawing'
+  if (shapeEntities.some((entity) => entity.id === entityId)) return 'shape'
   if (workspaceGroups.some((group) => group.id === entityId)) return 'group'
   if (workspaceEdges.some((edge) => edge.id === entityId)) return 'edge'
   return 'frame'
@@ -91,6 +93,7 @@ function normalizeEntitySelection(entityIds: string[]): SelectionCommand {
     if (textEntities.some((entity) => entity.id === entityId)) return true
     if (fileEntities.some((entity) => entity.id === entityId)) return true
     if (drawingEntities.some((entity) => entity.id === entityId)) return true
+    if (shapeEntities.some((entity) => entity.id === entityId)) return true
     return workspaceEdges.some((edge) => edge.id === entityId)
   })
 
@@ -245,6 +248,7 @@ export function enterGroup(
     ...pages.filter((page) => page.parentGroupId === groupId).map((page) => page.id),
     ...textEntities.filter((entity) => entity.parentGroupId === groupId).map((entity) => entity.id),
     ...fileEntities.filter((entity) => entity.parentGroupId === groupId).map((entity) => entity.id),
+    ...shapeEntities.filter((entity) => entity.parentGroupId === groupId).map((entity) => entity.id),
     ...workspaceGroups.filter((group) => group.parentGroupId === groupId).map((group) => group.id),
   ]
   if (!childIds.length) return false

--- a/src/main/runtime/shape-entity-state.ts
+++ b/src/main/runtime/shape-entity-state.ts
@@ -1,11 +1,3 @@
-/**
- * Shape Entity State
- *
- * Manages the in-memory state of shape entities on the canvas.
- * Shape entities are lightweight visual primitives — rectangle,
- * ellipse, or diamond bounding boxes with optional text inside.
- */
-
 import { randomUUID } from 'crypto'
 import type {
   CanvasSceneShapeEntity,

--- a/src/main/runtime/shape-entity-state.ts
+++ b/src/main/runtime/shape-entity-state.ts
@@ -23,9 +23,17 @@ export interface ShapeEntity {
 
 export const DEFAULT_SHAPE_WIDTH = 200
 export const DEFAULT_SHAPE_HEIGHT = 120
+export const DEFAULT_DIAMOND_SIZE = 160
 export const DEFAULT_STROKE_WIDTH = 2
 export const MIN_SHAPE_WIDTH = 24
 export const MIN_SHAPE_HEIGHT = 24
+
+export function defaultShapeSize(shapeKind: ShapeKind): { width: number; height: number } {
+  if (shapeKind === 'diamond') {
+    return { width: DEFAULT_DIAMOND_SIZE, height: DEFAULT_DIAMOND_SIZE }
+  }
+  return { width: DEFAULT_SHAPE_WIDTH, height: DEFAULT_SHAPE_HEIGHT }
+}
 
 export const shapeEntities: ShapeEntity[] = []
 
@@ -43,17 +51,19 @@ export function createShapeEntity(input: {
   parentGroupId?: string
   label?: string
 }): ShapeEntity {
+  const shapeKind = input.shapeKind ?? 'rectangle'
+  const fallback = defaultShapeSize(shapeKind)
   const entity: ShapeEntity = {
     id: input.id ?? `shape_${randomUUID()}`,
-    shapeKind: input.shapeKind ?? 'rectangle',
+    shapeKind,
     text: input.text ?? '',
     color: input.color,
     strokeWidth: input.strokeWidth,
     theme: input.theme,
     canvasX: input.canvasX,
     canvasY: input.canvasY,
-    width: input.width ?? DEFAULT_SHAPE_WIDTH,
-    height: input.height ?? DEFAULT_SHAPE_HEIGHT,
+    width: input.width ?? fallback.width,
+    height: input.height ?? fallback.height,
     parentGroupId: input.parentGroupId,
     label: input.label,
   }

--- a/src/main/runtime/shape-entity-state.ts
+++ b/src/main/runtime/shape-entity-state.ts
@@ -1,0 +1,167 @@
+/**
+ * Shape Entity State
+ *
+ * Manages the in-memory state of shape entities on the canvas.
+ * Shape entities are lightweight visual primitives — rectangle,
+ * ellipse, or diamond bounding boxes with optional text inside.
+ */
+
+import { randomUUID } from 'crypto'
+import type {
+  CanvasSceneShapeEntity,
+  PersistedShapeEntity,
+  ShapeKind,
+} from '../../shared/types'
+import { markDirty } from './layout-dirty'
+
+export interface ShapeEntity {
+  id: string
+  shapeKind: ShapeKind
+  text: string
+  color?: string
+  strokeWidth?: number
+  theme?: string
+  canvasX: number
+  canvasY: number
+  width: number
+  height: number
+  parentGroupId?: string
+  label?: string
+}
+
+export const DEFAULT_SHAPE_WIDTH = 200
+export const DEFAULT_SHAPE_HEIGHT = 120
+export const DEFAULT_STROKE_WIDTH = 2
+export const MIN_SHAPE_WIDTH = 24
+export const MIN_SHAPE_HEIGHT = 24
+
+export const shapeEntities: ShapeEntity[] = []
+
+export function createShapeEntity(input: {
+  canvasX: number
+  canvasY: number
+  shapeKind?: ShapeKind
+  width?: number
+  height?: number
+  text?: string
+  color?: string
+  strokeWidth?: number
+  theme?: string
+  id?: string
+  parentGroupId?: string
+  label?: string
+}): ShapeEntity {
+  const entity: ShapeEntity = {
+    id: input.id ?? `shape_${randomUUID()}`,
+    shapeKind: input.shapeKind ?? 'rectangle',
+    text: input.text ?? '',
+    color: input.color,
+    strokeWidth: input.strokeWidth,
+    theme: input.theme,
+    canvasX: input.canvasX,
+    canvasY: input.canvasY,
+    width: input.width ?? DEFAULT_SHAPE_WIDTH,
+    height: input.height ?? DEFAULT_SHAPE_HEIGHT,
+    parentGroupId: input.parentGroupId,
+    label: input.label,
+  }
+  shapeEntities.push(entity)
+  markDirty('canvas', 'sidebar', 'floating-ui')
+  return entity
+}
+
+export function updateShapeEntity(
+  id: string,
+  patch: Partial<Omit<ShapeEntity, 'id'>>,
+): ShapeEntity | null {
+  const entity = shapeEntities.find((s) => s.id === id)
+  if (!entity) return null
+  if (patch.shapeKind !== undefined) entity.shapeKind = patch.shapeKind
+  if (patch.text !== undefined) entity.text = patch.text
+  if (patch.color !== undefined) entity.color = patch.color || undefined
+  if (patch.strokeWidth !== undefined) entity.strokeWidth = patch.strokeWidth
+  if (patch.theme !== undefined) entity.theme = patch.theme || undefined
+  if (patch.canvasX !== undefined) entity.canvasX = patch.canvasX
+  if (patch.canvasY !== undefined) entity.canvasY = patch.canvasY
+  if (patch.width !== undefined) entity.width = patch.width
+  if (patch.height !== undefined) entity.height = patch.height
+  if (patch.parentGroupId !== undefined) entity.parentGroupId = patch.parentGroupId
+  if (patch.label !== undefined) entity.label = patch.label || undefined
+  markDirty('canvas', 'sidebar', 'floating-ui')
+  return entity
+}
+
+export function deleteShapeEntity(id: string): boolean {
+  const idx = shapeEntities.findIndex((s) => s.id === id)
+  if (idx === -1) return false
+  shapeEntities.splice(idx, 1)
+  markDirty('canvas', 'sidebar', 'floating-ui')
+  return true
+}
+
+export function clearShapeEntities(): void {
+  shapeEntities.length = 0
+}
+
+export function buildShapeEntitySceneEntity(
+  entity: ShapeEntity,
+  zoom: number,
+  pan: { x: number; y: number },
+  canvasOrigin: { x: number; y: number },
+): CanvasSceneShapeEntity {
+  const screenX = canvasOrigin.x + entity.canvasX * zoom + pan.x
+  const screenY = canvasOrigin.y + entity.canvasY * zoom + pan.y
+  return {
+    kind: 'shape',
+    id: entity.id,
+    shapeKind: entity.shapeKind,
+    text: entity.text,
+    color: entity.color,
+    strokeWidth: entity.strokeWidth,
+    theme: entity.theme,
+    canvasX: entity.canvasX,
+    canvasY: entity.canvasY,
+    width: entity.width,
+    height: entity.height,
+    parentGroupId: entity.parentGroupId,
+    screenX,
+    screenY,
+    screenWidth: entity.width * zoom,
+    screenHeight: entity.height * zoom,
+  }
+}
+
+export function persistShapeEntity(entity: ShapeEntity): PersistedShapeEntity {
+  return {
+    kind: 'shape',
+    id: entity.id,
+    shapeKind: entity.shapeKind,
+    text: entity.text,
+    color: entity.color,
+    strokeWidth: entity.strokeWidth,
+    theme: entity.theme,
+    canvasX: entity.canvasX,
+    canvasY: entity.canvasY,
+    width: entity.width,
+    height: entity.height,
+    parentGroupId: entity.parentGroupId,
+    label: entity.label,
+  }
+}
+
+export function restoreShapeEntity(persisted: PersistedShapeEntity): ShapeEntity {
+  return {
+    id: persisted.id,
+    shapeKind: persisted.shapeKind,
+    text: persisted.text ?? '',
+    color: persisted.color,
+    strokeWidth: persisted.strokeWidth,
+    theme: persisted.theme,
+    canvasX: persisted.canvasX,
+    canvasY: persisted.canvasY,
+    width: persisted.width,
+    height: persisted.height,
+    parentGroupId: persisted.parentGroupId,
+    label: persisted.label,
+  }
+}

--- a/src/main/runtime/sidebar-builder.ts
+++ b/src/main/runtime/sidebar-builder.ts
@@ -8,6 +8,7 @@ import type {
   SidebarDrawingItem,
   SidebarFileItem,
   SidebarFrameItem,
+  SidebarShapeItem,
   SidebarTextItem,
   WorkspaceBounds,
   WorkspaceGroup,
@@ -28,11 +29,17 @@ import {
 import { textEntities } from './text-entity-state'
 import { fileEntities } from './file-entity-state'
 import { drawingEntitiesForUi } from './drawing-entity-state'
+import { shapeEntities } from './shape-entity-state'
 import { frameDisplayLabel } from './runtime-serialization'
 import { workspaceTabSummaries } from './workspace-tabs'
 import { LEFT_SIDEBAR_WIDTH } from './runtime-constants'
 
-type SidebarLeafItem = SidebarFrameItem | SidebarTextItem | SidebarFileItem | SidebarDrawingItem
+type SidebarLeafItem =
+  | SidebarFrameItem
+  | SidebarTextItem
+  | SidebarFileItem
+  | SidebarDrawingItem
+  | SidebarShapeItem
 type SidebarNodeBuild = {
   group: WorkspaceGroup
   bounds: WorkspaceBounds
@@ -110,6 +117,20 @@ function buildSidebarLeafItem(entityId: string): (SidebarLeafItem & { sortKey: S
     }
   }
 
+  const se = shapeEntities.find((entity) => entity.id === entityId)
+  if (se) {
+    const trimmed = se.text.trim()
+    const defaultLabel =
+      se.shapeKind === 'ellipse' ? 'Ellipse' : se.shapeKind === 'diamond' ? 'Diamond' : 'Rectangle'
+    return {
+      kind: 'shape',
+      id: entityId,
+      label: se.label || trimmed || defaultLabel,
+      shapeKind: se.shapeKind,
+      sortKey: { y: se.canvasY, x: se.canvasX, priority: 0 },
+    }
+  }
+
   return null
 }
 
@@ -118,7 +139,8 @@ function countSidebarLeafDescendants(groupId: string): number {
     pages.filter((page) => page.parentGroupId === groupId).length +
     textEntities.filter((entity) => entity.parentGroupId === groupId).length +
     fileEntities.filter((entity) => entity.parentGroupId === groupId).length +
-    drawingEntitiesForUi().filter((entity) => entity.parentGroupId === groupId).length
+    drawingEntitiesForUi().filter((entity) => entity.parentGroupId === groupId).length +
+    shapeEntities.filter((entity) => entity.parentGroupId === groupId).length
 
   const nestedLeafCount = workspaceGroups
     .filter((group) => group.parentGroupId === groupId)
@@ -164,6 +186,7 @@ export function buildSidebarItems(): SidebarCanvasItem[] {
       ...textEntities.filter((entity) => entity.parentGroupId === node.group.id).map((entity) => entity.id),
       ...fileEntities.filter((entity) => entity.parentGroupId === node.group.id).map((entity) => entity.id),
       ...drawingEntitiesForUi().filter((entity) => entity.parentGroupId === node.group.id).map((entity) => entity.id),
+      ...shapeEntities.filter((entity) => entity.parentGroupId === node.group.id).map((entity) => entity.id),
     ]
       .map(buildSidebarLeafItem)
       .filter((item): item is NonNullable<typeof item> => Boolean(item))
@@ -183,6 +206,7 @@ export function buildSidebarItems(): SidebarCanvasItem[] {
     ...textEntities.filter((entity) => entity.parentGroupId).map((entity) => entity.id),
     ...fileEntities.filter((entity) => entity.parentGroupId).map((entity) => entity.id),
     ...drawingEntitiesForUi().filter((entity) => entity.parentGroupId).map((entity) => entity.id),
+    ...shapeEntities.filter((entity) => entity.parentGroupId).map((entity) => entity.id),
   ])
   const rootLeafItems = [
     ...pages
@@ -195,6 +219,9 @@ export function buildSidebarItems(): SidebarCanvasItem[] {
       .filter((entity) => !groupedEntityIds.has(entity.id))
       .map((entity) => buildSidebarLeafItem(entity.id)),
     ...drawingEntitiesForUi()
+      .filter((entity) => !groupedEntityIds.has(entity.id))
+      .map((entity) => buildSidebarLeafItem(entity.id)),
+    ...shapeEntities
       .filter((entity) => !groupedEntityIds.has(entity.id))
       .map((entity) => buildSidebarLeafItem(entity.id)),
   ].filter((item): item is NonNullable<typeof item> => Boolean(item))

--- a/src/main/runtime/tool-mode.ts
+++ b/src/main/runtime/tool-mode.ts
@@ -89,12 +89,14 @@ export function startPendingPlacement(input: {
   presetIndex?: number
   customSize?: boolean
   sourceFrameId?: string
+  shapeKind?: import('../../shared/types').ShapeKind
 }): void {
   setUiPendingPlacement({
     entityKind: input.entityKind ?? 'frame',
     presetIndex: input.presetIndex,
     customSize: input.customSize ?? false,
     sourceFrameId: input.sourceFrameId,
+    shapeKind: input.shapeKind,
   })
   setUiCanvasMode()
   setUiInspectEnabled(false, { hasPages: pages.length > 0 })

--- a/src/main/runtime/workspace-doc.ts
+++ b/src/main/runtime/workspace-doc.ts
@@ -189,6 +189,7 @@ export function syncRuntimeToDoc(
     textEntities: ReadonlyArray<{ id: string; kind?: string }>
     fileEntities: ReadonlyArray<{ id: string; kind?: string }>
     drawingEntities: ReadonlyArray<{ id: string; kind?: string }>
+    shapeEntities: ReadonlyArray<{ id: string; kind?: string }>
     workspaceGroups: ReadonlyArray<{ id: string }>
     workspaceEdges: ReadonlyArray<{ id: string }>
     workspaceAnnotations: ReadonlyArray<{ id: string }>
@@ -217,6 +218,7 @@ export function syncRuntimeToDoc(
       ...runtime.textEntities.map((e) => ({ ...e, kind: 'text' as const })),
       ...runtime.fileEntities.map((e) => ({ ...e, kind: 'file' as const })),
       ...runtime.drawingEntities.map((e) => ({ ...e, kind: 'drawing' as const })),
+      ...runtime.shapeEntities.map((e) => ({ ...e, kind: 'shape' as const })),
     ]
     syncMapFromArray(
       doc.getMap(DOC_MAP_ENTITIES) as Y.Map<Y.Map<unknown>>,
@@ -286,6 +288,7 @@ function syncEntityOrder(
     textEntities: ReadonlyArray<{ id: string }>
     fileEntities: ReadonlyArray<{ id: string }>
     drawingEntities: ReadonlyArray<{ id: string }>
+    shapeEntities: ReadonlyArray<{ id: string }>
     workspaceGroups: ReadonlyArray<{ id: string }>
   },
 ): void {
@@ -295,6 +298,7 @@ function syncEntityOrder(
     ...runtime.textEntities.map((e) => e.id),
     ...runtime.fileEntities.map((e) => e.id),
     ...runtime.drawingEntities.map((e) => e.id),
+    ...runtime.shapeEntities.map((e) => e.id),
     ...runtime.workspaceGroups.map((g) => g.id),
   ]
   const currentOrder = order.toArray()

--- a/src/main/runtime/workspace-observers.ts
+++ b/src/main/runtime/workspace-observers.ts
@@ -17,6 +17,7 @@ import type { Page } from './runtime-entities'
 import type { TextEntity } from './text-entity-state'
 import type { FileEntity } from './file-entity-state'
 import type { DrawingEntity } from './drawing-entity-state'
+import type { ShapeEntity } from './shape-entity-state'
 import {
   getActiveDoc,
   getDocActiveTabId,
@@ -44,6 +45,7 @@ interface RuntimeStateRefs {
   textEntities: TextEntity[]
   fileEntities: FileEntity[]
   drawingEntities: DrawingEntity[]
+  shapeEntities: ShapeEntity[]
   workspaceGroups: WorkspaceGroup[]
   workspaceEdges: WorkspaceEdge[]
   workspaceAnnotations: Annotation[]
@@ -142,6 +144,7 @@ function requestDocSyncImmediate(): void {
     textEntities: _refs.textEntities,
     fileEntities: _refs.fileEntities,
     drawingEntities: _refs.drawingEntities,
+    shapeEntities: _refs.shapeEntities,
     workspaceGroups: _refs.workspaceGroups,
     workspaceEdges: _refs.workspaceEdges,
     workspaceAnnotations: _refs.workspaceAnnotations,
@@ -253,6 +256,7 @@ function syncDocToRuntime(doc: Y.Doc): void {
     _refs!.textEntities.length = 0
     _refs!.fileEntities.length = 0
     _refs!.drawingEntities.length = 0
+    _refs!.shapeEntities.length = 0
     for (const [, yEntity] of yEntities.entries()) {
       const data = yEntity.toJSON() as Record<string, unknown>
       const kind = data.kind as string
@@ -262,6 +266,8 @@ function syncDocToRuntime(doc: Y.Doc): void {
         _refs!.fileEntities.push(data as unknown as FileEntity)
       } else if (kind === 'drawing') {
         _refs!.drawingEntities.push(data as unknown as DrawingEntity)
+      } else if (kind === 'shape') {
+        _refs!.shapeEntities.push(data as unknown as ShapeEntity)
       }
     }
 

--- a/src/main/runtime/workspace-restore.ts
+++ b/src/main/runtime/workspace-restore.ts
@@ -82,6 +82,10 @@ import {
   createDrawingEntity as createDrawingEntityInState,
 } from './drawing-entity-state'
 import {
+  clearShapeEntities,
+  createShapeEntity as createShapeEntityInState,
+} from './shape-entity-state'
+import {
   deselectAll,
   selectPage,
   setBrowserMode,
@@ -117,6 +121,7 @@ export function destroyActivePages(): void {
   clearTextEntities()
   clearFileEntities()
   clearDrawingEntities()
+  clearShapeEntities()
   while (pages.length) {
     removePageAtIndex(pages.length - 1)
   }
@@ -252,6 +257,21 @@ export function restoreWorkspaceSnapshot(snapshot: WorkspaceSnapshot): boolean {
             height: (entity as any).height,
             strokes: (entity as any).strokes ?? [],
             parentGroupId: (entity as any).parentGroupId,
+          })
+        } else if (entity?.kind === 'shape') {
+          createShapeEntityInState({
+            id: entity.id,
+            canvasX: entity.canvasX,
+            canvasY: entity.canvasY,
+            width: (entity as any).width,
+            height: (entity as any).height,
+            shapeKind: (entity as any).shapeKind,
+            text: (entity as any).text,
+            color: (entity as any).color,
+            strokeWidth: (entity as any).strokeWidth,
+            theme: (entity as any).theme,
+            parentGroupId: (entity as any).parentGroupId,
+            label: (entity as any).label,
           })
         }
       }

--- a/src/main/runtime/workspace-tabs.ts
+++ b/src/main/runtime/workspace-tabs.ts
@@ -52,6 +52,10 @@ import {
   drawingEntities,
   persistDrawingEntity,
 } from './drawing-entity-state'
+import {
+  shapeEntities,
+  persistShapeEntity,
+} from './shape-entity-state'
 import { persistGroupEntity } from './group-entity-state'
 
 export function workspaceSnapshot(): WorkspaceSnapshot {
@@ -110,6 +114,13 @@ export function workspaceSnapshot(): WorkspaceSnapshot {
   }
   for (const de of drawingEntities) {
     const entity = persistDrawingEntity(de)
+    if (!snapshot.entities) snapshot.entities = {}
+    if (!snapshot.entityOrder) snapshot.entityOrder = []
+    snapshot.entities[entity.id] = entity
+    snapshot.entityOrder.push(entity.id)
+  }
+  for (const se of shapeEntities) {
+    const entity = persistShapeEntity(se)
     if (!snapshot.entities) snapshot.entities = {}
     if (!snapshot.entityOrder) snapshot.entityOrder = []
     snapshot.entities[entity.id] = entity

--- a/src/main/sentry.ts
+++ b/src/main/sentry.ts
@@ -10,6 +10,7 @@ import { pages } from './runtime/page-runtime'
 import { textEntities } from './runtime/text-entity-state'
 import { fileEntities } from './runtime/file-entity-state'
 import { drawingEntities } from './runtime/drawing-entity-state'
+import { shapeEntities } from './runtime/shape-entity-state'
 import { workspaceViewMode } from './ui-state'
 
 /**
@@ -66,6 +67,7 @@ function readAppStateTags(): Record<string, string> {
       textEntities.length +
         fileEntities.length +
         drawingEntities.length +
+        shapeEntities.length +
         workspaceGroups.length,
     ),
     view_mode: workspaceViewMode(),

--- a/src/main/workspace-clipboard.ts
+++ b/src/main/workspace-clipboard.ts
@@ -15,8 +15,10 @@ import {
 } from './runtime/ui-actions'
 import { textEntities } from './runtime/text-entity-state'
 import { fileEntities } from './runtime/file-entity-state'
+import { shapeEntities } from './runtime/shape-entity-state'
 import { createTextEntity as createTextEntityInState } from './runtime/text-entity-state'
 import { createFileEntity as createFileEntityInState } from './runtime/file-entity-state'
+import { createShapeEntity as createShapeEntityInState } from './runtime/shape-entity-state'
 import { layoutAllViews, snapToGrid } from './runtime/surface-layout'
 import { scheduleWorkspaceAutosave } from './runtime/workspace-session'
 import { cloneMetadata } from './workspace-utils'
@@ -71,6 +73,11 @@ export function copyableSelectionPayload():
     const file = fileEntities.find((f) => f.id === id)
     if (file) {
       allPositions.push({ canvasX: file.canvasX, canvasY: file.canvasY })
+      continue
+    }
+    const shape = shapeEntities.find((s) => s.id === id)
+    if (shape) {
+      allPositions.push({ canvasX: shape.canvasX, canvasY: shape.canvasY })
     }
   }
 
@@ -118,6 +125,23 @@ export function copyableSelectionPayload():
         presetIndex: file.presetIndex,
         metadata: file.metadata,
         objectFit: file.objectFit,
+      })
+      continue
+    }
+    const shape = shapeEntities.find((s) => s.id === id)
+    if (shape) {
+      entities.push({
+        kind: 'shape',
+        shapeKind: shape.shapeKind,
+        text: shape.text,
+        color: shape.color,
+        strokeWidth: shape.strokeWidth,
+        theme: shape.theme,
+        label: shape.label,
+        width: shape.width,
+        height: shape.height,
+        dx: shape.canvasX - minX,
+        dy: shape.canvasY - minY,
       })
     }
   }
@@ -224,6 +248,20 @@ export function pasteEntitiesFromClipboard(input: {
         objectFit: entity.objectFit,
       })
       entityIds.push(file.id)
+    } else if (entity.kind === 'shape') {
+      const shape = createShapeEntityInState({
+        canvasX: snapToGrid(input.canvasX + entity.dx),
+        canvasY: snapToGrid(input.canvasY + entity.dy),
+        shapeKind: entity.shapeKind,
+        text: entity.text,
+        color: entity.color,
+        strokeWidth: entity.strokeWidth,
+        theme: entity.theme,
+        label: entity.label,
+        width: entity.width,
+        height: entity.height,
+      })
+      entityIds.push(shape.id)
     }
   }
 

--- a/src/main/workspace-entities.ts
+++ b/src/main/workspace-entities.ts
@@ -27,6 +27,7 @@ import {
 import { textEntities } from './runtime/text-entity-state'
 import { fileEntities } from './runtime/file-entity-state'
 import { drawingEntities } from './runtime/drawing-entity-state'
+import { shapeEntities } from './runtime/shape-entity-state'
 import {
   pageOuterCanvasBounds,
   pageContentSize,
@@ -96,6 +97,10 @@ function entityBoundsByIdWithVisited(
   if (te) return { x: te.canvasX, y: te.canvasY, width: te.width, height: te.height }
   const fe = fileEntities.find((f) => f.id === entityId)
   if (fe) return { x: fe.canvasX, y: fe.canvasY, width: fe.width, height: fe.height }
+  const de = drawingEntities.find((d) => d.id === entityId)
+  if (de) return { x: de.canvasX, y: de.canvasY, width: de.width, height: de.height }
+  const se = shapeEntities.find((s) => s.id === entityId)
+  if (se) return { x: se.canvasX, y: se.canvasY, width: se.width, height: se.height }
   const group = workspaceGroups.find((candidate) => candidate.id === entityId)
   if (group) {
     return {
@@ -133,6 +138,8 @@ export function groupChildIds(groupId: string): string[] {
     ...pages.filter((page) => page.parentGroupId === groupId).map((page) => page.id),
     ...textEntities.filter((entity) => entity.parentGroupId === groupId).map((entity) => entity.id),
     ...fileEntities.filter((entity) => entity.parentGroupId === groupId).map((entity) => entity.id),
+    ...drawingEntities.filter((entity) => entity.parentGroupId === groupId).map((entity) => entity.id),
+    ...shapeEntities.filter((entity) => entity.parentGroupId === groupId).map((entity) => entity.id),
     ...workspaceGroups.filter((group) => group.parentGroupId === groupId).map((group) => group.id),
   ]
 }
@@ -305,8 +312,21 @@ export function selectEntitiesInRect(
       ),
     )
     .map((de) => de.id)
+  const shapeIds = shapeEntities
+    .filter((se) =>
+      boundsOverlap(
+        {
+          x: se.canvasX,
+          y: se.canvasY,
+          width: se.width,
+          height: se.height,
+        },
+        bounds,
+      ),
+    )
+    .map((se) => se.id)
 
-  const entityIds = [...frameIds, ...textIds, ...fileIds, ...drawingIds]
+  const entityIds = [...frameIds, ...textIds, ...fileIds, ...drawingIds, ...shapeIds]
 
   if (mode !== 'replace') {
     // Additive / toggle / remove modes: preserve existing selection outside the rect
@@ -321,7 +341,7 @@ export function selectEntitiesInRect(
     return { entityIds: [] }
   }
 
-  if (!textIds.length && !fileIds.length && !drawingIds.length) {
+  if (!textIds.length && !fileIds.length && !drawingIds.length && !shapeIds.length) {
     if (frameIds.length === 1) {
       selectPageById(frameIds[0])
     } else {

--- a/src/main/workspace-entities.ts
+++ b/src/main/workspace-entities.ts
@@ -1,6 +1,7 @@
 import type {
   DeleteFramesRequest,
   DeleteFramesResponse,
+  EdgeSide,
   WorkspaceBounds,
   WorkspaceFrame,
   WorkspaceGraph,
@@ -325,8 +326,18 @@ export function selectEntitiesInRect(
       ),
     )
     .map((se) => se.id)
+  const edgeIds = workspaceEdges
+    .filter((edge) => {
+      const fromBounds = entityBoundsById(edge.fromEntityId)
+      const toBounds = entityBoundsById(edge.toEntityId)
+      if (!fromBounds || !toBounds) return false
+      const from = sideAnchorPoint(fromBounds, edge.fromSide)
+      const to = sideAnchorPoint(toBounds, edge.toSide)
+      return segmentIntersectsRect(from, to, bounds)
+    })
+    .map((edge) => edge.id)
 
-  const entityIds = [...frameIds, ...textIds, ...fileIds, ...drawingIds, ...shapeIds]
+  const entityIds = [...frameIds, ...textIds, ...fileIds, ...drawingIds, ...shapeIds, ...edgeIds]
 
   if (mode !== 'replace') {
     // Additive / toggle / remove modes: preserve existing selection outside the rect
@@ -341,7 +352,13 @@ export function selectEntitiesInRect(
     return { entityIds: [] }
   }
 
-  if (!textIds.length && !fileIds.length && !drawingIds.length && !shapeIds.length) {
+  if (
+    !textIds.length &&
+    !fileIds.length &&
+    !drawingIds.length &&
+    !shapeIds.length &&
+    !edgeIds.length
+  ) {
     if (frameIds.length === 1) {
       selectPageById(frameIds[0])
     } else {
@@ -352,6 +369,58 @@ export function selectEntitiesInRect(
 
   setSelectedEntities(entityIds)
   return { entityIds }
+}
+
+function sideAnchorPoint(
+  bounds: WorkspaceBounds,
+  side: EdgeSide | undefined,
+): { x: number; y: number } {
+  switch (side) {
+    case 'top':
+      return { x: bounds.x + bounds.width / 2, y: bounds.y }
+    case 'bottom':
+      return { x: bounds.x + bounds.width / 2, y: bounds.y + bounds.height }
+    case 'left':
+      return { x: bounds.x, y: bounds.y + bounds.height / 2 }
+    case 'right':
+      return { x: bounds.x + bounds.width, y: bounds.y + bounds.height / 2 }
+    default:
+      return { x: bounds.x + bounds.width / 2, y: bounds.y + bounds.height / 2 }
+  }
+}
+
+// Liang-Barsky: returns true if the segment from p1 to p2 intersects rect
+// (including the case where the segment lies entirely inside the rect).
+function segmentIntersectsRect(
+  p1: { x: number; y: number },
+  p2: { x: number; y: number },
+  rect: WorkspaceBounds,
+): boolean {
+  const dx = p2.x - p1.x
+  const dy = p2.y - p1.y
+  const xMin = rect.x
+  const xMax = rect.x + rect.width
+  const yMin = rect.y
+  const yMax = rect.y + rect.height
+  const p = [-dx, dx, -dy, dy]
+  const q = [p1.x - xMin, xMax - p1.x, p1.y - yMin, yMax - p1.y]
+  let t0 = 0
+  let t1 = 1
+  for (let i = 0; i < 4; i++) {
+    if (p[i] === 0) {
+      if (q[i] < 0) return false
+    } else {
+      const t = q[i] / p[i]
+      if (p[i] < 0) {
+        if (t > t1) return false
+        if (t > t0) t0 = t
+      } else {
+        if (t < t0) return false
+        if (t < t1) t1 = t
+      }
+    }
+  }
+  return true
 }
 
 // --- Workspace graph ---

--- a/src/main/workspace-frames.ts
+++ b/src/main/workspace-frames.ts
@@ -25,6 +25,7 @@ import {
 } from './runtime/ui-actions'
 import { textEntities, createTextEntity as createTextEntityInState } from './runtime/text-entity-state'
 import { fileEntities, createFileEntity as createFileEntityInState } from './runtime/file-entity-state'
+import { shapeEntities, createShapeEntity as createShapeEntityInState } from './runtime/shape-entity-state'
 import {
   layoutAllViews,
   pageContentSize,
@@ -421,6 +422,34 @@ export function duplicateEntity(input: {
     layoutAllViews()
     scheduleWorkspaceAutosave()
     return { entityId: newFile.id }
+  }
+
+  const shape = shapeEntities.find((s) => s.id === input.entityId)
+  if (shape) {
+    const shapePlacement = findDuplicatePlacement({
+      x: shape.canvasX,
+      y: shape.canvasY,
+      width: shape.width,
+      height: shape.height,
+    })
+    const newShape = createShapeEntityInState({
+      canvasX: shapePlacement.canvasX,
+      canvasY: shapePlacement.canvasY,
+      shapeKind: shape.shapeKind,
+      text: shape.text,
+      color: shape.color,
+      strokeWidth: shape.strokeWidth,
+      theme: shape.theme,
+      width: shape.width,
+      height: shape.height,
+      label: shape.label,
+    })
+    if (input.focus ?? true) {
+      setSelectedEntities([newShape.id])
+    }
+    layoutAllViews()
+    scheduleWorkspaceAutosave()
+    return { entityId: newShape.id }
   }
 
   throw new Error(`Unknown entity: ${input.entityId}`)

--- a/src/preload/canvas-bg.ts
+++ b/src/preload/canvas-bg.ts
@@ -237,6 +237,15 @@ const api: CanvasBgElectronAPI = {
     ipcRenderer.send('canvas-edge-drag-commit', { fromEntityId, toEntityId, fromSide, toSide }),
   cancelEdgeDrag: () =>
     ipcRenderer.send('canvas-edge-drag-cancel'),
+  commitEdgeEdit: (
+    edgeId: string,
+    movingEnd: 'from' | 'to',
+    targetEntityId: string,
+    targetSide: EdgeSide,
+  ) =>
+    ipcRenderer.send('canvas-edge-edit-commit', { edgeId, movingEnd, targetEntityId, targetSide }),
+  discardEdgeEdit: (edgeId: string) =>
+    ipcRenderer.send('canvas-edge-edit-discard', { edgeId }),
   createEdge: (fromEntityId: string, toEntityId: string, fromSide?: EdgeSide, toSide?: EdgeSide) =>
     ipcRenderer.send('canvas-create-edge', { fromEntityId, toEntityId, fromSide, toSide }),
   deleteEdge: (edgeId: string) =>

--- a/src/preload/canvas-bg.ts
+++ b/src/preload/canvas-bg.ts
@@ -128,6 +128,20 @@ const api: CanvasBgElectronAPI = {
     ipcRenderer.send('canvas-update-drawing-entity', { id, patch }),
   deleteDrawingEntity: (id: string) =>
     ipcRenderer.send('canvas-delete-drawing-entity', { id }),
+  updateShapeEntity: (id, patch) =>
+    ipcRenderer.send('canvas-update-shape', { id, patch }),
+  deleteShapeEntity: (id) =>
+    ipcRenderer.send('canvas-delete-shape', { id }),
+  placePendingShape: (canvasX, canvasY, dragRect) =>
+    ipcRenderer.send('canvas-place-pending-entity', { canvasX, canvasY, dragRect: dragRect ?? null }),
+  onShapeBeginEdit: (callback) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      data: { entityId: string },
+    ) => callback(data)
+    ipcRenderer.on('shape-begin-edit', handler)
+    return () => ipcRenderer.removeListener('shape-begin-edit', handler)
+  },
   showFileInFinder: (filePath: string) =>
     ipcRenderer.send('canvas-show-file-in-finder', { filePath }),
   updateGroupEntity: (id: string, patch: { width?: number; height?: number; canvasX?: number; canvasY?: number; label?: string; color?: string }) =>

--- a/src/preload/right-details-panel.ts
+++ b/src/preload/right-details-panel.ts
@@ -63,6 +63,10 @@ const api: DevtoolsPanelElectronAPI = {
     ipcRenderer.send('right-details-panel-toggle-file-device-shell', { fileId }),
   deleteDrawingEntity: (id: string) =>
     ipcRenderer.send('canvas-delete-drawing-entity', { id }),
+  updateShapeEntity: (id, patch) =>
+    ipcRenderer.send('canvas-update-shape', { id, patch }),
+  deleteShapeEntity: (id: string) =>
+    ipcRenderer.send('canvas-delete-shape', { id }),
   updateEdge: (id, patch) =>
     ipcRenderer.send('right-details-panel-update-edge', { id, patch }),
   deleteEdge: (id) =>

--- a/src/preload/toolbar.ts
+++ b/src/preload/toolbar.ts
@@ -20,6 +20,7 @@ const api: ToolbarElectronAPI = {
   cancelPendingPlacement: () => ipcRenderer.send('cancel-pending-placement'),
   addTextEntity: () => ipcRenderer.send('toolbar-add-text-entity'),
   addNote: () => ipcRenderer.send('toolbar-add-note'),
+  addShape: (shapeKind) => ipcRenderer.send('toolbar-add-shape', { shapeKind }),
   reloadApp: () => ipcRenderer.send('reload-app'),
   toggleTheme: () => ipcRenderer.send('toggle-theme'),
   getInitialData: () => ipcRenderer.invoke('get-theme-bootstrap'),

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -712,12 +712,28 @@ export default function App({
         }
       />
 
-      {placementPreview ? (
+      {placementPreview && selectionOverlay?.variant !== 'place-shape' ? (
         <PlacementPreviewLayer
           isDark={isDark}
           preview={{
             ...placementPreview,
             top: placementPreview.top - layoutData.canvasOrigin.y,
+          }}
+        />
+      ) : null}
+
+      {selectionOverlay?.variant === 'place-shape' &&
+      selectionOverlay.rect.width > 0 &&
+      selectionOverlay.rect.height > 0 ? (
+        <PlacementPreviewLayer
+          isDark={isDark}
+          preview={{
+            entityKind: 'shape',
+            shapeKind: selectionOverlay.shapeKind,
+            left: selectionOverlay.rect.left,
+            top: selectionOverlay.rect.top,
+            width: selectionOverlay.rect.width,
+            height: selectionOverlay.rect.height,
           }}
         />
       ) : null}

--- a/src/renderer/above-view/MarqueeLayer.tsx
+++ b/src/renderer/above-view/MarqueeLayer.tsx
@@ -7,6 +7,9 @@ import type { SelectionOverlayPayload } from '../../shared/types'
  */
 export function MarqueeLayer({ overlay }: { overlay: SelectionOverlayPayload | null }) {
   if (!overlay) return null
+  // Place-shape drag renders a live shape preview elsewhere; suppress the
+  // marquee box so they don't double up.
+  if (overlay.variant === 'place-shape') return null
   const isRegionSelect = overlay.variant === 'region-select'
   return (
     <div

--- a/src/renderer/canvas-bg/App.tsx
+++ b/src/renderer/canvas-bg/App.tsx
@@ -198,8 +198,13 @@ export default function App({
   const showSelectedGroupMenu =
     selectedGroupEntity !== null && delayedSelectedGroupMenuId === selectedGroupEntity.id
   const hoveredEntityId = layoutData.hover?.id ?? null
-  const selectedEdgeId =
-    layoutData.selection.find((target) => target.kind === 'edge')?.id ?? null
+  const selectedEdgeIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const target of layoutData.selection) {
+      if (target.kind === 'edge') ids.add(target.id)
+    }
+    return ids
+  }, [layoutData.selection])
   const getEntityLayerZoom = useCallback(() => layoutRef.current.zoom, [layoutRef])
   const frameInteractionsEnabled = layoutData.annotationMode !== 'region_select'
 
@@ -279,12 +284,14 @@ export default function App({
           hoveredEntityId={hoveredEntityId}
           isDark={isDark}
           interaction={layoutData.interaction}
-          selectedEdgeId={selectedEdgeId}
+          selectedEdgeIds={selectedEdgeIds}
           selectedEntityIds={layoutData.selectedEntityIds}
           zoom={layoutData.zoom}
           onBeginEdgeDrag={api.beginEdgeDrag}
           onCancelEdgeDrag={api.cancelEdgeDrag}
           onCommitEdgeDrag={api.commitEdgeDrag}
+          onCommitEdgeEdit={api.commitEdgeEdit}
+          onDiscardEdgeEdit={api.discardEdgeEdit}
           onHoverEntity={handleHoverEntity}
           onSelectEdge={handleSelectEdge}
           onUpdateEdgeDragTarget={api.updateEdgeDragTarget}

--- a/src/renderer/canvas-bg/App.tsx
+++ b/src/renderer/canvas-bg/App.tsx
@@ -388,6 +388,7 @@ export default function App({
             allTextEntities={textEntities}
             allFileEntities={fileEntities}
             allDrawingEntities={drawingEntities}
+            allShapeEntities={shapeEntities}
             frameInteractionsEnabled={frameInteractionsEnabled}
             isDark={isDark}
             zoom={layoutData.zoom}
@@ -399,6 +400,7 @@ export default function App({
             onResizeTextEntity={(id, patch) => api.updateTextEntity(id, patch)}
             onResizeFileEntity={(id, patch) => api.updateFileEntity(id, patch)}
             onResizeDrawingEntity={(id, patch) => api.updateDrawingEntity(id, patch)}
+            onResizeShapeEntity={(id, patch) => api.updateShapeEntity(id, patch)}
             onResizeMulti={(entries) => api.resizeMultiSelection(entries)}
             onDrawingMouseDown={(id, event) => {
               event.stopPropagation()

--- a/src/renderer/canvas-bg/App.tsx
+++ b/src/renderer/canvas-bg/App.tsx
@@ -32,7 +32,7 @@ import { EdgeLayer } from './EdgeLayer'
 import { GroupInlineMenu, StickyNoteInlineMenu } from './InlineEntityMenu'
 import { useCanvasLayoutState } from './useCanvasLayoutState'
 import { usePendingPlacementState } from './usePendingPlacementState'
-import { useCanvasViewportGestures } from './useCanvasViewportGestures'
+import { useCanvasViewportGestures, type ShapePlacementDragPreview } from './useCanvasViewportGestures'
 import { useFrameChromeDrag } from './useFrameChromeDrag'
 import { descendantIdsForGroup, selectedGroupHasDescendantFrame } from './groupMembership'
 import { SELECTED_FRAME_MENU_SHOW_DELAY_MS } from '../../shared/selectedFrameMenu'
@@ -67,6 +67,8 @@ export default function App({
   })
 
   const [marqueePreviewIds, setMarqueePreviewIds] = useState<Set<string> | null>(null)
+  const [shapePlacementPreview, setShapePlacementPreview] =
+    useState<ShapePlacementDragPreview | null>(null)
   const [fileJsonModeMap, setFileJsonModeMap] = useState<FileJsonModeMap>(() => new Map())
   const [captureMode, setCaptureMode] = useState(false)
   useEffect(() => api.onCaptureMode(setCaptureMode), [])
@@ -77,6 +79,7 @@ export default function App({
     layoutRef,
     setPlacementCursor,
     onMarqueePreview: setMarqueePreviewIds,
+    onShapePlacementPreview: setShapePlacementPreview,
   })
 
   useCanvasGlobalShortcuts({
@@ -223,7 +226,25 @@ export default function App({
       />
       {!captureMode ? (
         <>
-          <PlacementPreviewLayer isDark={isDark} preview={pendingPlacementPreview} />
+          <PlacementPreviewLayer
+            isDark={isDark}
+            preview={shapePlacementPreview ? null : pendingPlacementPreview}
+          />
+          {shapePlacementPreview &&
+          shapePlacementPreview.rect.width > 0 &&
+          shapePlacementPreview.rect.height > 0 ? (
+            <PlacementPreviewLayer
+              isDark={isDark}
+              preview={{
+                entityKind: 'shape',
+                shapeKind: shapePlacementPreview.shapeKind,
+                left: shapePlacementPreview.rect.left,
+                top: shapePlacementPreview.rect.top,
+                width: shapePlacementPreview.rect.width,
+                height: shapePlacementPreview.rect.height,
+              }}
+            />
+          ) : null}
           <DragCopyPreviewLayer dragCopyPreview={dragCopyPreview} isDark={isDark} />
         </>
       ) : null}

--- a/src/renderer/canvas-bg/App.tsx
+++ b/src/renderer/canvas-bg/App.tsx
@@ -4,6 +4,7 @@ import type {
   CanvasSceneDrawingEntity,
   CanvasSceneFileEntity,
   CanvasSceneFrameEntity,
+  CanvasSceneShapeEntity,
   CanvasSceneTextEntity,
   LayoutUpdateData,
   ThemeData,
@@ -22,6 +23,7 @@ import { FrameBorderLayer } from './FrameBorderLayer'
 import { SvgDeviceShellLayer } from './SvgDeviceShellLayer'
 import { FrameChromeLayer } from './FrameChromeLayer'
 import { TextBlockLayer } from './TextBlockLayer'
+import { ShapeBlockLayer } from './ShapeBlockLayer'
 import { FileBlockLayer, type FileJsonModeMap } from './FileBlockLayer'
 import { FileChromeLayer } from './FileChromeLayer'
 import { GroupBoundsLayer } from './GroupBoundsLayer'
@@ -102,6 +104,33 @@ export default function App({
   const drawingEntities = useMemo(
     () => layoutData.entities.filter((e): e is CanvasSceneDrawingEntity => e.kind === 'drawing'),
     [layoutData.entities],
+  )
+  const shapeEntities = useMemo(
+    () => layoutData.entities.filter((e): e is CanvasSceneShapeEntity => e.kind === 'shape'),
+    [layoutData.entities],
+  )
+  const [pendingShapeEditId, setPendingShapeEditId] = useState<string | null>(null)
+  const requestShapeEdit = useCallback((entityId: string) => {
+    api.selectEntity(entityId, 'shape')
+    setPendingShapeEditId(entityId)
+  }, [])
+  useEffect(() => {
+    if (!pendingShapeEditId) return
+    const timeoutId = window.setTimeout(() => setPendingShapeEditId(null), 1000)
+    return () => window.clearTimeout(timeoutId)
+  }, [pendingShapeEditId])
+  useEffect(() => {
+    if (!pendingShapeEditId) return
+    if (!shapeEntities.some((entity) => entity.id === pendingShapeEditId)) {
+      setPendingShapeEditId(null)
+    }
+  }, [pendingShapeEditId, shapeEntities])
+  useEffect(
+    () =>
+      api.onShapeBeginEdit(({ entityId }) => {
+        setPendingShapeEditId(entityId)
+      }),
+    [],
   )
   const borderFrames = useMemo(
     () => layoutData.viewMode === 'browser'
@@ -434,6 +463,38 @@ export default function App({
             onSelect={(id, modifiers) => api.selectEntity(id, 'text', modifiers)}
             onTextEditingChange={api.setTextEditing}
             onUpdateText={(id, text) => api.updateTextEntity(id, { text })}
+            selectedEntityCount={layoutData.selectedEntityIds.length}
+            selectedEntityIdSet={selectedEntityIdSet}
+            selectedGroupDescendantIds={selectedGroupDescendantIds}
+            selectedGroupId={layoutData.selectedGroupId ?? null}
+          />
+        </CanvasEntityViewportLayer>
+      ) : null}
+
+      {layoutData.viewMode === 'canvas' ? (
+        <CanvasEntityViewportLayer
+          canvasOrigin={layoutData.canvasOrigin}
+          pan={layoutData.pan}
+          zoom={layoutData.zoom}
+        >
+          <ShapeBlockLayer
+            entities={shapeEntities}
+            getZoom={getEntityLayerZoom}
+            isDark={isDark}
+            marqueePreviewIds={marqueePreviewIds}
+            pendingEditEntityId={pendingShapeEditId}
+            onDrag={api.dragEntity}
+            onDragEnd={api.endDragEntity}
+            onDragStart={api.startDragEntity}
+            onGroupDrag={api.dragGroup}
+            onGroupDragEnd={api.endDragGroup}
+            onGroupDragStart={api.startDragGroup}
+            onResize={(id, patch) => api.updateShapeEntity(id, patch)}
+            onSelect={(id, modifiers) => api.selectEntity(id, 'shape', modifiers)}
+            onRequestEdit={requestShapeEdit}
+            onPendingFocusConsumed={() => setPendingShapeEditId(null)}
+            onTextEditingChange={api.setTextEditing}
+            onUpdateText={(id, text) => api.updateShapeEntity(id, { text })}
             selectedEntityCount={layoutData.selectedEntityIds.length}
             selectedEntityIdSet={selectedEntityIdSet}
             selectedGroupDescendantIds={selectedGroupDescendantIds}

--- a/src/renderer/canvas-bg/CanvasGridSurface.tsx
+++ b/src/renderer/canvas-bg/CanvasGridSurface.tsx
@@ -83,11 +83,60 @@ export function PlacementPreviewLayer({
   preview,
 }: {
   isDark: boolean
-  preview: { entityKind?: string; left: number; top: number; width: number; height: number } | null
+  preview: { entityKind?: string; shapeKind?: string; left: number; top: number; width: number; height: number } | null
 }) {
   if (!preview) return null
   const isTextEntity = preview.entityKind === 'text'
   const isFileEntity = preview.entityKind === 'file'
+  const isShape = preview.entityKind === 'shape'
+  if (isShape) {
+    const baseStyle = previewBoxStyle(isDark, preview)
+    const stroke = isDark ? 'rgba(168, 162, 158, 0.6)' : 'rgba(120, 113, 108, 0.6)'
+    const fill = 'transparent'
+    if (preview.shapeKind === 'ellipse') {
+      return (
+        <div
+          className="pointer-events-none absolute border"
+          style={{ ...baseStyle, borderRadius: '50%', borderColor: stroke, background: fill }}
+        />
+      )
+    }
+    if (preview.shapeKind === 'diamond') {
+      return (
+        <div
+          className="pointer-events-none absolute"
+          style={{ ...baseStyle, background: 'transparent' }}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <div
+              style={{
+                width: `${(1 / Math.SQRT2) * 100}%`,
+                height: `${(1 / Math.SQRT2) * 100}%`,
+                transform: 'rotate(45deg)',
+                border: `1px solid ${stroke}`,
+                background: fill,
+                boxSizing: 'border-box',
+              }}
+            />
+          </div>
+        </div>
+      )
+    }
+    return (
+      <div
+        className="pointer-events-none absolute border"
+        style={{ ...baseStyle, borderColor: stroke, background: fill }}
+      />
+    )
+  }
   return (
     <div
       className={`pointer-events-none absolute border ${isTextEntity || isFileEntity ? '' : 'rounded-[8px]'}`}

--- a/src/renderer/canvas-bg/CanvasGridSurface.tsx
+++ b/src/renderer/canvas-bg/CanvasGridSurface.tsx
@@ -103,31 +103,22 @@ export function PlacementPreviewLayer({
     }
     if (preview.shapeKind === 'diamond') {
       return (
-        <div
+        <svg
           className="pointer-events-none absolute"
-          style={{ ...baseStyle, background: 'transparent' }}
+          width={baseStyle.width}
+          height={baseStyle.height}
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          style={{ left: baseStyle.left, top: baseStyle.top, overflow: 'visible' }}
         >
-          <div
-            style={{
-              position: 'absolute',
-              inset: 0,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <div
-              style={{
-                width: `${(1 / Math.SQRT2) * 100}%`,
-                height: `${(1 / Math.SQRT2) * 100}%`,
-                transform: 'rotate(45deg)',
-                border: `1px solid ${stroke}`,
-                background: fill,
-                boxSizing: 'border-box',
-              }}
-            />
-          </div>
-        </div>
+          <polygon
+            points="50,0 100,50 50,100 0,50"
+            fill={fill}
+            stroke={stroke}
+            strokeWidth={1}
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
       )
     }
     return (

--- a/src/renderer/canvas-bg/CanvasSelectionLayers.tsx
+++ b/src/renderer/canvas-bg/CanvasSelectionLayers.tsx
@@ -4,6 +4,7 @@ import type {
   CanvasSceneFileEntity,
   CanvasSceneFrameEntity,
   CanvasSceneGroupEntity,
+  CanvasSceneShapeEntity,
   CanvasSceneTextEntity,
 } from '../../shared/types'
 import { selectionColor } from './canvasBgConstants'
@@ -17,6 +18,8 @@ import {
   MIN_TEXT_HEIGHT,
   MIN_FILE_WIDTH,
   MIN_FILE_HEIGHT,
+  MIN_SHAPE_WIDTH,
+  MIN_SHAPE_HEIGHT,
 } from './entityConstants'
 import { CornerResizeHandle, EdgeResizeHandle } from './ResizeHandles'
 import { SelectionResizeGrid } from './SelectionResizeGrid'
@@ -144,7 +147,7 @@ function EntitySelectionOverlay({
   onResize,
   onMouseDown,
 }: {
-  entity: CanvasSceneTextEntity | CanvasSceneFileEntity | CanvasSceneDrawingEntity
+  entity: CanvasSceneTextEntity | CanvasSceneFileEntity | CanvasSceneDrawingEntity | CanvasSceneShapeEntity
   borderRadius: number
   isDark: boolean
   isSelected: boolean
@@ -153,9 +156,21 @@ function EntitySelectionOverlay({
   onMouseDown?: (id: string, event: React.MouseEvent) => void
 }) {
   const minWidth =
-    entity.kind === 'text' ? MIN_TEXT_WIDTH : entity.kind === 'file' ? MIN_FILE_WIDTH : 16
+    entity.kind === 'text'
+      ? MIN_TEXT_WIDTH
+      : entity.kind === 'file'
+        ? MIN_FILE_WIDTH
+        : entity.kind === 'shape'
+          ? MIN_SHAPE_WIDTH
+          : 16
   const minHeight =
-    entity.kind === 'text' ? MIN_TEXT_HEIGHT : entity.kind === 'file' ? MIN_FILE_HEIGHT : 16
+    entity.kind === 'text'
+      ? MIN_TEXT_HEIGHT
+      : entity.kind === 'file'
+        ? MIN_FILE_HEIGHT
+        : entity.kind === 'shape'
+          ? MIN_SHAPE_HEIGHT
+          : 16
   const aspectRatioResizeMode =
     entity.kind === 'file' ? aspectRatioResizeModeForCanvasFile(entity.file) : 'off'
   const zoom = entity.width > 0 ? entity.screenWidth / entity.width : 1
@@ -283,6 +298,7 @@ export function CanvasSelectionOutlineLayer({
   allTextEntities,
   allFileEntities,
   allDrawingEntities,
+  allShapeEntities,
   frameInteractionsEnabled,
   isDark,
   zoom,
@@ -294,6 +310,7 @@ export function CanvasSelectionOutlineLayer({
   onResizeTextEntity,
   onResizeFileEntity,
   onResizeDrawingEntity,
+  onResizeShapeEntity,
   onResizeMulti,
   onDrawingMouseDown,
 }: {
@@ -301,6 +318,7 @@ export function CanvasSelectionOutlineLayer({
   allTextEntities: CanvasSceneTextEntity[]
   allFileEntities: CanvasSceneFileEntity[]
   allDrawingEntities: CanvasSceneDrawingEntity[]
+  allShapeEntities: CanvasSceneShapeEntity[]
   frameInteractionsEnabled: boolean
   isDark: boolean
   zoom: number
@@ -315,6 +333,7 @@ export function CanvasSelectionOutlineLayer({
   onResizeTextEntity: (id: string, patch: EntityResizePatch) => void
   onResizeFileEntity: (id: string, patch: EntityResizePatch) => void
   onResizeDrawingEntity: (id: string, patch: EntityResizePatch) => void
+  onResizeShapeEntity: (id: string, patch: EntityResizePatch) => void
   onResizeMulti: (entries: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing'; width: number; height: number; canvasX: number; canvasY: number }>) => void
   onDrawingMouseDown: (drawingId: string, event: React.MouseEvent) => void
 }) {
@@ -322,10 +341,10 @@ export function CanvasSelectionOutlineLayer({
   const entityHoverId = localHoverId ?? hoveredEntityId
   const isMultiSelect = selectedIdSet.size > 1
   const entities = useMemo(
-    () => [...allTextEntities, ...allFileEntities, ...allDrawingEntities].filter(
+    () => [...allTextEntities, ...allFileEntities, ...allDrawingEntities, ...allShapeEntities].filter(
       (e) => selectedIdSet.has(e.id) || e.id === entityHoverId || marqueePreviewIds?.has(e.id),
     ),
-    [allDrawingEntities, allFileEntities, allTextEntities, selectedIdSet, entityHoverId, marqueePreviewIds],
+    [allDrawingEntities, allFileEntities, allTextEntities, allShapeEntities, selectedIdSet, entityHoverId, marqueePreviewIds],
   )
 
   const allSelectedEntities = useMemo(() => {
@@ -408,7 +427,9 @@ export function CanvasSelectionOutlineLayer({
                 ? onResizeTextEntity
                 : entity.kind === 'file'
                   ? onResizeFileEntity
-                  : onResizeDrawingEntity
+                  : entity.kind === 'shape'
+                    ? onResizeShapeEntity
+                    : onResizeDrawingEntity
             }
             onMouseDown={entity.kind === 'drawing' ? onDrawingMouseDown : undefined}
           />

--- a/src/renderer/canvas-bg/CanvasSelectionLayers.tsx
+++ b/src/renderer/canvas-bg/CanvasSelectionLayers.tsx
@@ -223,10 +223,10 @@ function MultiSelectionBoundingBox({
   isDark,
   onResizeMulti,
 }: {
-  selectedEntities: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing'; canvasX: number; canvasY: number; width: number; height: number; screenX: number; screenY: number; screenWidth: number; screenHeight: number }>
+  selectedEntities: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing' | 'shape'; canvasX: number; canvasY: number; width: number; height: number; screenX: number; screenY: number; screenWidth: number; screenHeight: number }>
   zoom: number
   isDark: boolean
-  onResizeMulti: (entries: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing'; width: number; height: number; canvasX: number; canvasY: number }>) => void
+  onResizeMulti: (entries: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing' | 'shape'; width: number; height: number; canvasX: number; canvasY: number }>) => void
 }) {
   const screenBbox = useMemo(() => {
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
@@ -334,7 +334,7 @@ export function CanvasSelectionOutlineLayer({
   onResizeFileEntity: (id: string, patch: EntityResizePatch) => void
   onResizeDrawingEntity: (id: string, patch: EntityResizePatch) => void
   onResizeShapeEntity: (id: string, patch: EntityResizePatch) => void
-  onResizeMulti: (entries: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing'; width: number; height: number; canvasX: number; canvasY: number }>) => void
+  onResizeMulti: (entries: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing' | 'shape'; width: number; height: number; canvasX: number; canvasY: number }>) => void
   onDrawingMouseDown: (drawingId: string, event: React.MouseEvent) => void
 }) {
   const localHoverId = useContext(EntityHoverValueContext)
@@ -349,7 +349,7 @@ export function CanvasSelectionOutlineLayer({
 
   const allSelectedEntities = useMemo(() => {
     if (!isMultiSelect) return []
-    const selected: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing'; canvasX: number; canvasY: number; width: number; height: number; screenX: number; screenY: number; screenWidth: number; screenHeight: number }> = []
+    const selected: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing' | 'shape'; canvasX: number; canvasY: number; width: number; height: number; screenX: number; screenY: number; screenWidth: number; screenHeight: number }> = []
     for (const f of frames) {
       if (selectedIdSet.has(f.id)) selected.push(f)
     }
@@ -362,8 +362,11 @@ export function CanvasSelectionOutlineLayer({
     for (const e of allDrawingEntities) {
       if (selectedIdSet.has(e.id)) selected.push(e)
     }
+    for (const e of allShapeEntities) {
+      if (selectedIdSet.has(e.id)) selected.push(e)
+    }
     return selected
-  }, [isMultiSelect, frames, allTextEntities, allFileEntities, allDrawingEntities, selectedIdSet])
+  }, [isMultiSelect, frames, allTextEntities, allFileEntities, allDrawingEntities, allShapeEntities, selectedIdSet])
 
   return (
     <>

--- a/src/renderer/canvas-bg/EdgeLayer.tsx
+++ b/src/renderer/canvas-bg/EdgeLayer.tsx
@@ -14,10 +14,10 @@ import { scaleEdgeHitTargetSize } from './edgeHitSizing'
 
 const SIDES: EdgeSide[] = ['top', 'right', 'bottom', 'left']
 const DOT_RADIUS = 3
-const DOT_HIT_LONG = 56
-const DOT_HIT_SHORT = 24
-const DOT_HIT_GAP = 4
-const DOT_HIT_CORNER = 2
+const EDGE_HIT_ALONG = 56
+const EDGE_HIT_ACROSS = 24
+const EDGE_HIT_GAP = 4
+const EDGE_HIT_CORNER = 2
 const DOT_OFFSET = 8
 const SNAP_DISTANCE = 48
 const CONTROL_POINT_MIN = 40
@@ -53,38 +53,22 @@ function getAnchorHitRect(
   zoom: number,
 ): { x: number; y: number; width: number; height: number } {
   const { screenX, screenY, screenWidth, screenHeight } = entity
-  const long = scaleEdgeHitTargetSize(DOT_HIT_LONG, zoom)
-  const short = scaleEdgeHitTargetSize(DOT_HIT_SHORT, zoom)
-  const gap = DOT_HIT_GAP
+  const along = scaleEdgeHitTargetSize(EDGE_HIT_ALONG, zoom)
+  const across = scaleEdgeHitTargetSize(EDGE_HIT_ACROSS, zoom)
+  const horizontal = side === 'top' || side === 'bottom'
+  const width = horizontal ? along : across
+  const height = horizontal ? across : along
+  const cx = screenX + screenWidth / 2
+  const cy = screenY + screenHeight / 2
   switch (side) {
     case 'top':
-      return {
-        x: screenX + screenWidth / 2 - long / 2,
-        y: screenY - gap - short,
-        width: long,
-        height: short,
-      }
+      return { x: cx - width / 2, y: screenY - EDGE_HIT_GAP - height, width, height }
     case 'bottom':
-      return {
-        x: screenX + screenWidth / 2 - long / 2,
-        y: screenY + screenHeight + gap,
-        width: long,
-        height: short,
-      }
+      return { x: cx - width / 2, y: screenY + screenHeight + EDGE_HIT_GAP, width, height }
     case 'left':
-      return {
-        x: screenX - gap - short,
-        y: screenY + screenHeight / 2 - long / 2,
-        width: short,
-        height: long,
-      }
+      return { x: screenX - EDGE_HIT_GAP - width, y: cy - height / 2, width, height }
     case 'right':
-      return {
-        x: screenX + screenWidth + gap,
-        y: screenY + screenHeight / 2 - long / 2,
-        width: short,
-        height: long,
-      }
+      return { x: screenX + screenWidth + EDGE_HIT_GAP, y: cy - height / 2, width, height }
   }
 }
 
@@ -235,14 +219,13 @@ function AnchorDots({
                 strokeWidth={1}
               />
             ) : null}
-            {/* Zoom-scaled interaction target */}
             <rect
               x={hitRect.x}
               y={hitRect.y}
               width={hitRect.width}
               height={hitRect.height}
-              rx={DOT_HIT_CORNER}
-              ry={DOT_HIT_CORNER}
+              rx={EDGE_HIT_CORNER}
+              ry={EDGE_HIT_CORNER}
               fill="transparent"
               style={{ cursor: 'crosshair', pointerEvents: 'all' }}
               onMouseDown={(e) => {

--- a/src/renderer/canvas-bg/EdgeLayer.tsx
+++ b/src/renderer/canvas-bg/EdgeLayer.tsx
@@ -14,7 +14,10 @@ import { scaleEdgeHitTargetSize } from './edgeHitSizing'
 
 const SIDES: EdgeSide[] = ['top', 'right', 'bottom', 'left']
 const DOT_RADIUS = 3
-const DOT_HIT_RADIUS = 24
+const DOT_HIT_LONG = 56
+const DOT_HIT_SHORT = 24
+const DOT_HIT_GAP = 4
+const DOT_HIT_CORNER = 2
 const DOT_OFFSET = 8
 const SNAP_DISTANCE = 48
 const CONTROL_POINT_MIN = 40
@@ -41,6 +44,47 @@ function getAnchorPoint(entity: CanvasSceneEntity, side: EdgeSide, zoom: number)
       return { x: screenX - dotOffset, y: screenY + screenHeight / 2, side }
     case 'right':
       return { x: screenX + screenWidth + dotOffset, y: screenY + screenHeight / 2, side }
+  }
+}
+
+function getAnchorHitRect(
+  entity: CanvasSceneEntity,
+  side: EdgeSide,
+  zoom: number,
+): { x: number; y: number; width: number; height: number } {
+  const { screenX, screenY, screenWidth, screenHeight } = entity
+  const long = scaleEdgeHitTargetSize(DOT_HIT_LONG, zoom)
+  const short = scaleEdgeHitTargetSize(DOT_HIT_SHORT, zoom)
+  const gap = DOT_HIT_GAP
+  switch (side) {
+    case 'top':
+      return {
+        x: screenX + screenWidth / 2 - long / 2,
+        y: screenY - gap - short,
+        width: long,
+        height: short,
+      }
+    case 'bottom':
+      return {
+        x: screenX + screenWidth / 2 - long / 2,
+        y: screenY + screenHeight + gap,
+        width: long,
+        height: short,
+      }
+    case 'left':
+      return {
+        x: screenX - gap - short,
+        y: screenY + screenHeight / 2 - long / 2,
+        width: short,
+        height: long,
+      }
+    case 'right':
+      return {
+        x: screenX + screenWidth + gap,
+        y: screenY + screenHeight / 2 - long / 2,
+        width: short,
+        height: long,
+      }
   }
 }
 
@@ -168,7 +212,6 @@ function AnchorDots({
   onHoverEntity: (entityId: string | null) => void
 }) {
   const [hoveredSide, setHoveredSide] = useState<EdgeSide | null>(null)
-  const dotHitRadius = scaleEdgeHitTargetSize(DOT_HIT_RADIUS, zoom)
 
   useEffect(() => {
     if (!isDragging) setHoveredSide(null)
@@ -178,6 +221,7 @@ function AnchorDots({
     <>
       {SIDES.map((side) => {
         const pt = getAnchorPoint(entity, side, zoom)
+        const hitRect = getAnchorHitRect(entity, side, zoom)
         const showDot = hoveredSide === side
         return (
           <g key={side}>
@@ -192,11 +236,14 @@ function AnchorDots({
               />
             ) : null}
             {/* Zoom-scaled interaction target */}
-            <circle
-              cx={pt.x}
-              cy={pt.y}
+            <rect
+              x={hitRect.x}
+              y={hitRect.y}
+              width={hitRect.width}
+              height={hitRect.height}
+              rx={DOT_HIT_CORNER}
+              ry={DOT_HIT_CORNER}
               fill="transparent"
-              r={dotHitRadius}
               style={{ cursor: 'crosshair', pointerEvents: 'all' }}
               onMouseDown={(e) => {
                 e.stopPropagation()

--- a/src/renderer/canvas-bg/EdgeLayer.tsx
+++ b/src/renderer/canvas-bg/EdgeLayer.tsx
@@ -89,6 +89,50 @@ function findClosestAnchorTarget(
   return bestTarget
 }
 
+/**
+ * Find an edge whose endpoint sits at the given anchor (entity + side).
+ * Used to detect when an anchor-dot grab should edit an existing edge
+ * rather than start a new one. Auto-side edges are matched against their
+ * resolved sides so their visible endpoints behave the same way.
+ */
+function findEdgeAtAnchor(
+  edges: WorkspaceEdge[],
+  entityMap: Map<string, CanvasSceneEntity>,
+  entityId: string,
+  side: EdgeSide,
+): {
+  edgeId: string
+  movingEnd: 'from' | 'to'
+  fixedEntityId: string
+  fixedSide: EdgeSide
+} | null {
+  for (const edge of edges) {
+    const fromEntity = entityMap.get(edge.fromEntityId)
+    const toEntity = entityMap.get(edge.toEntityId)
+    if (!fromEntity || !toEntity) continue
+    const { fromSide, toSide } = edge.fromSide && edge.toSide
+      ? { fromSide: edge.fromSide, toSide: edge.toSide }
+      : autoSides(fromEntity, toEntity)
+    if (edge.toEntityId === entityId && toSide === side) {
+      return {
+        edgeId: edge.id,
+        movingEnd: 'to',
+        fixedEntityId: edge.fromEntityId,
+        fixedSide: fromSide,
+      }
+    }
+    if (edge.fromEntityId === entityId && fromSide === side) {
+      return {
+        edgeId: edge.id,
+        movingEnd: 'from',
+        fixedEntityId: edge.toEntityId,
+        fixedSide: toSide,
+      }
+    }
+  }
+  return null
+}
+
 /** Pick the best sides to connect two entities when sides aren't specified. */
 function autoSides(
   from: CanvasSceneEntity,
@@ -185,12 +229,14 @@ export function EdgeLayer({
   hoveredEntityId,
   isDark,
   interaction,
-  selectedEdgeId,
+  selectedEdgeIds,
   selectedEntityIds,
   zoom,
   onBeginEdgeDrag,
   onCancelEdgeDrag,
   onCommitEdgeDrag,
+  onCommitEdgeEdit,
+  onDiscardEdgeEdit,
   onSelectEdge,
   onHoverEntity,
   onUpdateEdgeDragTarget,
@@ -200,12 +246,19 @@ export function EdgeLayer({
   hoveredEntityId: string | null
   isDark: boolean
   interaction: CanvasInteractionState
-  selectedEdgeId: string | null
+  selectedEdgeIds: ReadonlySet<string>
   selectedEntityIds: string[]
   zoom: number
   onBeginEdgeDrag: (fromEntityId: string, fromSide: EdgeSide) => void
   onCancelEdgeDrag: () => void
   onCommitEdgeDrag: (fromEntityId: string, toEntityId: string, fromSide: EdgeSide, toSide: EdgeSide) => void
+  onCommitEdgeEdit: (
+    edgeId: string,
+    movingEnd: 'from' | 'to',
+    targetEntityId: string,
+    targetSide: EdgeSide,
+  ) => void
+  onDiscardEdgeEdit: (edgeId: string) => void
   onSelectEdge: (edgeId: string) => void
   onHoverEntity: (entityId: string | null) => void
   onUpdateEdgeDragTarget: (targetEntityId: string | null, targetSide: EdgeSide | null) => void
@@ -217,12 +270,26 @@ export function EdgeLayer({
   }, [entities])
 
   // --- Edge creation drag state ---
-  const [dragState, setDragState] = useState<{
-    fromEntityId: string
-    fromSide: EdgeSide
-    cursorX: number
-    cursorY: number
-  } | null>(null)
+  // 'create' = new edge from this anchor; 'edit' = re-route or delete an
+  // existing edge whose endpoint sits at this anchor.
+  type DragState =
+    | {
+        mode: 'create'
+        fromEntityId: string
+        fromSide: EdgeSide
+        cursorX: number
+        cursorY: number
+      }
+    | {
+        mode: 'edit'
+        edgeId: string
+        movingEnd: 'from' | 'to'
+        fixedEntityId: string
+        fixedSide: EdgeSide
+        cursorX: number
+        cursorY: number
+      }
+  const [dragState, setDragState] = useState<DragState | null>(null)
 
   const hoveredDragEntityIdRef = useRef<string | null>(null)
   const dragListenersRef = useRef<{ move: (e: MouseEvent) => void; up: (e: MouseEvent) => void } | null>(null)
@@ -243,13 +310,38 @@ export function EdgeLayer({
 
   const handleDragStart = useCallback(
     (entityId: string, side: EdgeSide, clientX: number, clientY: number) => {
-      setDragState({ fromEntityId: entityId, fromSide: side, cursorX: clientX, cursorY: clientY })
-      onBeginEdgeDrag(entityId, side)
+      // Grabbing an anchor that already hosts an edge endpoint re-routes (or
+      // deletes) that edge instead of starting a new one.
+      const existing = findEdgeAtAnchor(edges, entityMap, entityId, side)
+      const initialDrag: DragState = existing
+        ? {
+            mode: 'edit',
+            edgeId: existing.edgeId,
+            movingEnd: existing.movingEnd,
+            fixedEntityId: existing.fixedEntityId,
+            fixedSide: existing.fixedSide,
+            cursorX: clientX,
+            cursorY: clientY,
+          }
+        : {
+            mode: 'create',
+            fromEntityId: entityId,
+            fromSide: side,
+            cursorX: clientX,
+            cursorY: clientY,
+          }
+      setDragState(initialDrag)
+
+      const dragOriginEntityId =
+        initialDrag.mode === 'edit' ? initialDrag.fixedEntityId : entityId
+      const dragOriginSide =
+        initialDrag.mode === 'edit' ? initialDrag.fixedSide : side
+      onBeginEdgeDrag(dragOriginEntityId, dragOriginSide)
 
       const handleMove = (e: MouseEvent) => {
         const bestTarget = findClosestAnchorTarget(
           entityMap,
-          entityId,
+          dragOriginEntityId,
           e.clientX,
           e.clientY,
           scaleEdgeHitTargetSize(SNAP_DISTANCE, zoomRef.current),
@@ -274,14 +366,25 @@ export function EdgeLayer({
 
         const bestTarget = findClosestAnchorTarget(
           entityMap,
-          entityId,
+          dragOriginEntityId,
           e.clientX,
           e.clientY,
           scaleEdgeHitTargetSize(SNAP_DISTANCE, zoomRef.current),
           zoomRef.current,
         )
 
-        if (bestTarget) {
+        if (initialDrag.mode === 'edit') {
+          if (bestTarget) {
+            onCommitEdgeEdit(
+              initialDrag.edgeId,
+              initialDrag.movingEnd,
+              bestTarget.entityId,
+              bestTarget.side,
+            )
+          } else {
+            onDiscardEdgeEdit(initialDrag.edgeId)
+          }
+        } else if (bestTarget) {
           onCommitEdgeDrag(entityId, bestTarget.entityId, side, bestTarget.side)
         } else {
           onCancelEdgeDrag()
@@ -297,10 +400,23 @@ export function EdgeLayer({
       window.addEventListener('mousemove', handleMove)
       window.addEventListener('mouseup', handleUp)
     },
-    [entityMap, onBeginEdgeDrag, onCancelEdgeDrag, onCommitEdgeDrag, onHoverEntity, onUpdateEdgeDragTarget],
+    [
+      edges,
+      entityMap,
+      onBeginEdgeDrag,
+      onCancelEdgeDrag,
+      onCommitEdgeDrag,
+      onCommitEdgeEdit,
+      onDiscardEdgeEdit,
+      onHoverEntity,
+      onUpdateEdgeDragTarget,
+    ],
   )
 
-  // Render existing edges
+  const editingEdgeId = dragState?.mode === 'edit' ? dragState.edgeId : null
+
+  // Render existing edges (skip the one being re-routed — the dashed drag
+  // path stands in for it).
   const edgePaths = useMemo(() => {
     const paths: Array<{
       id: string
@@ -312,6 +428,7 @@ export function EdgeLayer({
     }> = []
 
     for (const edge of edges) {
+      if (edge.id === editingEdgeId) continue
       const fromEntity = entityMap.get(edge.fromEntityId)
       const toEntity = entityMap.get(edge.toEntityId)
       if (!fromEntity || !toEntity) continue
@@ -326,29 +443,45 @@ export function EdgeLayer({
       paths.push({
         id: edge.id,
         d,
-        selected: edge.id === selectedEdgeId,
+        selected: selectedEdgeIds.has(edge.id),
         fromEnd: edge.fromEnd ?? 'none',
         toEnd: edge.toEnd ?? 'arrow',
         color: edge.color,
       })
     }
     return paths
-  }, [edges, entityMap, selectedEdgeId, zoom])
+  }, [edges, entityMap, selectedEdgeIds, zoom, editingEdgeId])
 
-  // Temporary drag edge path
+  // Temporary drag edge path: in 'create' mode it grows from the grabbed
+  // anchor; in 'edit' mode it grows from the fixed (non-moving) endpoint.
   const dragPath = useMemo(() => {
     if (!dragState) return null
-    const fromEntity = entityMap.get(dragState.fromEntityId)
-    if (!fromEntity) return null
-    const from = getAnchorPoint(fromEntity, dragState.fromSide, zoom)
-    const to: AnchorPoint = { x: dragState.cursorX, y: dragState.cursorY, side: dragState.fromSide === 'left' ? 'right' : dragState.fromSide === 'right' ? 'left' : dragState.fromSide === 'top' ? 'bottom' : 'top' }
+    const anchorEntityId =
+      dragState.mode === 'create' ? dragState.fromEntityId : dragState.fixedEntityId
+    const anchorSide =
+      dragState.mode === 'create' ? dragState.fromSide : dragState.fixedSide
+    const anchorEntity = entityMap.get(anchorEntityId)
+    if (!anchorEntity) return null
+    const from = getAnchorPoint(anchorEntity, anchorSide, zoom)
+    const to: AnchorPoint = {
+      x: dragState.cursorX,
+      y: dragState.cursorY,
+      side:
+        anchorSide === 'left'
+          ? 'right'
+          : anchorSide === 'right'
+            ? 'left'
+            : anchorSide === 'top'
+              ? 'bottom'
+              : 'top',
+    }
     return buildBezierPath(from, to, zoom)
   }, [dragState, entityMap, zoom])
 
   // Which entities should show anchor dots: selected + hovered entities, or all during drag
   const anchorEntities = useMemo(() => {
     const ids = new Set<string>()
-    if (!selectedEdgeId) {
+    if (selectedEdgeIds.size === 0) {
       for (const id of selectedEntityIds) {
         if (entityMap.has(id)) ids.add(id)
       }
@@ -359,7 +492,7 @@ export function EdgeLayer({
       for (const eId of entityMap.keys()) ids.add(eId)
     }
     return [...ids].map((id) => entityMap.get(id)!).filter(Boolean)
-  }, [selectedEntityIds, selectedEdgeId, hoveredEntityId, dragState, entityMap, interaction.kind])
+  }, [selectedEntityIds, selectedEdgeIds, hoveredEntityId, dragState, entityMap, interaction.kind])
 
   return (
     <svg

--- a/src/renderer/canvas-bg/FrameChromeLayer.tsx
+++ b/src/renderer/canvas-bg/FrameChromeLayer.tsx
@@ -97,11 +97,6 @@ function FrameChromeItem({
     setPendingUrl(null)
   }, [frame.url])
 
-  // Reset editing when becoming inactive
-  useEffect(() => {
-    if (!isActive && isEditing) setIsEditing(false)
-  }, [isActive, isEditing])
-
   const editValue = isBlank ? '' : frame.url
   const displayValue = isBlank
     ? 'Type a URL'

--- a/src/renderer/canvas-bg/SelectableEntityShell.tsx
+++ b/src/renderer/canvas-bg/SelectableEntityShell.tsx
@@ -35,6 +35,7 @@ export function SelectableEntityShell({
   borderRadius,
   showCardShadow = true,
   onSelect,
+  onDoubleClick,
   onResize,
   onDragStart,
   onDrag,
@@ -64,6 +65,7 @@ export function SelectableEntityShell({
   borderRadius?: number
   showCardShadow?: boolean
   onSelect: (id: string, modifiers?: SelectionModifiers) => void
+  onDoubleClick?: (id: string, event: React.MouseEvent<HTMLDivElement>) => void
   onResize: (id: string, patch: EntityResizePatch) => void
   onDragStart: (id: string) => void
   onDrag: (id: string, dx: number, dy: number) => void
@@ -201,6 +203,12 @@ export function SelectableEntityShell({
           ctrl: event.ctrlKey,
         })
         event.stopPropagation()
+      }}
+      onDoubleClick={(event) => {
+        if (!onDoubleClick) return
+        const target = event.target as HTMLElement | null
+        if (target?.closest('[data-resize-handle], button, input, textarea')) return
+        onDoubleClick(id, event)
       }}
     >
       {children}

--- a/src/renderer/canvas-bg/ShapeBlockLayer.tsx
+++ b/src/renderer/canvas-bg/ShapeBlockLayer.tsx
@@ -7,7 +7,7 @@ import { MIN_SHAPE_WIDTH, MIN_SHAPE_HEIGHT } from './entityConstants'
 
 const DEFAULT_STROKE_WIDTH = 2
 const FILL_OPACITY = 0.2
-const NEUTRAL_SLATE = '#94a3b8'
+const NEUTRAL_SLATE = '#6b7280'
 
 function ShapeBody({
   shape,

--- a/src/renderer/canvas-bg/ShapeBlockLayer.tsx
+++ b/src/renderer/canvas-bg/ShapeBlockLayer.tsx
@@ -7,10 +7,7 @@ import { MIN_SHAPE_WIDTH, MIN_SHAPE_HEIGHT } from './entityConstants'
 
 const DEFAULT_STROKE_WIDTH = 2
 const FILL_OPACITY = 0.2
-
-function neutralStroke(isDark: boolean): string {
-  return isDark ? 'hsl(0 0% 50%)' : 'hsl(0 0% 60%)'
-}
+const NEUTRAL_SLATE = '#94a3b8'
 
 function ShapeBody({
   shape,
@@ -72,9 +69,9 @@ function ShapeBody({
   }, [canEdit, editing, onTextEditingChange])
 
   const stroke = shape.strokeWidth ?? DEFAULT_STROKE_WIDTH
-  const resolvedColor = shape.color ? resolveCanvasColor(shape.color) : null
-  const fill = resolvedColor ? withAlpha(resolvedColor, FILL_OPACITY) : 'transparent'
-  const strokeColor = resolvedColor ?? neutralStroke(isDark)
+  const resolvedColor = shape.color ? resolveCanvasColor(shape.color) : NEUTRAL_SLATE
+  const fill = withAlpha(resolvedColor, FILL_OPACITY)
+  const strokeColor = resolvedColor
   const textColor = isDark && !shape.color ? 'rgb(220, 220, 220)' : 'rgb(20, 20, 20)'
 
   const baseStyle: React.CSSProperties = {

--- a/src/renderer/canvas-bg/ShapeBlockLayer.tsx
+++ b/src/renderer/canvas-bg/ShapeBlockLayer.tsx
@@ -11,18 +11,6 @@ function neutralStroke(isDark: boolean): string {
   return isDark ? 'hsl(0 0% 50%)' : 'hsl(0 0% 60%)'
 }
 
-function fillFromColor(color: string | undefined): string {
-  if (!color) return 'transparent'
-  const resolved = resolveCanvasColor(color)
-  return resolved
-}
-
-function strokeFromColor(color: string | undefined, isDark: boolean): string {
-  if (!color) return neutralStroke(isDark)
-  const resolved = resolveCanvasColor(color)
-  return resolved
-}
-
 function ShapeBody({
   shape,
   isDark,
@@ -76,8 +64,8 @@ function ShapeBody({
   }, [canEdit, editing, onTextEditingChange])
 
   const stroke = shape.strokeWidth ?? DEFAULT_STROKE_WIDTH
-  const fill = fillFromColor(shape.color)
-  const strokeColor = strokeFromColor(shape.color, isDark)
+  const fill = shape.color ? resolveCanvasColor(shape.color) : 'transparent'
+  const strokeColor = shape.color ? resolveCanvasColor(shape.color) : neutralStroke(isDark)
   const textColor = isDark && !shape.color ? 'rgb(220, 220, 220)' : 'rgb(20, 20, 20)'
 
   const baseStyle: React.CSSProperties = {

--- a/src/renderer/canvas-bg/ShapeBlockLayer.tsx
+++ b/src/renderer/canvas-bg/ShapeBlockLayer.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState } from 'react'
+import { memo, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { CanvasSceneShapeEntity, SelectionModifiers } from '../../shared/types'
 import { lightenHex, resolveCanvasColor, withAlpha } from '../../shared/canvas-colors'
 import { SelectableEntityShell } from './SelectableEntityShell'
@@ -10,23 +10,103 @@ const FILL_OPACITY = 0.24
 const FILL_LIGHTEN = 0.5
 const NEUTRAL_SLATE = '#6b7280'
 
+function ShapeText({
+  text,
+  editing,
+  textColor,
+  onChange,
+  onStartEditing,
+  onStopEditing,
+  onCommit,
+  containerStyle,
+}: {
+  text: string
+  editing: boolean
+  textColor: string
+  onChange: (value: string) => void
+  onStartEditing: () => void
+  onStopEditing: () => void
+  onCommit: (value: string) => void
+  containerStyle: React.CSSProperties
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  // Keep DOM textContent in sync with prop while not editing. Avoids overwriting
+  // the user's in-flight typing. useLayoutEffect runs before paint so the
+  // initial mount never shows an empty frame.
+  useLayoutEffect(() => {
+    if (!editing && ref.current && ref.current.textContent !== text) {
+      ref.current.textContent = text
+    }
+  }, [text, editing])
+
+  // On entering edit mode, focus and select all.
+  useEffect(() => {
+    const node = ref.current
+    if (!editing || !node) return
+    node.focus()
+    const range = document.createRange()
+    range.selectNodeContents(node)
+    const sel = window.getSelection()
+    sel?.removeAllRanges()
+    sel?.addRange(range)
+  }, [editing])
+
+  return (
+    <div style={containerStyle}>
+      <div
+        ref={ref}
+        contentEditable={editing}
+        suppressContentEditableWarning
+        onInput={(e) => onChange((e.target as HTMLDivElement).textContent ?? '')}
+        onMouseDown={(e) => { if (editing) e.stopPropagation() }}
+        onPointerDown={(e) => { if (editing) e.stopPropagation() }}
+        onFocus={onStartEditing}
+        onBlur={(e) => {
+          onStopEditing()
+          onCommit((e.target as HTMLDivElement).textContent ?? '')
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault()
+            ;(e.target as HTMLDivElement).blur()
+          }
+        }}
+        style={{
+          width: '100%',
+          maxHeight: '100%',
+          fontSize: 13,
+          lineHeight: 1.4,
+          color: textColor,
+          fontFamily: 'system-ui, sans-serif',
+          textAlign: 'center',
+          overflow: 'hidden',
+          wordBreak: 'break-word',
+          whiteSpace: 'pre-wrap',
+          outline: 'none',
+          userSelect: editing ? 'text' : 'none',
+          pointerEvents: editing ? 'auto' : 'none',
+          cursor: editing ? 'text' : 'inherit',
+        }}
+      />
+    </div>
+  )
+}
+
 function ShapeBody({
   shape,
   isDark,
   pendingFocus,
   onCommitText,
   onTextEditingChange,
-  onRequestEdit,
   onPendingFocusConsumed,
   canEdit,
-  selected,
 }: {
   shape: CanvasSceneShapeEntity
   isDark: boolean
   pendingFocus: boolean
   onCommitText: (text: string) => void
   onTextEditingChange: (active: boolean) => void
-  onRequestEdit: () => void
   onPendingFocusConsumed: () => void
   canEdit: boolean
   selected: boolean
@@ -34,7 +114,6 @@ function ShapeBody({
   const [editing, setEditing] = useState(false)
   const [localText, setLocalText] = useState(shape.text)
   const isFocusedRef = useRef(false)
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
     if (!isFocusedRef.current) setLocalText(shape.text)
@@ -46,20 +125,6 @@ function ShapeBody({
       onPendingFocusConsumed()
     }
   }, [canEdit, onPendingFocusConsumed, pendingFocus])
-
-  useEffect(() => {
-    if (editing && textareaRef.current) {
-      textareaRef.current.focus()
-      textareaRef.current.select()
-    }
-  }, [editing])
-
-  useEffect(() => {
-    const node = textareaRef.current
-    if (!editing || !node) return
-    node.style.height = 'auto'
-    node.style.height = `${node.scrollHeight}px`
-  }, [editing, localText, shape.width, shape.height])
 
   useEffect(() => {
     if (!canEdit && editing) {
@@ -86,89 +151,59 @@ function ShapeBody({
     pointerEvents: 'none',
   }
 
-  const textWrapperStyle: React.CSSProperties = {
-    position: 'absolute',
-    inset: 0,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 8,
-  }
+  const textContainerStyle: React.CSSProperties =
+    shape.shapeKind === 'diamond'
+      ? {
+          position: 'absolute',
+          left: '25%',
+          top: '25%',
+          width: '50%',
+          height: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 8,
+          boxSizing: 'border-box',
+          pointerEvents: editing ? 'auto' : 'none',
+        }
+      : {
+          position: 'absolute',
+          inset: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 8,
+          pointerEvents: editing ? 'auto' : 'none',
+        }
 
-  const innerTextStyle: React.CSSProperties = {
-    width: '100%',
-    height: 'auto',
-    maxHeight: '100%',
-    fontSize: 13,
-    lineHeight: 1.4,
-    color: textColor,
-    fontFamily: 'system-ui, sans-serif',
-    textAlign: 'center',
-    overflow: 'hidden',
-    wordBreak: 'break-word',
-    background: 'transparent',
-    border: 'none',
-    outline: 'none',
-    resize: 'none',
-    margin: 0,
-    padding: 0,
-    boxSizing: 'border-box',
-    pointerEvents: editing ? 'auto' : 'none',
-  }
-
-  const handleStartEdit = (event: React.MouseEvent) => {
-    event.preventDefault()
-    event.stopPropagation()
-    onRequestEdit()
-    if (canEdit) setEditing(true)
-  }
-
-  const renderText = () => (
-    <div style={textWrapperStyle} onDoubleClick={handleStartEdit}>
-      {editing ? (
-        <textarea
-          ref={textareaRef}
-          value={localText}
-          onChange={(e) => setLocalText(e.target.value)}
-          onMouseDown={(e) => e.stopPropagation()}
-          onPointerDown={(e) => e.stopPropagation()}
-          onFocus={() => {
-            isFocusedRef.current = true
-            onTextEditingChange(true)
-          }}
-          onKeyDown={(e) => {
-            if (e.key === 'Escape') {
-              e.preventDefault()
-              ;(e.target as HTMLTextAreaElement).blur()
-            }
-          }}
-          onBlur={() => {
-            isFocusedRef.current = false
-            onTextEditingChange(false)
-            setEditing(false)
-            onCommitText(localText)
-          }}
-          style={innerTextStyle}
-        />
-      ) : (
-        <div
-          style={{
-            ...innerTextStyle,
-            whiteSpace: 'pre-wrap',
-            userSelect: 'none',
-          }}
-        >
-          {localText}
-        </div>
-      )}
-    </div>
+  const text = (
+    <ShapeText
+      text={localText}
+      editing={editing}
+      textColor={textColor}
+      containerStyle={textContainerStyle}
+      onChange={setLocalText}
+      onStartEditing={() => {
+        isFocusedRef.current = true
+        onTextEditingChange(true)
+      }}
+      onStopEditing={() => {
+        isFocusedRef.current = false
+        onTextEditingChange(false)
+        setEditing(false)
+      }}
+      onCommit={(value) => {
+        setLocalText(value)
+        onCommitText(value)
+      }}
+    />
   )
 
   if (shape.shapeKind === 'rectangle') {
     return (
       <>
         <div style={baseStyle} />
-        {renderText()}
+        {text}
       </>
     )
   }
@@ -177,7 +212,7 @@ function ShapeBody({
     return (
       <>
         <div style={{ ...baseStyle, borderRadius: '50%' }} />
-        {renderText()}
+        {text}
       </>
     )
   }
@@ -203,58 +238,7 @@ function ShapeBody({
           vectorEffect="non-scaling-stroke"
         />
       </svg>
-      <div
-        style={{
-          position: 'absolute',
-          left: '25%',
-          top: '25%',
-          width: '50%',
-          height: '50%',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          padding: 8,
-          boxSizing: 'border-box',
-        }}
-        onDoubleClick={handleStartEdit}
-      >
-        {editing ? (
-          <textarea
-            ref={textareaRef}
-            value={localText}
-            onChange={(e) => setLocalText(e.target.value)}
-            onMouseDown={(e) => e.stopPropagation()}
-            onPointerDown={(e) => e.stopPropagation()}
-            onFocus={() => {
-              isFocusedRef.current = true
-              onTextEditingChange(true)
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') {
-                e.preventDefault()
-                ;(e.target as HTMLTextAreaElement).blur()
-              }
-            }}
-            onBlur={() => {
-              isFocusedRef.current = false
-              onTextEditingChange(false)
-              setEditing(false)
-              onCommitText(localText)
-            }}
-            style={innerTextStyle}
-          />
-        ) : (
-          <div
-            style={{
-              ...innerTextStyle,
-              whiteSpace: 'pre-wrap',
-              userSelect: 'none',
-            }}
-          >
-            {localText}
-          </div>
-        )}
-      </div>
+      {text}
     </>
   )
 }
@@ -349,7 +333,7 @@ function ShapeCard({
       onGroupDragEnd={onGroupDragEnd}
       shouldStartDrag={(event) => {
         const target = event.target as HTMLElement | null
-        if (target?.closest('textarea')) return false
+        if (target?.closest('[contenteditable="true"]')) return false
         return true
       }}
       overflowVisible
@@ -362,7 +346,6 @@ function ShapeCard({
         pendingFocus={pendingFocus}
         onCommitText={(text) => onUpdateText(shape.id, text)}
         onTextEditingChange={onTextEditingChange}
-        onRequestEdit={() => onRequestEdit(shape.id)}
         onPendingFocusConsumed={onPendingFocusConsumed}
       />
     </SelectableEntityShell>

--- a/src/renderer/canvas-bg/ShapeBlockLayer.tsx
+++ b/src/renderer/canvas-bg/ShapeBlockLayer.tsx
@@ -1,0 +1,474 @@
+import { memo, useEffect, useRef, useState } from 'react'
+import type { CanvasSceneShapeEntity, SelectionModifiers } from '../../shared/types'
+import { resolveCanvasColor } from '../../shared/canvas-colors'
+import { SelectableEntityShell } from './SelectableEntityShell'
+import type { EntityResizePatch } from './entityConstants'
+import { MIN_SHAPE_WIDTH, MIN_SHAPE_HEIGHT } from './entityConstants'
+
+const DEFAULT_STROKE_WIDTH = 2
+
+function neutralStroke(isDark: boolean): string {
+  return isDark ? 'hsl(0 0% 50%)' : 'hsl(0 0% 60%)'
+}
+
+function fillFromColor(color: string | undefined): string {
+  if (!color) return 'transparent'
+  const resolved = resolveCanvasColor(color)
+  return resolved
+}
+
+function strokeFromColor(color: string | undefined, isDark: boolean): string {
+  if (!color) return neutralStroke(isDark)
+  const resolved = resolveCanvasColor(color)
+  return resolved
+}
+
+function ShapeBody({
+  shape,
+  isDark,
+  pendingFocus,
+  onCommitText,
+  onTextEditingChange,
+  onRequestEdit,
+  onPendingFocusConsumed,
+  canEdit,
+  selected,
+}: {
+  shape: CanvasSceneShapeEntity
+  isDark: boolean
+  pendingFocus: boolean
+  onCommitText: (text: string) => void
+  onTextEditingChange: (active: boolean) => void
+  onRequestEdit: () => void
+  onPendingFocusConsumed: () => void
+  canEdit: boolean
+  selected: boolean
+}) {
+  const [editing, setEditing] = useState(false)
+  const [localText, setLocalText] = useState(shape.text)
+  const isFocusedRef = useRef(false)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (!isFocusedRef.current) setLocalText(shape.text)
+  }, [shape.text])
+
+  useEffect(() => {
+    if (pendingFocus && canEdit) {
+      setEditing(true)
+      onPendingFocusConsumed()
+    }
+  }, [canEdit, onPendingFocusConsumed, pendingFocus])
+
+  useEffect(() => {
+    if (editing && textareaRef.current) {
+      textareaRef.current.focus()
+      textareaRef.current.select()
+    }
+  }, [editing])
+
+  useEffect(() => {
+    if (!canEdit && editing) {
+      setEditing(false)
+      isFocusedRef.current = false
+      onTextEditingChange(false)
+    }
+  }, [canEdit, editing, onTextEditingChange])
+
+  const stroke = shape.strokeWidth ?? DEFAULT_STROKE_WIDTH
+  const fill = fillFromColor(shape.color)
+  const strokeColor = strokeFromColor(shape.color, isDark)
+  const textColor = isDark && !shape.color ? 'rgb(220, 220, 220)' : 'rgb(20, 20, 20)'
+
+  const baseStyle: React.CSSProperties = {
+    width: '100%',
+    height: '100%',
+    boxSizing: 'border-box',
+    borderWidth: stroke,
+    borderStyle: 'solid',
+    borderColor: strokeColor,
+    backgroundColor: fill,
+    pointerEvents: 'none',
+  }
+
+  const textWrapperStyle: React.CSSProperties = {
+    position: 'absolute',
+    inset: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 8,
+  }
+
+  const innerTextStyle: React.CSSProperties = {
+    width: '100%',
+    height: '100%',
+    fontSize: 13,
+    color: textColor,
+    fontFamily: 'system-ui, sans-serif',
+    textAlign: 'center',
+    overflow: 'hidden',
+    wordBreak: 'break-word',
+    background: 'transparent',
+    border: 'none',
+    outline: 'none',
+    resize: 'none',
+    padding: 0,
+    pointerEvents: editing ? 'auto' : 'none',
+  }
+
+  const handleStartEdit = (event: React.MouseEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    onRequestEdit()
+    if (canEdit) setEditing(true)
+  }
+
+  const renderText = () => (
+    <div style={textWrapperStyle} onDoubleClick={handleStartEdit}>
+      {editing ? (
+        <textarea
+          ref={textareaRef}
+          value={localText}
+          onChange={(e) => setLocalText(e.target.value)}
+          onMouseDown={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+          onFocus={() => {
+            isFocusedRef.current = true
+            onTextEditingChange(true)
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              e.preventDefault()
+              ;(e.target as HTMLTextAreaElement).blur()
+            }
+          }}
+          onBlur={() => {
+            isFocusedRef.current = false
+            onTextEditingChange(false)
+            setEditing(false)
+            onCommitText(localText)
+          }}
+          style={{
+            ...innerTextStyle,
+            display: 'flex',
+            textAlign: 'center',
+          }}
+        />
+      ) : (
+        <div
+          style={{
+            ...innerTextStyle,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            whiteSpace: 'pre-wrap',
+            userSelect: 'none',
+          }}
+        >
+          {localText}
+        </div>
+      )}
+    </div>
+  )
+
+  if (shape.shapeKind === 'rectangle') {
+    return (
+      <>
+        <div style={baseStyle} />
+        {renderText()}
+      </>
+    )
+  }
+
+  if (shape.shapeKind === 'ellipse') {
+    return (
+      <>
+        <div style={{ ...baseStyle, borderRadius: '50%' }} />
+        {renderText()}
+      </>
+    )
+  }
+
+  // diamond: rotate the silhouette square 45deg, place a counter-rotated text box inscribed inside.
+  // Inscribed-rectangle dimensions for a 45° rotation are width / sqrt(2), height / sqrt(2).
+  const inscribedRatio = 1 / Math.SQRT2
+  return (
+    <>
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          pointerEvents: 'none',
+        }}
+      >
+        <div
+          style={{
+            width: `${inscribedRatio * 100}%`,
+            height: `${inscribedRatio * 100}%`,
+            transform: 'rotate(45deg)',
+            transformOrigin: 'center',
+            borderWidth: stroke,
+            borderStyle: 'solid',
+            borderColor: strokeColor,
+            backgroundColor: fill,
+            boxSizing: 'border-box',
+          }}
+        />
+      </div>
+      <div
+        style={{
+          position: 'absolute',
+          left: '50%',
+          top: '50%',
+          width: `${inscribedRatio * 100}%`,
+          height: `${inscribedRatio * 100}%`,
+          transform: 'translate(-50%, -50%)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 8,
+          boxSizing: 'border-box',
+        }}
+        onDoubleClick={handleStartEdit}
+      >
+        {editing ? (
+          <textarea
+            ref={textareaRef}
+            value={localText}
+            onChange={(e) => setLocalText(e.target.value)}
+            onMouseDown={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            onFocus={() => {
+              isFocusedRef.current = true
+              onTextEditingChange(true)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault()
+                ;(e.target as HTMLTextAreaElement).blur()
+              }
+            }}
+            onBlur={() => {
+              isFocusedRef.current = false
+              onTextEditingChange(false)
+              setEditing(false)
+              onCommitText(localText)
+            }}
+            style={{
+              ...innerTextStyle,
+              textAlign: 'center',
+            }}
+          />
+        ) : (
+          <div
+            style={{
+              ...innerTextStyle,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              whiteSpace: 'pre-wrap',
+              userSelect: 'none',
+            }}
+          >
+            {localText}
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+const MemoShapeBody = memo(ShapeBody, (a, b) => {
+  return (
+    a.shape.id === b.shape.id &&
+    a.shape.shapeKind === b.shape.shapeKind &&
+    a.shape.text === b.shape.text &&
+    a.shape.color === b.shape.color &&
+    a.shape.strokeWidth === b.shape.strokeWidth &&
+    a.shape.width === b.shape.width &&
+    a.shape.height === b.shape.height &&
+    a.isDark === b.isDark &&
+    a.pendingFocus === b.pendingFocus &&
+    a.canEdit === b.canEdit &&
+    a.selected === b.selected
+  )
+})
+
+function ShapeCard({
+  shape,
+  isDark,
+  isSelected,
+  isMarqueePreview,
+  canEdit,
+  pendingFocus,
+  selectedGroupDragTargetId,
+  onSelect,
+  onResize,
+  onUpdateText,
+  onTextEditingChange,
+  onRequestEdit,
+  onPendingFocusConsumed,
+  onDragStart,
+  onDrag,
+  onDragEnd,
+  onGroupDragStart,
+  onGroupDrag,
+  onGroupDragEnd,
+  getZoom,
+}: {
+  shape: CanvasSceneShapeEntity
+  isDark: boolean
+  isSelected: boolean
+  isMarqueePreview: boolean
+  canEdit: boolean
+  pendingFocus: boolean
+  selectedGroupDragTargetId?: string | null
+  onSelect: (id: string, modifiers?: SelectionModifiers) => void
+  onResize: (id: string, patch: EntityResizePatch) => void
+  onUpdateText: (id: string, text: string) => void
+  onTextEditingChange: (active: boolean) => void
+  onRequestEdit: (id: string) => void
+  onPendingFocusConsumed: () => void
+  onDragStart: (id: string) => void
+  onDrag: (id: string, dx: number, dy: number) => void
+  onDragEnd: () => void
+  onGroupDragStart: (groupId: string) => void
+  onGroupDrag: (groupId: string, dx: number, dy: number) => void
+  onGroupDragEnd: () => void
+  getZoom: () => number
+}) {
+  return (
+    <SelectableEntityShell
+      id={shape.id}
+      canvasX={shape.canvasX}
+      canvasY={shape.canvasY}
+      width={shape.width}
+      height={shape.height}
+      getZoom={getZoom}
+      minWidth={MIN_SHAPE_WIDTH}
+      minHeight={MIN_SHAPE_HEIGHT}
+      isDark={isDark}
+      isSelected={isSelected}
+      isMarqueePreview={isMarqueePreview}
+      background="transparent"
+      showCardShadow={false}
+      onSelect={onSelect}
+      onDoubleClick={(entityId, event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        onRequestEdit(entityId)
+      }}
+      onResize={onResize}
+      onDragStart={onDragStart}
+      onDrag={onDrag}
+      onDragEnd={onDragEnd}
+      selectedGroupDragTargetId={selectedGroupDragTargetId}
+      onGroupDragStart={onGroupDragStart}
+      onGroupDrag={onGroupDrag}
+      onGroupDragEnd={onGroupDragEnd}
+      shouldStartDrag={(event) => {
+        const target = event.target as HTMLElement | null
+        if (target?.closest('textarea')) return false
+        return true
+      }}
+      overflowVisible
+    >
+      <MemoShapeBody
+        shape={shape}
+        isDark={isDark}
+        canEdit={canEdit}
+        selected={isSelected}
+        pendingFocus={pendingFocus}
+        onCommitText={(text) => onUpdateText(shape.id, text)}
+        onTextEditingChange={onTextEditingChange}
+        onRequestEdit={() => onRequestEdit(shape.id)}
+        onPendingFocusConsumed={onPendingFocusConsumed}
+      />
+    </SelectableEntityShell>
+  )
+}
+
+export function ShapeBlockLayer({
+  entities,
+  getZoom,
+  isDark,
+  marqueePreviewIds,
+  selectedEntityIdSet,
+  selectedEntityCount,
+  selectedGroupId,
+  selectedGroupDescendantIds,
+  pendingEditEntityId,
+  onSelect,
+  onUpdateText,
+  onResize,
+  onTextEditingChange,
+  onRequestEdit,
+  onPendingFocusConsumed,
+  onDragStart,
+  onDrag,
+  onDragEnd,
+  onGroupDragStart,
+  onGroupDrag,
+  onGroupDragEnd,
+}: {
+  entities: CanvasSceneShapeEntity[]
+  getZoom: () => number
+  isDark: boolean
+  marqueePreviewIds: Set<string> | null
+  selectedEntityIdSet: Set<string>
+  selectedEntityCount: number
+  selectedGroupId: string | null
+  selectedGroupDescendantIds: Set<string>
+  pendingEditEntityId: string | null
+  onSelect: (id: string, modifiers?: SelectionModifiers) => void
+  onUpdateText: (id: string, text: string) => void
+  onResize: (id: string, patch: EntityResizePatch) => void
+  onTextEditingChange: (active: boolean) => void
+  onRequestEdit: (id: string) => void
+  onPendingFocusConsumed: () => void
+  onDragStart: (id: string) => void
+  onDrag: (id: string, dx: number, dy: number) => void
+  onDragEnd: () => void
+  onGroupDragStart: (groupId: string) => void
+  onGroupDrag: (groupId: string, dx: number, dy: number) => void
+  onGroupDragEnd: () => void
+}) {
+  if (!entities.length) return null
+  return (
+    <>
+      {entities.map((shape) => (
+        <ShapeCard
+          key={shape.id}
+          shape={shape}
+          getZoom={getZoom}
+          isDark={isDark}
+          isSelected={selectedEntityIdSet.has(shape.id)}
+          isMarqueePreview={marqueePreviewIds?.has(shape.id) ?? false}
+          canEdit={selectedEntityCount === 1 && selectedEntityIdSet.has(shape.id)}
+          pendingFocus={pendingEditEntityId === shape.id}
+          selectedGroupDragTargetId={
+            selectedGroupId && selectedGroupDescendantIds.has(shape.id)
+              ? selectedGroupId
+              : null
+          }
+          onSelect={onSelect}
+          onResize={onResize}
+          onUpdateText={onUpdateText}
+          onTextEditingChange={onTextEditingChange}
+          onRequestEdit={onRequestEdit}
+          onPendingFocusConsumed={onPendingFocusConsumed}
+          onDragStart={onDragStart}
+          onDrag={onDrag}
+          onDragEnd={onDragEnd}
+          onGroupDragStart={onGroupDragStart}
+          onGroupDrag={onGroupDrag}
+          onGroupDragEnd={onGroupDragEnd}
+        />
+      ))}
+    </>
+  )
+}

--- a/src/renderer/canvas-bg/ShapeBlockLayer.tsx
+++ b/src/renderer/canvas-bg/ShapeBlockLayer.tsx
@@ -1,12 +1,13 @@
 import { memo, useEffect, useRef, useState } from 'react'
 import type { CanvasSceneShapeEntity, SelectionModifiers } from '../../shared/types'
-import { resolveCanvasColor, withAlpha } from '../../shared/canvas-colors'
+import { lightenHex, resolveCanvasColor, withAlpha } from '../../shared/canvas-colors'
 import { SelectableEntityShell } from './SelectableEntityShell'
 import type { EntityResizePatch } from './entityConstants'
 import { MIN_SHAPE_WIDTH, MIN_SHAPE_HEIGHT } from './entityConstants'
 
 const DEFAULT_STROKE_WIDTH = 2
-const FILL_OPACITY = 0.08
+const FILL_OPACITY = 0.5
+const FILL_LIGHTEN = 0.5
 const NEUTRAL_SLATE = '#6b7280'
 
 function ShapeBody({
@@ -70,7 +71,7 @@ function ShapeBody({
 
   const stroke = shape.strokeWidth ?? DEFAULT_STROKE_WIDTH
   const resolvedColor = shape.color ? resolveCanvasColor(shape.color) : NEUTRAL_SLATE
-  const fill = withAlpha(resolvedColor, FILL_OPACITY)
+  const fill = withAlpha(lightenHex(resolvedColor, FILL_LIGHTEN), FILL_OPACITY)
   const strokeColor = resolvedColor
   const textColor = isDark && !shape.color ? 'rgb(220, 220, 220)' : 'rgb(20, 20, 20)'
 

--- a/src/renderer/canvas-bg/ShapeBlockLayer.tsx
+++ b/src/renderer/canvas-bg/ShapeBlockLayer.tsx
@@ -1,11 +1,12 @@
 import { memo, useEffect, useRef, useState } from 'react'
 import type { CanvasSceneShapeEntity, SelectionModifiers } from '../../shared/types'
-import { resolveCanvasColor } from '../../shared/canvas-colors'
+import { resolveCanvasColor, withAlpha } from '../../shared/canvas-colors'
 import { SelectableEntityShell } from './SelectableEntityShell'
 import type { EntityResizePatch } from './entityConstants'
 import { MIN_SHAPE_WIDTH, MIN_SHAPE_HEIGHT } from './entityConstants'
 
 const DEFAULT_STROKE_WIDTH = 2
+const FILL_OPACITY = 0.2
 
 function neutralStroke(isDark: boolean): string {
   return isDark ? 'hsl(0 0% 50%)' : 'hsl(0 0% 60%)'
@@ -71,8 +72,9 @@ function ShapeBody({
   }, [canEdit, editing, onTextEditingChange])
 
   const stroke = shape.strokeWidth ?? DEFAULT_STROKE_WIDTH
-  const fill = shape.color ? resolveCanvasColor(shape.color) : 'transparent'
-  const strokeColor = shape.color ? resolveCanvasColor(shape.color) : neutralStroke(isDark)
+  const resolvedColor = shape.color ? resolveCanvasColor(shape.color) : null
+  const fill = resolvedColor ? withAlpha(resolvedColor, FILL_OPACITY) : 'transparent'
+  const strokeColor = resolvedColor ?? neutralStroke(isDark)
   const textColor = isDark && !shape.color ? 'rgb(220, 220, 220)' : 'rgb(20, 20, 20)'
 
   const baseStyle: React.CSSProperties = {

--- a/src/renderer/canvas-bg/ShapeBlockLayer.tsx
+++ b/src/renderer/canvas-bg/ShapeBlockLayer.tsx
@@ -56,6 +56,13 @@ function ShapeBody({
   }, [editing])
 
   useEffect(() => {
+    const node = textareaRef.current
+    if (!editing || !node) return
+    node.style.height = 'auto'
+    node.style.height = `${node.scrollHeight}px`
+  }, [editing, localText, shape.width, shape.height])
+
+  useEffect(() => {
     if (!canEdit && editing) {
       setEditing(false)
       isFocusedRef.current = false
@@ -139,7 +146,8 @@ function ShapeBody({
           }}
           style={{
             ...innerTextStyle,
-            display: 'flex',
+            height: 'auto',
+            maxHeight: '100%',
             textAlign: 'center',
           }}
         />
@@ -178,43 +186,34 @@ function ShapeBody({
     )
   }
 
-  // diamond: rotate the silhouette square 45deg, place a counter-rotated text box inscribed inside.
-  // Inscribed-rectangle dimensions for a 45° rotation are width / sqrt(2), height / sqrt(2).
-  const inscribedRatio = 1 / Math.SQRT2
+  // diamond: a true rhombus with vertices at the midpoints of each bounding-box
+  // edge. Drawn as an SVG polygon so the stroke stays uniform when the bounding
+  // box is non-square. The text box is the largest axis-aligned rectangle that
+  // fits inside the rhombus — which is half the bbox width × half the height.
   return (
     <>
-      <div
-        style={{
-          position: 'absolute',
-          inset: 0,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          pointerEvents: 'none',
-        }}
+      <svg
+        width="100%"
+        height="100%"
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        style={{ position: 'absolute', inset: 0, pointerEvents: 'none', overflow: 'visible' }}
       >
-        <div
-          style={{
-            width: `${inscribedRatio * 100}%`,
-            height: `${inscribedRatio * 100}%`,
-            transform: 'rotate(45deg)',
-            transformOrigin: 'center',
-            borderWidth: stroke,
-            borderStyle: 'solid',
-            borderColor: strokeColor,
-            backgroundColor: fill,
-            boxSizing: 'border-box',
-          }}
+        <polygon
+          points="50,0 100,50 50,100 0,50"
+          fill={fill}
+          stroke={strokeColor}
+          strokeWidth={stroke}
+          vectorEffect="non-scaling-stroke"
         />
-      </div>
+      </svg>
       <div
         style={{
           position: 'absolute',
-          left: '50%',
-          top: '50%',
-          width: `${inscribedRatio * 100}%`,
-          height: `${inscribedRatio * 100}%`,
-          transform: 'translate(-50%, -50%)',
+          left: '25%',
+          top: '25%',
+          width: '50%',
+          height: '50%',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -248,6 +247,8 @@ function ShapeBody({
             }}
             style={{
               ...innerTextStyle,
+              height: 'auto',
+              maxHeight: '100%',
               textAlign: 'center',
             }}
           />

--- a/src/renderer/canvas-bg/ShapeBlockLayer.tsx
+++ b/src/renderer/canvas-bg/ShapeBlockLayer.tsx
@@ -336,6 +336,7 @@ function ShapeCard({
         if (target?.closest('[contenteditable="true"]')) return false
         return true
       }}
+      aspectRatioResizeMode="shift-locks"
       overflowVisible
     >
       <MemoShapeBody

--- a/src/renderer/canvas-bg/ShapeBlockLayer.tsx
+++ b/src/renderer/canvas-bg/ShapeBlockLayer.tsx
@@ -6,7 +6,7 @@ import type { EntityResizePatch } from './entityConstants'
 import { MIN_SHAPE_WIDTH, MIN_SHAPE_HEIGHT } from './entityConstants'
 
 const DEFAULT_STROKE_WIDTH = 2
-const FILL_OPACITY = 0.5
+const FILL_OPACITY = 0.24
 const FILL_LIGHTEN = 0.5
 const NEUTRAL_SLATE = '#6b7280'
 
@@ -73,7 +73,7 @@ function ShapeBody({
   const resolvedColor = shape.color ? resolveCanvasColor(shape.color) : NEUTRAL_SLATE
   const fill = withAlpha(lightenHex(resolvedColor, FILL_LIGHTEN), FILL_OPACITY)
   const strokeColor = resolvedColor
-  const textColor = isDark && !shape.color ? 'rgb(220, 220, 220)' : 'rgb(20, 20, 20)'
+  const textColor = isDark ? 'rgb(220, 220, 220)' : 'rgb(20, 20, 20)'
 
   const baseStyle: React.CSSProperties = {
     width: '100%',
@@ -97,8 +97,10 @@ function ShapeBody({
 
   const innerTextStyle: React.CSSProperties = {
     width: '100%',
-    height: '100%',
+    height: 'auto',
+    maxHeight: '100%',
     fontSize: 13,
+    lineHeight: 1.4,
     color: textColor,
     fontFamily: 'system-ui, sans-serif',
     textAlign: 'center',
@@ -108,7 +110,9 @@ function ShapeBody({
     border: 'none',
     outline: 'none',
     resize: 'none',
+    margin: 0,
     padding: 0,
+    boxSizing: 'border-box',
     pointerEvents: editing ? 'auto' : 'none',
   }
 
@@ -144,20 +148,12 @@ function ShapeBody({
             setEditing(false)
             onCommitText(localText)
           }}
-          style={{
-            ...innerTextStyle,
-            height: 'auto',
-            maxHeight: '100%',
-            textAlign: 'center',
-          }}
+          style={innerTextStyle}
         />
       ) : (
         <div
           style={{
             ...innerTextStyle,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
             whiteSpace: 'pre-wrap',
             userSelect: 'none',
           }}
@@ -245,20 +241,12 @@ function ShapeBody({
               setEditing(false)
               onCommitText(localText)
             }}
-            style={{
-              ...innerTextStyle,
-              height: 'auto',
-              maxHeight: '100%',
-              textAlign: 'center',
-            }}
+            style={innerTextStyle}
           />
         ) : (
           <div
             style={{
               ...innerTextStyle,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
               whiteSpace: 'pre-wrap',
               userSelect: 'none',
             }}

--- a/src/renderer/canvas-bg/ShapeBlockLayer.tsx
+++ b/src/renderer/canvas-bg/ShapeBlockLayer.tsx
@@ -6,7 +6,7 @@ import type { EntityResizePatch } from './entityConstants'
 import { MIN_SHAPE_WIDTH, MIN_SHAPE_HEIGHT } from './entityConstants'
 
 const DEFAULT_STROKE_WIDTH = 2
-const FILL_OPACITY = 0.2
+const FILL_OPACITY = 0.08
 const NEUTRAL_SLATE = '#6b7280'
 
 function ShapeBody({

--- a/src/renderer/canvas-bg/canvasBgSelectors.ts
+++ b/src/renderer/canvas-bg/canvasBgSelectors.ts
@@ -27,6 +27,7 @@ export function buildPendingPlacementPreview(
   const snappedY = snapToGrid(point.y)
   return {
     entityKind: layoutData.pendingPlacement.entityKind,
+    shapeKind: layoutData.pendingPlacement.shapeKind,
     left: layoutData.canvasOrigin.x + layoutData.pan.x + snappedX * layoutData.zoom,
     top: layoutData.canvasOrigin.y + layoutData.pan.y + snappedY * layoutData.zoom,
     width: layoutData.pendingPlacement.width * layoutData.zoom,

--- a/src/renderer/canvas-bg/entityConstants.ts
+++ b/src/renderer/canvas-bg/entityConstants.ts
@@ -35,6 +35,8 @@ export const MIN_TEXT_WIDTH = 100
 export const MIN_TEXT_HEIGHT = 60
 export const MIN_FILE_WIDTH = 80
 export const MIN_FILE_HEIGHT = 80
+export const MIN_SHAPE_WIDTH = 24
+export const MIN_SHAPE_HEIGHT = 24
 
 export const CORNER_CURSORS: Record<ResizeCorner, string> = {
   'top-left': 'nwse-resize',

--- a/src/renderer/canvas-bg/useCanvasViewportGestures.ts
+++ b/src/renderer/canvas-bg/useCanvasViewportGestures.ts
@@ -47,6 +47,31 @@ type DragMode =
 
 const MIN_SHAPE_DRAG_SIZE = 24
 
+function squareDragRect(
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number,
+  constrainSquare: boolean,
+): { minX: number; minY: number; w: number; h: number } {
+  const dx = endX - startX
+  const dy = endY - startY
+  if (constrainSquare) {
+    const side = Math.max(Math.abs(dx), Math.abs(dy))
+    const sx = dx < 0 ? -1 : 1
+    const sy = dy < 0 ? -1 : 1
+    const minX = sx < 0 ? startX - side : startX
+    const minY = sy < 0 ? startY - side : startY
+    return { minX, minY, w: side, h: side }
+  }
+  return {
+    minX: Math.min(startX, endX),
+    minY: Math.min(startY, endY),
+    w: Math.abs(dx),
+    h: Math.abs(dy),
+  }
+}
+
 export type ShapePlacementDragPreview = {
   rect: { left: number; top: number; width: number; height: number }
   shapeKind: ShapeKind
@@ -131,10 +156,17 @@ export function useCanvasViewportGestures({
       }
       if (mode.kind === 'place-shape') {
         const endCanvas = screenPointToCanvasPoint(ctx.clientX, ctx.clientY, layout)
-        const minCanvasX = snapToGrid(Math.min(mode.startCanvasX, endCanvas.x))
-        const minCanvasY = snapToGrid(Math.min(mode.startCanvasY, endCanvas.y))
-        const snappedW = snapToGrid(Math.abs(endCanvas.x - mode.startCanvasX))
-        const snappedH = snapToGrid(Math.abs(endCanvas.y - mode.startCanvasY))
+        const square = squareDragRect(
+          mode.startCanvasX,
+          mode.startCanvasY,
+          endCanvas.x,
+          endCanvas.y,
+          ctx.modifiers.shift,
+        )
+        const minCanvasX = snapToGrid(square.minX)
+        const minCanvasY = snapToGrid(square.minY)
+        const snappedW = snapToGrid(square.w)
+        const snappedH = snapToGrid(square.h)
         const rect = {
           left: canvasToScreenX(layout, minCanvasX),
           top: canvasToScreenY(layout, minCanvasY),
@@ -185,18 +217,19 @@ export function useCanvasViewportGestures({
         stopDragging()
         const startCanvas = { x: mode.startCanvasX, y: mode.startCanvasY }
         const endCanvas = screenPointToCanvasPoint(ctx.clientX, ctx.clientY, layout)
-        const dx = endCanvas.x - startCanvas.x
-        const dy = endCanvas.y - startCanvas.y
-        const minCanvasX = Math.min(startCanvas.x, endCanvas.x)
-        const minCanvasY = Math.min(startCanvas.y, endCanvas.y)
-        const w = Math.abs(dx)
-        const h = Math.abs(dy)
-        if (w >= MIN_SHAPE_DRAG_SIZE && h >= MIN_SHAPE_DRAG_SIZE) {
-          api.placePendingShape(snapToGrid(minCanvasX), snapToGrid(minCanvasY), {
-            x: snapToGrid(minCanvasX),
-            y: snapToGrid(minCanvasY),
-            width: snapToGrid(w),
-            height: snapToGrid(h),
+        const square = squareDragRect(
+          startCanvas.x,
+          startCanvas.y,
+          endCanvas.x,
+          endCanvas.y,
+          ctx.modifiers.shift,
+        )
+        if (square.w >= MIN_SHAPE_DRAG_SIZE && square.h >= MIN_SHAPE_DRAG_SIZE) {
+          api.placePendingShape(snapToGrid(square.minX), snapToGrid(square.minY), {
+            x: snapToGrid(square.minX),
+            y: snapToGrid(square.minY),
+            width: snapToGrid(square.w),
+            height: snapToGrid(square.h),
           })
         } else {
           api.placePendingShape(snapToGrid(startCanvas.x), snapToGrid(startCanvas.y), null)

--- a/src/renderer/canvas-bg/useCanvasViewportGestures.ts
+++ b/src/renderer/canvas-bg/useCanvasViewportGestures.ts
@@ -41,6 +41,10 @@ type DragMode =
   | { kind: 'pan'; startPanX: number; startPanY: number }
   | { kind: 'region-select' }
   | { kind: 'marquee' }
+  | { kind: 'place-shape'; startCanvasX: number; startCanvasY: number }
+
+const SHAPE_DRAG_THRESHOLD_PX = 6
+const MIN_SHAPE_DRAG_SIZE = 24
 
 export function useCanvasViewportGestures({
   api,
@@ -77,9 +81,17 @@ export function useCanvasViewportGestures({
       if (ctx.pointerType === 'mouse' && ctx.button === 0) {
         if (layout.viewMode === 'browser') return null
 
-        // Pending-placement click: commit the placement and decline the
-        // gesture. Returning null cleanly releases capture.
+        // Pending-placement: shapes support drag-to-size; everything
+        // else commits with default size on click.
         if (layout.pendingPlacement) {
+          if (layout.pendingPlacement.entityKind === 'shape') {
+            const point = screenPointToCanvasPoint(ctx.clientX, ctx.clientY, layout)
+            return {
+              kind: 'place-shape',
+              startCanvasX: point.x,
+              startCanvasY: point.y,
+            }
+          }
           const point = screenPointToCanvasPoint(ctx.clientX, ctx.clientY, layout)
           api.placePendingEntity(snapToGrid(point.x), snapToGrid(point.y))
           return null
@@ -106,6 +118,18 @@ export function useCanvasViewportGestures({
       const layout = layoutRef.current
       if (mode.kind === 'pan') {
         api.canvasPanTo(mode.startPanX + ctx.dx, mode.startPanY + ctx.dy)
+        return
+      }
+      if (mode.kind === 'place-shape') {
+        const rect = normalizeRect(ctx.startClientX, ctx.startClientY, ctx.clientX, ctx.clientY)
+        if (rect.width < SHAPE_DRAG_THRESHOLD_PX && rect.height < SHAPE_DRAG_THRESHOLD_PX) {
+          api.setSelectionOverlayRect(null)
+          return
+        }
+        api.setSelectionOverlayRect({
+          rect: toOverlayRect(rect, layout),
+          variant: 'default',
+        })
         return
       }
       const rect = normalizeRect(ctx.startClientX, ctx.startClientY, ctx.clientX, ctx.clientY)
@@ -137,6 +161,28 @@ export function useCanvasViewportGestures({
       const layout = layoutRef.current
       if (mode.kind === 'pan') {
         stopDragging()
+        return
+      }
+      if (mode.kind === 'place-shape') {
+        stopDragging()
+        const startCanvas = { x: mode.startCanvasX, y: mode.startCanvasY }
+        const endCanvas = screenPointToCanvasPoint(ctx.clientX, ctx.clientY, layout)
+        const dx = endCanvas.x - startCanvas.x
+        const dy = endCanvas.y - startCanvas.y
+        const minCanvasX = Math.min(startCanvas.x, endCanvas.x)
+        const minCanvasY = Math.min(startCanvas.y, endCanvas.y)
+        const w = Math.abs(dx)
+        const h = Math.abs(dy)
+        if (w >= MIN_SHAPE_DRAG_SIZE && h >= MIN_SHAPE_DRAG_SIZE) {
+          api.placePendingShape(snapToGrid(minCanvasX), snapToGrid(minCanvasY), {
+            x: snapToGrid(minCanvasX),
+            y: snapToGrid(minCanvasY),
+            width: snapToGrid(w),
+            height: snapToGrid(h),
+          })
+        } else {
+          api.placePendingShape(snapToGrid(startCanvas.x), snapToGrid(startCanvas.y), null)
+        }
         return
       }
       const rect = normalizeRect(ctx.startClientX, ctx.startClientY, ctx.clientX, ctx.clientY)

--- a/src/renderer/canvas-bg/useCanvasViewportGestures.ts
+++ b/src/renderer/canvas-bg/useCanvasViewportGestures.ts
@@ -11,6 +11,7 @@ import {
   screenPointToCanvasPoint,
   screenRectToCanvasRect,
   snapToGrid,
+  squareConstrainedRect,
 } from '../../shared/gesture-utils'
 import { useDragGesture } from '../shared/useDragGesture'
 import { toOverlayRect } from './canvasGeometry'
@@ -46,31 +47,6 @@ type DragMode =
   | { kind: 'place-shape'; startCanvasX: number; startCanvasY: number }
 
 const MIN_SHAPE_DRAG_SIZE = 24
-
-function squareDragRect(
-  startX: number,
-  startY: number,
-  endX: number,
-  endY: number,
-  constrainSquare: boolean,
-): { minX: number; minY: number; w: number; h: number } {
-  const dx = endX - startX
-  const dy = endY - startY
-  if (constrainSquare) {
-    const side = Math.max(Math.abs(dx), Math.abs(dy))
-    const sx = dx < 0 ? -1 : 1
-    const sy = dy < 0 ? -1 : 1
-    const minX = sx < 0 ? startX - side : startX
-    const minY = sy < 0 ? startY - side : startY
-    return { minX, minY, w: side, h: side }
-  }
-  return {
-    minX: Math.min(startX, endX),
-    minY: Math.min(startY, endY),
-    w: Math.abs(dx),
-    h: Math.abs(dy),
-  }
-}
 
 export type ShapePlacementDragPreview = {
   rect: { left: number; top: number; width: number; height: number }
@@ -156,17 +132,17 @@ export function useCanvasViewportGestures({
       }
       if (mode.kind === 'place-shape') {
         const endCanvas = screenPointToCanvasPoint(ctx.clientX, ctx.clientY, layout)
-        const square = squareDragRect(
+        const square = squareConstrainedRect(
           mode.startCanvasX,
           mode.startCanvasY,
           endCanvas.x,
           endCanvas.y,
           ctx.modifiers.shift,
         )
-        const minCanvasX = snapToGrid(square.minX)
-        const minCanvasY = snapToGrid(square.minY)
-        const snappedW = snapToGrid(square.w)
-        const snappedH = snapToGrid(square.h)
+        const minCanvasX = snapToGrid(square.left)
+        const minCanvasY = snapToGrid(square.top)
+        const snappedW = snapToGrid(square.width)
+        const snappedH = snapToGrid(square.height)
         const rect = {
           left: canvasToScreenX(layout, minCanvasX),
           top: canvasToScreenY(layout, minCanvasY),
@@ -217,19 +193,19 @@ export function useCanvasViewportGestures({
         stopDragging()
         const startCanvas = { x: mode.startCanvasX, y: mode.startCanvasY }
         const endCanvas = screenPointToCanvasPoint(ctx.clientX, ctx.clientY, layout)
-        const square = squareDragRect(
+        const square = squareConstrainedRect(
           startCanvas.x,
           startCanvas.y,
           endCanvas.x,
           endCanvas.y,
           ctx.modifiers.shift,
         )
-        if (square.w >= MIN_SHAPE_DRAG_SIZE && square.h >= MIN_SHAPE_DRAG_SIZE) {
-          api.placePendingShape(snapToGrid(square.minX), snapToGrid(square.minY), {
-            x: snapToGrid(square.minX),
-            y: snapToGrid(square.minY),
-            width: snapToGrid(square.w),
-            height: snapToGrid(square.h),
+        if (square.width >= MIN_SHAPE_DRAG_SIZE && square.height >= MIN_SHAPE_DRAG_SIZE) {
+          api.placePendingShape(snapToGrid(square.left), snapToGrid(square.top), {
+            x: snapToGrid(square.left),
+            y: snapToGrid(square.top),
+            width: snapToGrid(square.width),
+            height: snapToGrid(square.height),
           })
         } else {
           api.placePendingShape(snapToGrid(startCanvas.x), snapToGrid(startCanvas.y), null)

--- a/src/renderer/canvas-bg/useCanvasViewportGestures.ts
+++ b/src/renderer/canvas-bg/useCanvasViewportGestures.ts
@@ -1,7 +1,9 @@
 import { useEffect, useMemo } from 'react'
 import type { RefObject } from 'react'
-import type { CanvasBgElectronAPI, LayoutUpdateData, SelectionModifiers } from '../../shared/types'
+import type { CanvasBgElectronAPI, LayoutUpdateData, SelectionModifiers, ShapeKind } from '../../shared/types'
 import {
+  canvasToScreenX,
+  canvasToScreenY,
   classifyViewportWheel,
   isOverlayUiTarget,
   middleDragDelta,
@@ -43,8 +45,12 @@ type DragMode =
   | { kind: 'marquee' }
   | { kind: 'place-shape'; startCanvasX: number; startCanvasY: number }
 
-const SHAPE_DRAG_THRESHOLD_PX = 6
 const MIN_SHAPE_DRAG_SIZE = 24
+
+export type ShapePlacementDragPreview = {
+  rect: { left: number; top: number; width: number; height: number }
+  shapeKind: ShapeKind
+}
 
 export function useCanvasViewportGestures({
   api,
@@ -52,6 +58,7 @@ export function useCanvasViewportGestures({
   layoutRef,
   setPlacementCursor,
   onMarqueePreview,
+  onShapePlacementPreview,
 }: {
   api: CanvasBgElectronAPI
   bgRef: RefObject<HTMLDivElement | null>
@@ -60,13 +67,15 @@ export function useCanvasViewportGestures({
     React.SetStateAction<{ clientX: number; clientY: number } | null>
   >
   onMarqueePreview: (ids: Set<string> | null) => void
+  onShapePlacementPreview: (preview: ShapePlacementDragPreview | null) => void
 }) {
   const stopDragging = useMemo(
     () => () => {
       api.setSelectionOverlayRect(null)
       onMarqueePreview(null)
+      onShapePlacementPreview(null)
     },
-    [api, onMarqueePreview],
+    [api, onMarqueePreview, onShapePlacementPreview],
   )
 
   useDragGesture<DragMode>({
@@ -121,15 +130,24 @@ export function useCanvasViewportGestures({
         return
       }
       if (mode.kind === 'place-shape') {
-        const rect = normalizeRect(ctx.startClientX, ctx.startClientY, ctx.clientX, ctx.clientY)
-        if (rect.width < SHAPE_DRAG_THRESHOLD_PX && rect.height < SHAPE_DRAG_THRESHOLD_PX) {
-          api.setSelectionOverlayRect(null)
-          return
+        const endCanvas = screenPointToCanvasPoint(ctx.clientX, ctx.clientY, layout)
+        const minCanvasX = snapToGrid(Math.min(mode.startCanvasX, endCanvas.x))
+        const minCanvasY = snapToGrid(Math.min(mode.startCanvasY, endCanvas.y))
+        const snappedW = snapToGrid(Math.abs(endCanvas.x - mode.startCanvasX))
+        const snappedH = snapToGrid(Math.abs(endCanvas.y - mode.startCanvasY))
+        const rect = {
+          left: canvasToScreenX(layout, minCanvasX),
+          top: canvasToScreenY(layout, minCanvasY),
+          width: snappedW * layout.zoom,
+          height: snappedH * layout.zoom,
         }
+        const shapeKind = layout.pendingPlacement?.shapeKind ?? 'rectangle'
         api.setSelectionOverlayRect({
           rect: toOverlayRect(rect, layout),
-          variant: 'default',
+          variant: 'place-shape',
+          shapeKind,
         })
+        onShapePlacementPreview({ rect, shapeKind })
         return
       }
       const rect = normalizeRect(ctx.startClientX, ctx.startClientY, ctx.clientX, ctx.clientY)

--- a/src/renderer/canvas-bg/useMultiSelectionResize.ts
+++ b/src/renderer/canvas-bg/useMultiSelectionResize.ts
@@ -3,7 +3,7 @@ import type { ResizeCorner, ResizeEdge } from './entityConstants'
 
 export interface MultiResizeEntity {
   id: string
-  kind: 'frame' | 'text' | 'file' | 'drawing'
+  kind: 'frame' | 'text' | 'file' | 'drawing' | 'shape'
   canvasX: number
   canvasY: number
   width: number
@@ -26,7 +26,7 @@ function applyProportional(
   accY: number,
   accW: number,
   accH: number,
-  onResize: (entries: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing'; width: number; height: number; canvasX: number; canvasY: number }>) => void,
+  onResize: (entries: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing' | 'shape'; width: number; height: number; canvasX: number; canvasY: number }>) => void,
 ) {
   const scaleX = initialBbox.width > 0 ? accW / initialBbox.width : 1
   const scaleY = initialBbox.height > 0 ? accH / initialBbox.height : 1
@@ -53,7 +53,7 @@ export function useMultiCornerResize({
   canvasBbox: CanvasBBox
   zoom: number
   corner: ResizeCorner
-  onResize: (entries: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing'; width: number; height: number; canvasX: number; canvasY: number }>) => void
+  onResize: (entries: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing' | 'shape'; width: number; height: number; canvasX: number; canvasY: number }>) => void
 }): (e: React.MouseEvent) => void {
   return useCallback(
     (e: React.MouseEvent) => {
@@ -128,7 +128,7 @@ export function useMultiEdgeResize({
   canvasBbox: CanvasBBox
   zoom: number
   edge: ResizeEdge
-  onResize: (entries: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing'; width: number; height: number; canvasX: number; canvasY: number }>) => void
+  onResize: (entries: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing' | 'shape'; width: number; height: number; canvasX: number; canvasY: number }>) => void
 }): (e: React.MouseEvent) => void {
   return useCallback(
     (e: React.MouseEvent) => {

--- a/src/renderer/left-sidebar/SidebarCanvasTree.tsx
+++ b/src/renderer/left-sidebar/SidebarCanvasTree.tsx
@@ -2,7 +2,18 @@ import { useState } from 'react'
 import { Collapsible } from '@base-ui/react/collapsible'
 import { ContextMenu } from '@base-ui/react/context-menu'
 import { Menu } from '@base-ui/react/menu'
-import { ChevronDown, ChevronRight, Folder, FolderOpen, Image, PenLine, StickyNote } from 'lucide-react'
+import {
+  ChevronDown,
+  ChevronRight,
+  Circle,
+  Diamond,
+  Folder,
+  FolderOpen,
+  Image,
+  PenLine,
+  Square,
+  StickyNote,
+} from 'lucide-react'
 import type { LeftSidebarElectronAPI, SidebarCanvasItem, SidebarFileItem, SidebarFrameItem, SidebarGroupItem, SidebarTextItem } from '../../shared/types'
 import { FrameListItem } from '../shared/frameListItem'
 import { InlineEditLabel } from '../shared/InlineEditLabel'
@@ -343,6 +354,25 @@ function SidebarCanvasTreeItem({
           onRename={(name) => api.renameDrawingEntity(item.id, name)}
           onDelete={() => api.deleteEntity(item.id, 'drawing')}
           deleteLabel="Delete Drawing"
+        />
+      </div>
+    )
+  }
+
+  if (item.kind === 'shape') {
+    const ShapeIcon =
+      item.shapeKind === 'ellipse' ? Circle : item.shapeKind === 'diamond' ? Diamond : Square
+    return (
+      <div>
+        <EntityListItem
+          icon={<ShapeIcon size={14} className="shrink-0 text-zinc-500" />}
+          label={item.label}
+          active={isSelected}
+          isDark={isDark}
+          depth={depth}
+          onClick={() => api.revealEntity(item.id, 'shape')}
+          onDelete={() => api.deleteEntity(item.id, 'shape')}
+          deleteLabel="Delete Shape"
         />
       </div>
     )

--- a/src/renderer/right-details-panel/App.tsx
+++ b/src/renderer/right-details-panel/App.tsx
@@ -11,6 +11,7 @@ import { FramePane } from './components/FramePane'
 import { GroupEntityPane } from './components/GroupEntityPane'
 import { MultiEntityPane } from './components/MultiEntityPane'
 import { PaneHeader } from './components/PaneHeader'
+import { ShapeEntityPane } from './components/ShapeEntityPane'
 import { TextEntityPane } from './components/TextEntityPane'
 import { rightDetailsPanelApi } from './rightDetailsPanelApi'
 import { useRightDetailsPanelData } from './useRightDetailsPanelData'
@@ -88,6 +89,11 @@ export default function App({ initialTheme }: { initialTheme: ThemeData }) {
       case 'drawing':
         return DRAWING_FEATURE_ENABLED && panelData.drawingEntity ? (
           <DrawingEntityPane drawingEntity={panelData.drawingEntity} isDark={isDark} />
+        ) : null
+
+      case 'shape':
+        return panelData.shapeEntity ? (
+          <ShapeEntityPane shapeEntity={panelData.shapeEntity} isDark={isDark} />
         ) : null
 
       case 'edge':

--- a/src/renderer/right-details-panel/components/ColorSwatchPicker.tsx
+++ b/src/renderer/right-details-panel/components/ColorSwatchPicker.tsx
@@ -32,7 +32,7 @@ export function ColorSwatchPicker({
         >
           <span
             className="block h-3.5 w-3.5 rounded-full"
-            style={{ background: '#94a3b8' }}
+            style={{ background: '#6b7280' }}
           />
         </button>
       ) : null}

--- a/src/renderer/right-details-panel/components/ShapeEntityPane.tsx
+++ b/src/renderer/right-details-panel/components/ShapeEntityPane.tsx
@@ -3,7 +3,6 @@ import type { PanelShapeEntityDetail, ShapeKind } from '../../../shared/types'
 import {
   dividerClass,
   mutedClass,
-  paneActionBtnClass,
   paneDeleteBtnClass,
 } from '../rightDetailsPanelHelpers'
 import { rightDetailsPanelApi } from '../rightDetailsPanelApi'
@@ -61,7 +60,7 @@ export function ShapeEntityPane({
         }
       />
 
-      <div className={`px-2 pt-2 pb-2`}>
+      <div className="px-2 pt-2 pb-2">
         <div className={`mb-1 text-[10px] font-medium ${muted}`}>shape</div>
         <div className="flex items-center gap-1">
           {SHAPE_OPTIONS.map(({ kind, label, Icon }) => (

--- a/src/renderer/right-details-panel/components/ShapeEntityPane.tsx
+++ b/src/renderer/right-details-panel/components/ShapeEntityPane.tsx
@@ -1,0 +1,128 @@
+import { Circle, Diamond, Square, Trash2 } from 'lucide-react'
+import type { PanelShapeEntityDetail, ShapeKind } from '../../../shared/types'
+import {
+  dividerClass,
+  mutedClass,
+  paneActionBtnClass,
+  paneDeleteBtnClass,
+} from '../rightDetailsPanelHelpers'
+import { rightDetailsPanelApi } from '../rightDetailsPanelApi'
+import { ColorSwatchPicker } from './ColorSwatchPicker'
+import { PaneHeader } from './PaneHeader'
+
+const STROKE_WIDTHS: number[] = [1, 2, 3, 4]
+
+const SHAPE_OPTIONS: Array<{ kind: ShapeKind; label: string; Icon: React.ComponentType<{ size?: number }> }> = [
+  { kind: 'rectangle', label: 'Rectangle', Icon: Square },
+  { kind: 'ellipse', label: 'Ellipse', Icon: Circle },
+  { kind: 'diamond', label: 'Diamond', Icon: Diamond },
+]
+
+export function ShapeEntityPane({
+  shapeEntity,
+  isDark,
+}: {
+  shapeEntity: PanelShapeEntityDetail
+  isDark: boolean
+}) {
+  const muted = mutedClass(isDark)
+  const divider = dividerClass(isDark)
+  const deleteBtnClass = paneDeleteBtnClass(isDark)
+  const segmentBtn = (active: boolean) =>
+    `flex items-center gap-1 rounded px-2 py-1 text-[11px] ${
+      active
+        ? isDark
+          ? 'bg-zinc-700 text-zinc-100'
+          : 'bg-zinc-200 text-zinc-900'
+        : isDark
+          ? 'text-zinc-300 hover:bg-zinc-800'
+          : 'text-zinc-600 hover:bg-zinc-100'
+    }`
+
+  const HeaderIcon =
+    SHAPE_OPTIONS.find((o) => o.kind === shapeEntity.shapeKind)?.Icon ?? Square
+  const currentStroke = shapeEntity.strokeWidth ?? 2
+
+  return (
+    <div className="flex flex-col">
+      <PaneHeader
+        icon={<HeaderIcon size={14} />}
+        label={shapeEntity.text.slice(0, 40) || shapeEntity.shapeKind}
+        actions={
+          <button
+            type="button"
+            className={deleteBtnClass}
+            onClick={() => rightDetailsPanelApi.deleteShapeEntity(shapeEntity.id)}
+            title="Delete"
+            aria-label="Delete Shape"
+          >
+            <Trash2 size={14} />
+          </button>
+        }
+      />
+
+      <div className={`px-2 pt-2 pb-2`}>
+        <div className={`mb-1 text-[10px] font-medium ${muted}`}>shape</div>
+        <div className="flex items-center gap-1">
+          {SHAPE_OPTIONS.map(({ kind, label, Icon }) => (
+            <button
+              key={kind}
+              type="button"
+              className={segmentBtn(shapeEntity.shapeKind === kind)}
+              onClick={() =>
+                rightDetailsPanelApi.updateShapeEntity(shapeEntity.id, { shapeKind: kind })
+              }
+              title={label}
+            >
+              <Icon size={12} />
+              <span>{label.toLowerCase()}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className={`border-t px-2 pt-2 pb-2 ${divider}`}>
+        <div className={`mb-1 text-[10px] font-medium ${muted}`}>color</div>
+        <ColorSwatchPicker
+          activeColor={shapeEntity.color ?? null}
+          isDark={isDark}
+          allowNone
+          onSelectColor={(color) =>
+            rightDetailsPanelApi.updateShapeEntity(shapeEntity.id, { color })
+          }
+        />
+      </div>
+
+      <div className={`border-t px-2 pt-2 pb-2 ${divider}`}>
+        <div className={`mb-1 text-[10px] font-medium ${muted}`}>stroke</div>
+        <div className="flex items-center gap-1">
+          {STROKE_WIDTHS.map((value) => (
+            <button
+              key={value}
+              type="button"
+              className={segmentBtn(currentStroke === value)}
+              onClick={() =>
+                rightDetailsPanelApi.updateShapeEntity(shapeEntity.id, { strokeWidth: value })
+              }
+            >
+              <span>{value}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {shapeEntity.text ? (
+        <div className={`border-t px-2 pt-2 pb-2 ${divider}`}>
+          <div className={`mb-1 text-[10px] font-medium ${muted}`}>content</div>
+          <div
+            className={`rounded px-2 py-1.5 text-[11px] leading-5 ${
+              isDark ? 'bg-zinc-800' : 'bg-zinc-100'
+            }`}
+          >
+            {shapeEntity.text}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/toolbar/App.tsx
+++ b/src/renderer/toolbar/App.tsx
@@ -172,6 +172,7 @@ export default function App({ initialTheme }: { initialTheme: ThemeData }) {
                 onAddPage={toolbarApi.addPage}
                 onAddTextEntity={toolbarApi.addTextEntity}
                 onAddNote={toolbarApi.addNote}
+                onAddShape={toolbarApi.addShape}
                 onDropdownOpenChange={(open) => {
                   if (open) toolbarApi.dropdownOpen()
                   else toolbarApi.dropdownClose()
@@ -221,6 +222,7 @@ export default function App({ initialTheme }: { initialTheme: ThemeData }) {
                 onAddPage={toolbarApi.addPage}
                 onAddTextEntity={toolbarApi.addTextEntity}
                 onAddNote={toolbarApi.addNote}
+                onAddShape={toolbarApi.addShape}
                 onDropdownOpenChange={(open) => {
                   if (open) toolbarApi.dropdownOpen()
                   else toolbarApi.dropdownClose()

--- a/src/renderer/toolbar/toolbarSections.tsx
+++ b/src/renderer/toolbar/toolbarSections.tsx
@@ -1,10 +1,13 @@
 import type { Dispatch, SetStateAction } from 'react'
 import { Select } from '@base-ui/react/select'
 import { Tabs } from '@base-ui/react/tabs'
+import { useState } from 'react'
 import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  Circle,
+  Diamond,
   Frame,
   LayoutTemplate,
   MessageCircle,
@@ -16,11 +19,18 @@ import {
   Pipette,
   RotateCw,
   FileText,
+  Square,
   SquareDashedMousePointer,
   StickyNote,
   Sun,
 } from 'lucide-react'
-import type { AgentPresenceCursor, AnnotationMode, ToolbarSelectionData } from '../../shared/types'
+import { Menu } from '@base-ui/react/menu'
+import type {
+  AgentPresenceCursor,
+  AnnotationMode,
+  ShapeKind,
+  ToolbarSelectionData,
+} from '../../shared/types'
 import { summarizePresenceCursor } from '../../shared/agent-presence'
 import { normalizeUserUrl } from '../../shared/url'
 import { FramePresetDropdown } from '../shared/FramePresetDropdown'
@@ -37,6 +47,68 @@ function toolbarActiveIconBtnClass(isDark: boolean): string {
   return isDark
     ? 'toolbar-squircle-btn rounded-[8px] border border-transparent bg-[var(--surface-interactive)] p-1.5 text-zinc-100'
     : 'toolbar-squircle-btn rounded-[8px] border border-transparent bg-[var(--surface-interactive)] p-1.5 text-zinc-900'
+}
+
+const SHAPE_OPTIONS: Array<{ kind: ShapeKind; label: string; Icon: React.ComponentType<{ size?: number }> }> = [
+  { kind: 'rectangle', label: 'rectangle', Icon: Square },
+  { kind: 'ellipse', label: 'ellipse', Icon: Circle },
+  { kind: 'diamond', label: 'diamond', Icon: Diamond },
+]
+
+function ShapeMenu({
+  isDark,
+  onAddShape,
+  onDropdownOpenChange,
+}: {
+  isDark: boolean
+  onAddShape: (shapeKind: ShapeKind) => void
+  onDropdownOpenChange: (open: boolean) => void
+}) {
+  const [lastShape, setLastShape] = useState<ShapeKind>('rectangle')
+  const triggerClassName = toolbarIconBtnClass(isDark)
+  const LastIcon = SHAPE_OPTIONS.find((o) => o.kind === lastShape)?.Icon ?? Square
+
+  const popupClassName = `z-50 min-w-[160px] rounded-[10px] border p-1 shadow-xl outline-none ${
+    isDark
+      ? 'border-[var(--surface-popover-border)] bg-[var(--surface-popover-subtle)] text-zinc-100'
+      : 'border-[var(--surface-popover-border)] bg-[var(--surface-popover-subtle)] text-zinc-900'
+  }`
+  const itemClassName = `flex cursor-default items-center gap-2 rounded-[7px] px-2.5 py-1.5 text-xs outline-none ${
+    isDark
+      ? 'text-zinc-100 data-[highlighted]:bg-[var(--surface-popover)]'
+      : 'text-zinc-900 data-[highlighted]:bg-[var(--surface-popover)]'
+  }`
+
+  return (
+    <Menu.Root onOpenChange={onDropdownOpenChange}>
+      <Menu.Trigger
+        className={`${triggerClassName} flex items-center gap-0.5 pr-1`}
+        title="Add Shape"
+      >
+        <LastIcon size={14} />
+        <ChevronDown size={10} className={isDark ? 'text-zinc-400' : 'text-zinc-500'} />
+      </Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner side="bottom" align="center" sideOffset={4}>
+          <Menu.Popup className={popupClassName}>
+            {SHAPE_OPTIONS.map(({ kind, label, Icon }) => (
+              <Menu.Item
+                key={kind}
+                className={itemClassName}
+                onClick={() => {
+                  setLastShape(kind)
+                  onAddShape(kind)
+                }}
+              >
+                <Icon size={12} />
+                <span>{label}</span>
+              </Menu.Item>
+            ))}
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  )
 }
 
 function AddFramePresetMenu({
@@ -132,6 +204,7 @@ interface CenterActionsProps {
   onAddPage: (presetIndex: number | 'custom') => void
   onAddTextEntity: () => void
   onAddNote: () => void
+  onAddShape: (shapeKind: ShapeKind) => void
   onDropdownOpenChange: (open: boolean) => void
   onClearToolMode: () => void
   onToggleAnnotateMode: () => void
@@ -157,6 +230,7 @@ export function CenterActions({
   onAddPage,
   onAddTextEntity,
   onAddNote,
+  onAddShape,
   onDropdownOpenChange,
   onClearToolMode,
   onToggleAnnotateMode,
@@ -219,6 +293,14 @@ export function CenterActions({
           >
             <FileText size={14} />
           </button>
+        ) : null}
+
+        {!isBrowserMode ? (
+          <ShapeMenu
+            isDark={isDark}
+            onAddShape={onAddShape}
+            onDropdownOpenChange={onDropdownOpenChange}
+          />
         ) : null}
 
         <div className="ml-0.5 flex items-center gap-2">

--- a/src/shared/canvas-colors.ts
+++ b/src/shared/canvas-colors.ts
@@ -34,3 +34,16 @@ export function withAlpha(color: string, alpha: number): string {
   }
   return color
 }
+
+/** Lighten a #RRGGBB hex by interpolating toward white. amount=0 leaves it; amount=1 returns white. */
+export function lightenHex(color: string, amount: number): string {
+  if (!color.startsWith('#') || color.length !== 7) return color
+  const r = parseInt(color.slice(1, 3), 16)
+  const g = parseInt(color.slice(3, 5), 16)
+  const b = parseInt(color.slice(5, 7), 16)
+  const lr = Math.round(r + (255 - r) * amount)
+  const lg = Math.round(g + (255 - g) * amount)
+  const lb = Math.round(b + (255 - b) * amount)
+  const hex = (n: number) => n.toString(16).padStart(2, '0')
+  return `#${hex(lr)}${hex(lg)}${hex(lb)}`
+}

--- a/src/shared/canvas-colors.ts
+++ b/src/shared/canvas-colors.ts
@@ -23,3 +23,14 @@ export const COLOR_PRESETS: Record<string, string> = {
 export function resolveCanvasColor(color: string): string {
   return COLOR_PRESETS[color] ?? color
 }
+
+/** Apply an alpha to a #RRGGBB hex color; passes other forms through. */
+export function withAlpha(color: string, alpha: number): string {
+  if (color.startsWith('#') && color.length === 7) {
+    const r = parseInt(color.slice(1, 3), 16)
+    const g = parseInt(color.slice(3, 5), 16)
+    const b = parseInt(color.slice(5, 7), 16)
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`
+  }
+  return color
+}

--- a/src/shared/gesture-utils.ts
+++ b/src/shared/gesture-utils.ts
@@ -40,6 +40,25 @@ export function normalizeRect(
   }
 }
 
+export function squareConstrainedRect(
+  startX: number,
+  startY: number,
+  currentX: number,
+  currentY: number,
+  constrainSquare: boolean,
+) {
+  if (!constrainSquare) return normalizeRect(startX, startY, currentX, currentY)
+  const dx = currentX - startX
+  const dy = currentY - startY
+  const side = Math.max(Math.abs(dx), Math.abs(dy))
+  return {
+    left: dx < 0 ? startX - side : startX,
+    top: dy < 0 ? startY - side : startY,
+    width: side,
+    height: side,
+  }
+}
+
 export function snapToGrid(value: number): number {
   return Math.round(value / GRID_SIZE) * GRID_SIZE
 }

--- a/src/shared/json-canvas-types.ts
+++ b/src/shared/json-canvas-types.ts
@@ -13,7 +13,7 @@ export type CanvasColor = '1' | '2' | '3' | '4' | '5' | '6' | (string & {})
 
 export interface JsonCanvasNodeBase {
   id: string
-  type: 'text' | 'link' | 'file' | 'group' | 'drawing'
+  type: 'text' | 'link' | 'file' | 'group' | 'drawing' | 'shape'
   x: number
   y: number
   width: number
@@ -77,12 +77,27 @@ export interface JsonCanvasDrawingNode extends JsonCanvasNodeBase {
   parentGroupId?: string
 }
 
+/**
+ * Shape node (Specular extension). Other JSON Canvas tools ignore
+ * unknown `type` values per the spec's extensibility model.
+ */
+export interface JsonCanvasShapeNode extends JsonCanvasNodeBase {
+  type: 'shape'
+  shapeKind: 'rectangle' | 'ellipse' | 'diamond'
+  text?: string
+  strokeWidth?: number
+  theme?: string
+  label?: string
+  parentGroupId?: string
+}
+
 export type JsonCanvasNode =
   | JsonCanvasTextNode
   | JsonCanvasLinkNode
   | JsonCanvasFileNode
   | JsonCanvasGroupNode
   | JsonCanvasDrawingNode
+  | JsonCanvasShapeNode
 
 // --- Edges ---
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -47,7 +47,9 @@ export interface PageConfig {
 
 // --- Generic Canvas Entity Types ---
 
-export type CanvasEntityKind = 'frame' | 'text' | 'file' | 'group' | 'edge' | 'drawing'
+export type CanvasEntityKind = 'frame' | 'text' | 'file' | 'group' | 'edge' | 'drawing' | 'shape'
+
+export type ShapeKind = 'rectangle' | 'ellipse' | 'diamond'
 
 export interface CanvasEntityRef {
   kind: CanvasEntityKind
@@ -207,12 +209,32 @@ export interface CanvasSceneDrawingEntity {
   parentGroupId?: string
 }
 
+export interface CanvasSceneShapeEntity {
+  kind: 'shape'
+  id: string
+  shapeKind: ShapeKind
+  text: string
+  color?: string
+  strokeWidth?: number
+  theme?: string
+  canvasX: number
+  canvasY: number
+  width: number
+  height: number
+  parentGroupId?: string
+  screenX: number
+  screenY: number
+  screenWidth: number
+  screenHeight: number
+}
+
 export type CanvasSceneEntity =
   | CanvasSceneFrameEntity
   | CanvasSceneTextEntity
   | CanvasSceneFileEntity
   | CanvasSceneGroupEntity
   | CanvasSceneDrawingEntity
+  | CanvasSceneShapeEntity
 
 export interface ActiveCanvasEntitySelection {
   entityRef: CanvasEntityRef
@@ -226,6 +248,7 @@ export interface ActiveCanvasEntitySelection {
 export interface PendingPlacement {
   entityKind: CanvasEntityKind
   presetIndex?: number
+  shapeKind?: ShapeKind
   width: number
   height: number
   initialClientX: number | null
@@ -299,12 +322,25 @@ export interface PersistedDrawingEntity extends CanvasEntityBase {
   label?: string
 }
 
+export interface PersistedShapeEntity extends CanvasEntityBase {
+  kind: 'shape'
+  shapeKind: ShapeKind
+  text: string
+  color?: string
+  strokeWidth?: number
+  theme?: string
+  width: number
+  height: number
+  label?: string
+}
+
 export type PersistedCanvasEntity =
   | PersistedFrameEntity
   | PersistedTextEntity
   | PersistedFileEntity
   | PersistedGroupEntity
   | PersistedDrawingEntity
+  | PersistedShapeEntity
 
 // --- Layout Update Data ---
 
@@ -652,9 +688,20 @@ export type PanelMode =
   | { kind: 'text'; entityId: string }
   | { kind: 'file'; entityId: string }
   | { kind: 'drawing'; entityId: string }
+  | { kind: 'shape'; entityId: string }
   | { kind: 'edge'; entityId: string }
   | { kind: 'group'; entityId: string }
   | { kind: 'multi'; entityIds: string[] }
+
+export interface PanelShapeEntityDetail {
+  id: string
+  shapeKind: ShapeKind
+  text: string
+  color?: string
+  strokeWidth?: number
+  width: number
+  height: number
+}
 
 export interface PanelTextEntityDetail {
   id: string
@@ -734,6 +781,7 @@ export interface DevtoolsPanelData {
   textEntity?: PanelTextEntityDetail
   fileEntity?: PanelFileEntityDetail
   drawingEntity?: PanelDrawingEntityDetail
+  shapeEntity?: PanelShapeEntityDetail
   edgeEntity?: PanelEdgeEntityDetail
   groupEntity?: PanelGroupEntityDetail
   multiEntities?: PanelMultiEntitySummary[]
@@ -948,6 +996,7 @@ export interface UiPendingPlacement {
   presetIndex?: number
   customSize?: boolean
   sourceFrameId?: string
+  shapeKind?: ShapeKind
 }
 
 export interface UiState {
@@ -1365,6 +1414,7 @@ export interface ToolbarElectronAPI {
   cancelPendingPlacement: () => void
   addTextEntity: () => void
   addNote: () => void
+  addShape: (shapeKind: ShapeKind) => void
   reloadApp: () => void
   toggleTheme: () => void
   getInitialData: () => Promise<ThemeBootstrapData>
@@ -1455,6 +1505,14 @@ export interface CanvasBgElectronAPI {
   deleteFileEntity: (id: string) => void
   updateDrawingEntity: (id: string, patch: { width?: number; height?: number; canvasX?: number; canvasY?: number }) => void
   deleteDrawingEntity: (id: string) => void
+  updateShapeEntity: (id: string, patch: { shapeKind?: ShapeKind; text?: string; color?: string; strokeWidth?: number; theme?: string; width?: number; height?: number; canvasX?: number; canvasY?: number }) => void
+  deleteShapeEntity: (id: string) => void
+  placePendingShape: (
+    canvasX: number,
+    canvasY: number,
+    dragRect?: { x: number; y: number; width: number; height: number } | null,
+  ) => void
+  onShapeBeginEdit: (callback: (data: { entityId: string }) => void) => () => void
   showFileInFinder: (filePath: string) => void
   updateGroupEntity: (id: string, patch: { width?: number; height?: number; canvasX?: number; canvasY?: number; label?: string; color?: string }) => void
   duplicateGroup: (id: string) => void
@@ -1484,7 +1542,7 @@ export interface CanvasBgElectronAPI {
   createAnnotation: (request: AnnotationCreateRequest) => void
   createDrawing: (input: { canvasX: number; canvasY: number; width: number; height: number; strokes: AnnotationDrawingStroke[] }) => void
   selectEntities: (entityIds: string[]) => void
-  resizeMultiSelection: (entries: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing'; width: number; height: number; canvasX: number; canvasY: number }>) => void
+  resizeMultiSelection: (entries: Array<{ id: string; kind: 'frame' | 'text' | 'file' | 'drawing' | 'shape'; width: number; height: number; canvasX: number; canvasY: number }>) => void
   deleteSelection: () => void
   moveAnnotation: (annotationId: string, dx: number, dy: number) => void
   addAnnotationReply: (annotationId: string, text: string) => void
@@ -1640,6 +1698,8 @@ export interface DevtoolsPanelElectronAPI {
   setFileDeviceOrientation: (fileId: string, orientation: string) => void
   toggleFileDeviceShell: (fileId: string) => void
   deleteDrawingEntity: (id: string) => void
+  updateShapeEntity: (id: string, patch: { shapeKind?: ShapeKind; text?: string; color?: string; strokeWidth?: number; theme?: string; width?: number; height?: number; canvasX?: number; canvasY?: number }) => void
+  deleteShapeEntity: (id: string) => void
   updateEdge: (id: string, patch: { fromEnd?: EdgeEnd; toEnd?: EdgeEnd; fromSide?: EdgeSide; toSide?: EdgeSide; color?: string; label?: string }) => void
   deleteEdge: (id: string) => void
   setFramePreset: (frameId: string, presetIndex: number) => void

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -510,6 +510,13 @@ export interface SidebarDrawingItem {
   strokeCount: number
 }
 
+export interface SidebarShapeItem {
+  kind: 'shape'
+  id: string
+  label: string
+  shapeKind: ShapeKind
+}
+
 export interface SidebarGroupItem {
   kind: 'group'
   id: string
@@ -523,6 +530,7 @@ export type SidebarCanvasItem =
   | SidebarTextItem
   | SidebarFileItem
   | SidebarDrawingItem
+  | SidebarShapeItem
   | SidebarGroupItem
 
 export interface LeftSidebarData {
@@ -1181,6 +1189,11 @@ export interface ClipboardEntityPayload {
   file?: string
   subpath?: string
   objectFit?: FileObjectFit
+  // Shape entity-specific
+  shapeKind?: ShapeKind
+  strokeWidth?: number
+  theme?: string
+  label?: string
 }
 
 export interface ClipboardEntitySelectionPayload {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1566,6 +1566,13 @@ export interface CanvasBgElectronAPI {
   updateEdgeDragTarget: (targetEntityId: string | null, targetSide: EdgeSide | null) => void
   commitEdgeDrag: (fromEntityId: string, toEntityId: string, fromSide: EdgeSide, toSide: EdgeSide) => void
   cancelEdgeDrag: () => void
+  commitEdgeEdit: (
+    edgeId: string,
+    movingEnd: 'from' | 'to',
+    targetEntityId: string,
+    targetSide: EdgeSide,
+  ) => void
+  discardEdgeEdit: (edgeId: string) => void
   createEdge: (fromEntityId: string, toEntityId: string, fromSide?: EdgeSide, toSide?: EdgeSide) => void
   deleteEdge: (edgeId: string) => void
   selectEdge: (edgeId: string | null) => void

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -972,7 +972,8 @@ export type SelectionOverlayRect = {
 
 export type SelectionOverlayPayload = {
   rect: SelectionOverlayRect
-  variant?: 'default' | 'region-select'
+  variant?: 'default' | 'region-select' | 'place-shape'
+  shapeKind?: ShapeKind
 }
 
 export type UiViewMode =

--- a/tests/unit/json-canvas-serializer.test.ts
+++ b/tests/unit/json-canvas-serializer.test.ts
@@ -6,6 +6,7 @@ import {
 import type {
   PersistedDrawingEntity,
   PersistedFileEntity,
+  PersistedShapeEntity,
   WorkspaceSnapshot,
 } from '../../src/shared/types'
 
@@ -93,6 +94,59 @@ describe('json-canvas-serializer drawings', () => {
 
     const { snapshot: restored } = deserializeFromJsonCanvas(doc)
     expect(restored.entities?.['f1']).toEqual(file)
+  })
+
+  it('round-trips shape entities with all optional fields', () => {
+    const shape: PersistedShapeEntity = {
+      kind: 'shape',
+      id: 'sh1',
+      shapeKind: 'diamond',
+      text: 'Approve?',
+      color: '2',
+      strokeWidth: 3,
+      canvasX: 10,
+      canvasY: 20,
+      width: 200,
+      height: 120,
+    }
+    const snapshot = emptySnapshot()
+    snapshot.entities!['sh1'] = shape
+    snapshot.entityOrder = ['sh1']
+
+    const doc = serializeToJsonCanvas(snapshot)
+    expect(doc.nodes).toHaveLength(1)
+    expect(doc.nodes[0]).toMatchObject({
+      type: 'shape',
+      id: 'sh1',
+      shapeKind: 'diamond',
+      text: 'Approve?',
+      color: '2',
+      strokeWidth: 3,
+    })
+
+    const { snapshot: restored } = deserializeFromJsonCanvas(doc)
+    expect(restored.entities?.['sh1']).toEqual(shape)
+    expect(restored.entityOrder).toEqual(['sh1'])
+  })
+
+  it('round-trips a minimal shape entity (no color, no stroke)', () => {
+    const shape: PersistedShapeEntity = {
+      kind: 'shape',
+      id: 'sh2',
+      shapeKind: 'rectangle',
+      text: '',
+      canvasX: 0,
+      canvasY: 0,
+      width: 200,
+      height: 120,
+    }
+    const snapshot = emptySnapshot()
+    snapshot.entities!['sh2'] = shape
+    snapshot.entityOrder = ['sh2']
+
+    const doc = serializeToJsonCanvas(snapshot)
+    const { snapshot: restored } = deserializeFromJsonCanvas(doc)
+    expect(restored.entities?.['sh2']).toEqual(shape)
   })
 
   it('preserves drawing z-order among other entities', () => {

--- a/tests/unit/shape-entity-state.test.ts
+++ b/tests/unit/shape-entity-state.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, it, expect } from 'vitest'
+import {
+  buildShapeEntitySceneEntity,
+  clearShapeEntities,
+  createShapeEntity,
+  DEFAULT_SHAPE_HEIGHT,
+  DEFAULT_SHAPE_WIDTH,
+  deleteShapeEntity,
+  persistShapeEntity,
+  shapeEntities,
+  updateShapeEntity,
+} from '../../src/main/runtime/shape-entity-state'
+
+afterEach(() => {
+  clearShapeEntities()
+})
+
+describe('shape-entity-state', () => {
+  it('creates a rectangle with default size when nothing is supplied', () => {
+    const entity = createShapeEntity({ canvasX: 10, canvasY: 20 })
+    expect(entity.shapeKind).toBe('rectangle')
+    expect(entity.width).toBe(DEFAULT_SHAPE_WIDTH)
+    expect(entity.height).toBe(DEFAULT_SHAPE_HEIGHT)
+    expect(entity.text).toBe('')
+    expect(shapeEntities).toHaveLength(1)
+  })
+
+  it('honors explicit shapeKind, size, and text', () => {
+    const entity = createShapeEntity({
+      canvasX: 0,
+      canvasY: 0,
+      shapeKind: 'ellipse',
+      width: 80,
+      height: 40,
+      text: 'hello',
+      color: '2',
+      strokeWidth: 3,
+    })
+    expect(entity.shapeKind).toBe('ellipse')
+    expect(entity.width).toBe(80)
+    expect(entity.height).toBe(40)
+    expect(entity.text).toBe('hello')
+    expect(entity.color).toBe('2')
+    expect(entity.strokeWidth).toBe(3)
+  })
+
+  it('updates fields including shapeKind and text', () => {
+    const entity = createShapeEntity({ canvasX: 0, canvasY: 0 })
+    updateShapeEntity(entity.id, { shapeKind: 'diamond', text: 'go' })
+    expect(entity.shapeKind).toBe('diamond')
+    expect(entity.text).toBe('go')
+  })
+
+  it('deletes by id', () => {
+    const entity = createShapeEntity({ canvasX: 0, canvasY: 0 })
+    expect(deleteShapeEntity(entity.id)).toBe(true)
+    expect(shapeEntities).toHaveLength(0)
+  })
+
+  it('builds a scene entity with screen-space coords', () => {
+    const entity = createShapeEntity({
+      canvasX: 100,
+      canvasY: 200,
+      width: 50,
+      height: 30,
+      shapeKind: 'rectangle',
+    })
+    const scene = buildShapeEntitySceneEntity(entity, 2, { x: 5, y: 7 }, { x: 10, y: 20 })
+    expect(scene.kind).toBe('shape')
+    // canvasOrigin + canvasX*zoom + pan
+    expect(scene.screenX).toBe(10 + 100 * 2 + 5)
+    expect(scene.screenY).toBe(20 + 200 * 2 + 7)
+    expect(scene.screenWidth).toBe(100)
+    expect(scene.screenHeight).toBe(60)
+  })
+
+  it('persists and restores all fields', () => {
+    const entity = createShapeEntity({
+      canvasX: 1,
+      canvasY: 2,
+      shapeKind: 'diamond',
+      text: 'go',
+      color: '3',
+      strokeWidth: 4,
+      width: 80,
+      height: 90,
+    })
+    const persisted = persistShapeEntity(entity)
+    expect(persisted).toMatchObject({
+      kind: 'shape',
+      id: entity.id,
+      shapeKind: 'diamond',
+      text: 'go',
+      color: '3',
+      strokeWidth: 4,
+      width: 80,
+      height: 90,
+      canvasX: 1,
+      canvasY: 2,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- New `shape` canvas entity kind with rectangle, ellipse, and diamond variants — toolbar picker, drag-to-place, inline text, color/stroke controls in the inspector pane
- Full integration through Y.Doc persistence, JSON Canvas serializer, selection/multi-resize, grouping, and undo/redo
- Unit tests for shape state mutations and serializer round-trip

## Test plan
- [ ] Add each shape variant from the toolbar; drag to size; commit text
- [ ] Color, stroke width, and shape-kind switches in the right details pane apply live
- [ ] Multi-select drag, resize, group, and delete include shapes
- [ ] Undo/redo restores shape state across tab switches
- [ ] Reload restores shapes from .canvas; open in another JSON Canvas tool ignores them gracefully