### PR TITLE
feat(upsert): declarative layout directive with chrome-aware gaps

### DIFF
--- a/.claude/skills/specular/SKILL.md
+++ b/.claude/skills/specular/SKILL.md
@@ -54,22 +54,65 @@ canvas and frame operations go through the `specular` command.
 
 ### Upsert tips
 
-`upsert --json` is the fastest way to create many entities at once. For
-**frames**, it honors `canvasX`, `canvasY`, `presetIndex`, and
-`orientation: "landscape" | "portrait"` — use it to drop a batch of frames
-at exact positions with the right device preset in one call:
+`upsert --json` is the fastest way to create many entities at once. It accepts
+two shapes on stdin: a bare array of items (legacy), or `{layout, items}` with
+a declarative `layout` directive that places everything for you.
+
+**Use the `layout` directive for any composition of more than 2 items.** It
+takes a `kind` (`row` / `column` / `grid`), a `gap` (token or pixel number),
+and an anchor (`originX`/`originY`, `near: <id>`, or implicit). Same shape
+creates new items *and* reorganizes existing ones — pass an `id` to re-lay-out
+an entity that's already on the canvas.
 
 ```bash
+# Create three frames in a row at breakpoints
 cat << 'EOF' | specular upsert --json
-[
-  {"kind":"frame","url":"https://example.com","presetIndex":6,"orientation":"landscape","canvasX":200,"canvasY":200},
-  {"kind":"frame","url":"https://example.com","presetIndex":0,"canvasX":1520,"canvasY":200}
-]
+{
+  "layout": { "kind": "row", "gap": "m", "originX": 200, "originY": 200 },
+  "items": [
+    {"kind":"frame","url":"https://example.com","presetIndex":0},
+    {"kind":"frame","url":"https://example.com","presetIndex":3},
+    {"kind":"frame","url":"https://example.com","presetIndex":6}
+  ]
+}
 EOF
 ```
 
-For **files** (markdown, wireframe, image) upsert ignores `canvasX/canvasY` —
-the layout engine always places them. Images additionally ignore `width`.
+```bash
+# Reorganize 6 existing frames into a 3x2 grid
+cat << 'EOF' | specular upsert --json
+{
+  "layout": { "kind": "grid", "cols": 3, "gap": "m", "near": "frame_a" },
+  "items": [
+    {"id":"frame_a"}, {"id":"frame_b"}, {"id":"frame_c"},
+    {"id":"frame_d"}, {"id":"frame_e"}, {"id":"frame_f"}
+  ]
+}
+EOF
+```
+
+When a directive is present, per-item `canvasX`/`canvasY` are ignored. Without
+`originX/Y` or `near`, the directive anchors at the bounding box of any
+existing items in `items[]` (so re-layout doesn't teleport the cluster); with
+no existing items, it falls back to `find-placement`.
+
+**Spacing scale.** Tokens are aligned to the canvas grid (20px multiples).
+Numbers work too as an escape hatch:
+
+| Token | Pixels |
+|---|---|
+| `xs` | 20 |
+| `s` | 40 |
+| `m` | 60 |
+| `l` | 100 |
+| `xl` | 160 |
+
+For ad-hoc single drops, the bare-array form still works and honors `canvasX`,
+`canvasY`, `presetIndex`, and `orientation: "landscape" | "portrait"` per item.
+
+For **files** (markdown, wireframe, image) without a directive, upsert ignores
+`canvasX/canvasY` — the layout engine always places them. Images additionally
+ignore `width`.
 
 ### Note colors
 

--- a/docs/plans/agent-layout-spine.md
+++ b/docs/plans/agent-layout-spine.md
@@ -1,17 +1,18 @@
 # Agent Layout Spine
 
-Branch: `claude/agent-layout-guidance-UuRCO`. Plan for the three primitives that
+Branch: `claude/agent-layout-guidance-UuRCO`. Plan for the two primitives that
 collapse most agent-driven layout failures: a declarative `layout` directive
-on `upsert`, auto-layout groups, and a `workspace --check` feedback loop.
+on `upsert` (covering both new and existing items), and a `workspace --check`
+feedback loop. Auto-layout groups are explicitly out of scope here — see
+[Future work](#future-work-auto-layout-groups-humans).
 
 ## Status
 
 | Phase | Status |
 |---|---|
-| 1 — `layout` directive on `upsert --json` | ⬜ not started |
+| 1 — `layout` directive on `upsert --json` (creates + re-layout) | ⬜ not started |
 | 2 — `specular workspace --check` | ⬜ not started |
-| 3 — Auto-layout groups (runtime honors `managedLayout`) | ⬜ not started |
-| 4 — Skill update | ⬜ not started |
+| 3 — Skill update | ⬜ not started |
 
 ## Context
 
@@ -21,47 +22,48 @@ output looks bad. Today's primitives (`upsert --json`, `find-placement`, `group`
 require the agent to do the layout math, then verify by reading back JSON they
 can't visually interpret.
 
-Three additions cover ~80% of these failures without growing the verb list
-meaningfully:
+Two additions cover ~80% of these failures without growing the verb list:
 
-1. **Declarative `layout` directive** — agents describe intent (`row`, `column`,
-   `grid`) instead of computing coordinates.
-2. **Auto-layout groups** — groups with `managedLayout: true` enforce direction,
-   gap, and padding on members. The schema is already in place; the runtime
-   needs to honor it.
-3. **`workspace --check`** — one-call feedback that flags overlaps, off-scale
+1. **Declarative `layout` directive on `upsert`** — agents describe intent
+   (`row`, `column`, `grid`) instead of computing coordinates. Crucially, the
+   directive applies to items with an `id` too, so the same call that creates
+   N frames in a row also reorganizes N existing frames into a row.
+2. **`workspace --check`** — one-call feedback that flags overlaps, off-scale
    gaps, and near-misalignment so agents self-correct.
 
 Together these turn layout from "agent computes positions" into "agent describes
-composition; canvas places, validates, and reports."
+composition; canvas places, validates, and reports." Persistent enforcement
+(auto-layout groups for humans, drag-to-swap, etc.) is a separate problem;
+agents re-emit the directive when they want it re-applied.
 
 ## Build order
 
-1. **Phase 1 — `layout` directive on upsert.** Smallest scope; validates the
-   spacing-scale vocabulary before it gets baked into idea 8's runtime work.
+1. **Phase 1 — `layout` directive on upsert.** Validates the spacing-scale
+   vocabulary and delivers the agent's primary tool for both layout and
+   re-layout.
 2. **Phase 2 — `workspace --check`.** Independent of phase 1, but agents using
    the directive will lean on `--check` to verify output.
-3. **Phase 3 — Auto-layout groups.** Biggest surface area (UX, runtime, persistence
-   already partly done). Reuses the layout-math helper from phase 1.
-4. **Phase 4 — Skill update.** Single edit at the end so examples reflect the
+3. **Phase 3 — Skill update.** Single edit at the end so examples reflect the
    final shape.
 
 ## Existing scaffolding
 
-A scan of the codebase before drafting turned up partial work:
+A scan before drafting turned up partial work that this plan builds on:
 
-- `src/shared/types.ts:309` — `WorkspaceGroupLayoutMode = 'freeform' | 'row' | 'grid'`
-  already exists on groups.
-- `src/shared/types.ts:199` — `layoutMode` and `managedLayout` are persisted
-  fields on `WorkspaceGroupEntity`.
-- `src/main/runtime/group-entity-state.ts:43` — defaults are `'freeform'` and
-  `false`.
-- `src/main/runtime/json-canvas-serializer.ts:399` — round-trips both fields.
-- `src/main/runtime/layout-engine.ts` — does **not** read either field. This is
-  the runtime gap idea 8 has to close.
+- `src/main/shared/entity-ops.ts:35-38` — `UpsertOptions` already has `layout`
+  and `gap`. They flow into `/layout/batch-placement` at lines 97-108, but
+  only fire for *creates without `canvasX/Y`* (the `needsPlacement` filter at
+  line 76). Phase 1 generalizes this to all items in the call, including ones
+  with an `id`.
+- `src/main/shared/entity-ops.ts:66-72` — items with an `id` already route to
+  update buckets. The plumbing for re-layout-by-id exists; only the
+  position-computation step needs to learn about it.
+- `BatchLayoutMode` in `src/shared/types.ts` — current values are the
+  starting point for the directive's `kind` enum.
 
-`'column'` is missing from the enum and will need to be added. The schema lacks
-`gap` and `padding` on groups — both need to be added before phase 3 can land.
+Group schema fields (`WorkspaceGroupEntity.layoutMode`, `managedLayout`) and
+the `WorkspaceGroupLayoutMode` enum exist but are unused by the runtime. They
+remain unused after this plan; see Future work.
 
 ## Phase 1 — `layout` directive on `upsert --json`
 
@@ -79,6 +81,32 @@ The existing array form keeps working. New object form:
 }
 ```
 
+### Re-layout of existing items
+
+Items in the directive may carry an `id` instead of (or in addition to)
+creation attrs. The directive computes new positions for them too. This is
+the primary "clean up the canvas" verb:
+
+```json
+{
+  "layout": { "kind": "grid", "cols": 3, "gap": "m", "near": "frame_a" },
+  "items": [
+    { "id": "frame_a" }, { "id": "frame_b" }, { "id": "frame_c" },
+    { "id": "frame_d" }, { "id": "frame_e" }, { "id": "frame_f" }
+  ]
+}
+```
+
+Mechanics:
+
+- The size used for layout math is the entity's current width/height (read
+  from runtime state). Patches in the same item (e.g. `presetIndex`) are
+  applied first so the new size is honored.
+- Items with `id` route to the existing update buckets in
+  `entity-ops.ts:66-72`. The new step is: when a `layout` directive is
+  present, compute positions for *all* items (creates and updates) in one
+  pass and override `canvasX`/`canvasY` on each before bucket-routing.
+
 ### Layout kinds (v1)
 
 - `row` — left-to-right, `gap` between
@@ -90,40 +118,56 @@ The existing array form keeps working. New object form:
 Resolved in this order:
 
 1. Explicit `originX` / `originY`
-2. `near: <id>` — place adjacent to an existing entity, with `gap` between
-3. Default — `find-placement` finds open canvas space
+2. `near: <id>` — place adjacent to an existing entity, with `gap` between.
+   When the only `id` references in `items[]` are the things being
+   re-laid-out, `near` lets you anchor to a separate landmark.
+3. Default — for pure-create directives, `find-placement` finds open canvas
+   space. For directives containing existing IDs, the bounding box of those
+   items' current positions becomes the implicit origin (so re-layout doesn't
+   teleport the cluster).
 
 ### Spacing scale
 
-Accept both tokens and numbers:
+Accept both tokens and numbers. All token values are multiples of `GRID_SIZE`
+(20px) so they survive snap-to-grid intact:
 
 | Token | Pixels |
 |---|---|
-| `xs` | 8 |
-| `s` | 16 |
-| `m` | 24 |
-| `l` | 40 |
-| `xl` | 80 |
+| `xs` | 20 |
+| `s` | 40 |
+| `m` | 60 |
+| `l` | 100 |
+| `xl` | 160 |
 
 Examples in the skill default to tokens. Numbers remain an escape hatch.
 
 ### Item-level coordinates inside a directive
 
-Per-item `canvasX` / `canvasY` are ignored when a `layout` directive is present.
-Emit a warning in the response so agents notice. Per-item attrs like
-`presetIndex`, `width`, `height`, `text` still apply.
+Per-item `canvasX` / `canvasY` are ignored when a `layout` directive is
+present, for both creates and updates. Emit a warning in the response so
+agents notice. Per-item attrs like `presetIndex`, `width`, `height`, `text`
+still apply (and feed the layout math).
 
 ### Files
 
-- Upsert handler — TBD; route lives in `src/main/routes/`, runtime call is in
-  `src/main/runtime/`. Confirm during implementation.
+- `src/main/shared/entity-ops.ts` — extend `UpsertOptions` to accept the
+  full directive (kind, gap, cols, originX/Y, near). Replace the
+  `needsPlacement` filter (line 76) with: when a `layout` directive is
+  present, compute positions for *all* items; otherwise keep existing
+  per-item behavior.
+- `src/main/cli-commands.ts:64-77` — the `upsert` handler currently reads
+  `args.flags.layout` as a string. Extend to accept the directive object
+  from stdin JSON's top-level `layout` field (when stdin is the object form
+  rather than the array form).
 - New helper `src/main/runtime/layout-math.ts` — pure functions:
   `computeRow(items, gap, origin)`, `computeColumn(...)`, `computeGrid(...)`.
-  Consumed by phase 1 and phase 3.
-- CLI parsing for the new shape — `resources/specular-cli.sh` is a shell
-  shim; the JSON parsing lives server-side.
+- Optional: factor existing batch-placement logic in
+  `/layout/batch-placement` to share `layout-math.ts` so behavior is
+  identical between the new directive and the legacy auto-placement path.
 - `tests/unit/layout-math.test.ts` — pure-math coverage.
-- `tests/smoke/upsert-layout.test.ts` — end-to-end via AppClient.
+- `tests/smoke/upsert-layout.test.ts` — end-to-end via AppClient, including:
+  pure-create row, pure re-layout of existing IDs into a grid, and a mixed
+  case (3 existing + 2 new in one column).
 
 ### Edge cases
 
@@ -134,6 +178,10 @@ Emit a warning in the response so agents notice. Per-item attrs like
 - Heterogeneous-sized items in a row — align top by default; `align` field is
   v2.
 - Items with explicit `canvasX/Y` — warn and ignore.
+- Re-layout where one of the items doesn't exist — error the whole call,
+  return the bad ID. Don't partially apply.
+- `near: <id>` referencing one of the items being re-laid-out — fine; resolve
+  `near` against the entity's *original* position (before re-layout).
 
 ## Phase 2 — `specular workspace --check`
 
@@ -188,71 +236,7 @@ JSON by default for agents:
   under-report than nag.
 - Allow `--rules overlap,offscale` to disable misalignment. Cheap insurance.
 
-## Phase 3 — Auto-layout groups
-
-The schema is already in place (`layoutMode`, `managedLayout`). This phase wires
-the runtime to honor those fields and extends the schema with `gap` and
-`padding`.
-
-### Schema extensions
-
-On `WorkspaceGroupEntity`:
-
-- Add `'column'` to `WorkspaceGroupLayoutMode` enum: `'freeform' | 'row' | 'column' | 'grid'`.
-- Add `gap?: number | SpacingToken` (default `'m'` when `managedLayout: true`).
-- Add `padding?: number | [v, h] | [t, r, b, l]` (default `0`).
-- For `grid`, add `cols?: number` (default 2).
-
-JSON Canvas extension fields per `docs/file-formats.md` §Specular extensions.
-Update that doc as part of phase 3.
-
-### Runtime behavior
-
-When a group has `managedLayout: true`:
-
-- Member positions are computed by the group, not user input.
-- Adding a member appends and re-flows.
-- Removing closes the gap.
-- Reordering = mutating `members` order; positions follow.
-- Group move = members move with it (existing behavior, unchanged).
-
-### Manual drag of layout-managed members
-
-**v1 decision: block manual drag of members in a layout-managed group. Allow
-drag of the group itself.**
-
-Rationale: agents don't drag, so they're unaffected. Humans get a clear "this
-is managed" signal instead of confusing snap-back. Drag-to-reorder lands as v2
-if humans request it.
-
-Visible affordance: managed groups render with a distinct border/icon so the
-disabled drag is explicable.
-
-### Files
-
-- `src/main/runtime/layout-engine.ts` — read `managedLayout`, dispatch to
-  `layout-math.ts` helpers.
-- `src/main/runtime/group-entity-state.ts` — add `gap`/`padding` accessors and
-  re-flow on member add/remove/reorder.
-- `src/main/runtime/json-canvas-serializer.ts` — persist new fields.
-- `src/shared/types.ts` — extend enum and entity type.
-- `src/shared/json-canvas-types.ts` — extend persisted shape.
-- `src/renderer/canvas-bg/` — disable member drag when `managedLayout: true`;
-  render the affordance.
-- `docs/file-formats.md` — document `gap`, `padding`, and the extended enum.
-- `tests/unit/group-layout.test.ts` — add/remove/reorder behavior.
-- `tests/smoke/managed-group.test.ts` — end-to-end.
-
-### Edge cases
-
-- Single-member group — degenerate; render as if `freeform`.
-- Nested layout groups — recursion is fine because `layout-math.ts` is pure.
-- Heterogeneous-sized members — align top by default in row; left in column.
-  `align` is v2.
-- Toggling `managedLayout: false` → `true` on an existing group — re-flow on
-  toggle so positions snap to the directive.
-
-## Phase 4 — Skill update
+## Phase 3 — Skill update
 
 A single edit to `resources/skills/specular/SKILL.md` and
 `.claude/skills/specular/SKILL.md` (kept in sync per the CLAUDE.md skill-files
@@ -262,10 +246,11 @@ Changes:
 
 - Replace the canonical upsert example in `### Upsert tips` with the new
   `{layout, items}` shape using a 3-frame row at breakpoints.
-- Add a 2-line note: "Use `layout` instead of computing `canvasX`/`canvasY` for
-  more than 2 items."
-- Add 2 lines under groups: "Set `managedLayout: true` to auto-arrange members
-  in a row, column, or grid."
+- Add a second example showing re-layout of existing IDs into a grid — this
+  is the "clean up the canvas" pattern and deserves first-class billing.
+- Add a 2-line note: "Use `layout` instead of computing `canvasX`/`canvasY`
+  for more than 2 items. The same directive reorganizes existing entities
+  when items carry an `id`."
 - Add 1 line at the end of the workflow: "Run `specular workspace --check`
   after batch creates."
 - Add the spacing-scale table.
@@ -273,17 +258,35 @@ Changes:
 Do **not** add a separate "Layout" section. Folding into existing structure
 keeps skill bloat minimal.
 
+## Future work — auto-layout groups (humans)
+
+Persistent layout enforcement on groups is a different problem motivated by
+direct manipulation, not agent reliability. It belongs in its own plan
+because:
+
+- Agents don't need it — they re-emit the layout directive when they want
+  re-application. Phase 1 covers their use case.
+- The hard parts are UX, not runtime: drag-to-reorder, drag-to-swap content,
+  the "this is managed" affordance, snap-back vs. block-drag tradeoffs.
+- The schema fields (`layoutMode`, `managedLayout` on `WorkspaceGroupEntity`)
+  already exist; they remain unused until that plan lands. Adding `gap`,
+  `padding`, and `'column'` to the enum is part of that future plan.
+
+If a future agent-side use case demands persistent enforcement, the
+`layout-math.ts` helper from Phase 1 is reusable as-is.
+
 ## Cross-cutting decisions (settled)
 
 - **Spacing tokens vs. numbers.** Both. Tokens default in skill examples;
   numbers as escape hatches.
-- **Manual drag in layout-managed groups.** Block in v1; reorder in v2.
 - **Misalignment rule.** Ship in v1, narrow band (1–8px), opt-out via
   `--rules`.
 - **Backwards compat.** Existing array-form `upsert --json` keeps working
   unchanged. The object form is additive.
-- **`'column'` on `WorkspaceGroupLayoutMode`.** Add. Required for column
-  layouts in both phase 1 and phase 3.
+- **Re-layout vs. create symmetry.** The directive applies to both creates
+  and items with `id`; mixing is allowed. One verb covers both.
+- **No partial application on re-layout error.** If any referenced `id`
+  doesn't exist, the whole call errors. Avoids silent half-applied layouts.
 
 ## Open decisions (decide during phase 1)
 
@@ -297,21 +300,20 @@ keeps skill bloat minimal.
 ## Risks
 
 - **Layout directive doesn't get adopted** because the skill example isn't
-  compelling. Mitigation: canonical example is the breakpoint comparison
-  scenario — the same shape that motivates the audit use case.
+  compelling. Mitigation: canonical examples are (a) the breakpoint
+  comparison scenario for creates and (b) "reorganize 6 frames into a 3×2
+  grid" for re-layout — the latter is the most-asked agent task today.
 - **`--check` becomes noisy** and agents start ignoring it. Mitigation: tight
   tolerances, opt-out flag, only ship rules with high signal-to-noise.
-- **Auto-layout groups confuse humans** when drag is blocked. Mitigation:
-  clear affordance on managed groups; disable drag silently rather than with
-  an error toast.
-- **Schema drift** between the existing `layoutMode` enum and the new
-  `kind` field on the upsert directive. Mitigation: use the same string
-  values everywhere (`'row' | 'column' | 'grid'`); the directive's `kind`
-  is what gets written to the group's `layoutMode` when an upsert creates a
-  managed group.
+- **Re-layout teleports content unexpectedly** when no anchor is given.
+  Mitigation: implicit origin = bounding box of the existing items being
+  re-laid-out (see Anchoring rule 3). Agents who *want* the cluster moved
+  pass `originX/Y` or `near` explicitly.
 
 ## Out of scope (this plan)
 
+- **Auto-layout groups (persistent enforcement, drag-to-reorder, drag-to-swap).**
+  See [Future work](#future-work-auto-layout-groups-humans).
 - Tour mode / ordered traversal (separate plan; relates to Explain use case).
 - Image/video/text export (separate plan; relates to handoff).
 - Compositional grammar primitives (`comparison`, `sequence`, etc.) — these

--- a/docs/plans/agent-layout-spine.md
+++ b/docs/plans/agent-layout-spine.md
@@ -1,0 +1,322 @@
+# Agent Layout Spine
+
+Branch: `claude/agent-layout-guidance-UuRCO`. Plan for the three primitives that
+collapse most agent-driven layout failures: a declarative `layout` directive
+on `upsert`, auto-layout groups, and a `workspace --check` feedback loop.
+
+## Status
+
+| Phase | Status |
+|---|---|
+| 1 — `layout` directive on `upsert --json` | ⬜ not started |
+| 2 — `specular workspace --check` | ⬜ not started |
+| 3 — Auto-layout groups (runtime honors `managedLayout`) | ⬜ not started |
+| 4 — Skill update | ⬜ not started |
+
+## Context
+
+Agents that write to the canvas struggle with composition: they guess pixel
+coordinates, overlap entities, pick off-scale gaps, and don't notice when their
+output looks bad. Today's primitives (`upsert --json`, `find-placement`, `group`)
+require the agent to do the layout math, then verify by reading back JSON they
+can't visually interpret.
+
+Three additions cover ~80% of these failures without growing the verb list
+meaningfully:
+
+1. **Declarative `layout` directive** — agents describe intent (`row`, `column`,
+   `grid`) instead of computing coordinates.
+2. **Auto-layout groups** — groups with `managedLayout: true` enforce direction,
+   gap, and padding on members. The schema is already in place; the runtime
+   needs to honor it.
+3. **`workspace --check`** — one-call feedback that flags overlaps, off-scale
+   gaps, and near-misalignment so agents self-correct.
+
+Together these turn layout from "agent computes positions" into "agent describes
+composition; canvas places, validates, and reports."
+
+## Build order
+
+1. **Phase 1 — `layout` directive on upsert.** Smallest scope; validates the
+   spacing-scale vocabulary before it gets baked into idea 8's runtime work.
+2. **Phase 2 — `workspace --check`.** Independent of phase 1, but agents using
+   the directive will lean on `--check` to verify output.
+3. **Phase 3 — Auto-layout groups.** Biggest surface area (UX, runtime, persistence
+   already partly done). Reuses the layout-math helper from phase 1.
+4. **Phase 4 — Skill update.** Single edit at the end so examples reflect the
+   final shape.
+
+## Existing scaffolding
+
+A scan of the codebase before drafting turned up partial work:
+
+- `src/shared/types.ts:309` — `WorkspaceGroupLayoutMode = 'freeform' | 'row' | 'grid'`
+  already exists on groups.
+- `src/shared/types.ts:199` — `layoutMode` and `managedLayout` are persisted
+  fields on `WorkspaceGroupEntity`.
+- `src/main/runtime/group-entity-state.ts:43` — defaults are `'freeform'` and
+  `false`.
+- `src/main/runtime/json-canvas-serializer.ts:399` — round-trips both fields.
+- `src/main/runtime/layout-engine.ts` — does **not** read either field. This is
+  the runtime gap idea 8 has to close.
+
+`'column'` is missing from the enum and will need to be added. The schema lacks
+`gap` and `padding` on groups — both need to be added before phase 3 can land.
+
+## Phase 1 — `layout` directive on `upsert --json`
+
+### Shape
+
+The existing array form keeps working. New object form:
+
+```json
+{
+  "layout": { "kind": "row", "gap": "m", "originX": 200, "originY": 200 },
+  "items": [
+    { "kind": "frame", "url": "https://a.example.com" },
+    { "kind": "frame", "url": "https://b.example.com" }
+  ]
+}
+```
+
+### Layout kinds (v1)
+
+- `row` — left-to-right, `gap` between
+- `column` — top-to-bottom, `gap` between
+- `grid` — `cols` required, optional `rowGap` and `colGap` (default both to `gap`)
+
+### Anchoring
+
+Resolved in this order:
+
+1. Explicit `originX` / `originY`
+2. `near: <id>` — place adjacent to an existing entity, with `gap` between
+3. Default — `find-placement` finds open canvas space
+
+### Spacing scale
+
+Accept both tokens and numbers:
+
+| Token | Pixels |
+|---|---|
+| `xs` | 8 |
+| `s` | 16 |
+| `m` | 24 |
+| `l` | 40 |
+| `xl` | 80 |
+
+Examples in the skill default to tokens. Numbers remain an escape hatch.
+
+### Item-level coordinates inside a directive
+
+Per-item `canvasX` / `canvasY` are ignored when a `layout` directive is present.
+Emit a warning in the response so agents notice. Per-item attrs like
+`presetIndex`, `width`, `height`, `text` still apply.
+
+### Files
+
+- Upsert handler — TBD; route lives in `src/main/routes/`, runtime call is in
+  `src/main/runtime/`. Confirm during implementation.
+- New helper `src/main/runtime/layout-math.ts` — pure functions:
+  `computeRow(items, gap, origin)`, `computeColumn(...)`, `computeGrid(...)`.
+  Consumed by phase 1 and phase 3.
+- CLI parsing for the new shape — `resources/specular-cli.sh` is a shell
+  shim; the JSON parsing lives server-side.
+- `tests/unit/layout-math.test.ts` — pure-math coverage.
+- `tests/smoke/upsert-layout.test.ts` — end-to-end via AppClient.
+
+### Edge cases
+
+- Mixing frames (today honor `canvasX/Y`) and file entities (today auto-placed)
+  — directive overrides both.
+- Empty `items` — no-op.
+- Single item — place at resolved origin, ignore `gap`.
+- Heterogeneous-sized items in a row — align top by default; `align` field is
+  v2.
+- Items with explicit `canvasX/Y` — warn and ignore.
+
+## Phase 2 — `specular workspace --check`
+
+### Output
+
+JSON by default for agents:
+
+```json
+{
+  "overlaps": [{ "a": "id1", "b": "id2", "amount": 12 }],
+  "misaligned": [{ "id": "id3", "near": "row y=200", "delta": 4 }],
+  "offScale": [{ "between": ["id1", "id2"], "gap": 37, "suggest": 40 }]
+}
+```
+
+`--pretty` for human reading:
+
+```
+1 overlap: frame_a and frame_b (12px)
+1 misaligned: frame_c is 4px below the row at y=200
+1 off-scale gap: 37px between frame_a and frame_b (round to 40)
+```
+
+### Rules in v1
+
+- **Overlap** — AABB intersection. Exclude parent-group/member pairs and edges.
+  Highest-signal, must ship.
+- **Off-scale gap** — gap between adjacent entities not within tolerance of the
+  spacing scale. Tolerance: ±3px. Suggest the nearest token.
+- **Misalignment** — cluster y values into implicit rows; flag entities whose y
+  is within 1–8px of a cluster's baseline but not on it. Same for columns.
+  Heuristic; ship behind a `--rules` flag if it false-positives in practice.
+
+### Out of v1
+
+- **Off-canvas / orphan** — ill-defined on an unbounded canvas. Revisit if
+  agents actually create orphans.
+- **Width/size consistency** — flagging mismatched widths in a row. Defer until
+  it's clear agents need it.
+
+### Files
+
+- New `src/main/runtime/layout-check.ts` — pure rule evaluators.
+- Wire into the workspace route in `src/main/routes/` (path TBD; verify during
+  implementation).
+- `tests/unit/layout-check.test.ts` — one test per rule, including
+  near-miss/no-flag cases for tolerance correctness.
+
+### Tradeoffs
+
+- False positives are worse than false negatives. Tight tolerances. Better to
+  under-report than nag.
+- Allow `--rules overlap,offscale` to disable misalignment. Cheap insurance.
+
+## Phase 3 — Auto-layout groups
+
+The schema is already in place (`layoutMode`, `managedLayout`). This phase wires
+the runtime to honor those fields and extends the schema with `gap` and
+`padding`.
+
+### Schema extensions
+
+On `WorkspaceGroupEntity`:
+
+- Add `'column'` to `WorkspaceGroupLayoutMode` enum: `'freeform' | 'row' | 'column' | 'grid'`.
+- Add `gap?: number | SpacingToken` (default `'m'` when `managedLayout: true`).
+- Add `padding?: number | [v, h] | [t, r, b, l]` (default `0`).
+- For `grid`, add `cols?: number` (default 2).
+
+JSON Canvas extension fields per `docs/file-formats.md` §Specular extensions.
+Update that doc as part of phase 3.
+
+### Runtime behavior
+
+When a group has `managedLayout: true`:
+
+- Member positions are computed by the group, not user input.
+- Adding a member appends and re-flows.
+- Removing closes the gap.
+- Reordering = mutating `members` order; positions follow.
+- Group move = members move with it (existing behavior, unchanged).
+
+### Manual drag of layout-managed members
+
+**v1 decision: block manual drag of members in a layout-managed group. Allow
+drag of the group itself.**
+
+Rationale: agents don't drag, so they're unaffected. Humans get a clear "this
+is managed" signal instead of confusing snap-back. Drag-to-reorder lands as v2
+if humans request it.
+
+Visible affordance: managed groups render with a distinct border/icon so the
+disabled drag is explicable.
+
+### Files
+
+- `src/main/runtime/layout-engine.ts` — read `managedLayout`, dispatch to
+  `layout-math.ts` helpers.
+- `src/main/runtime/group-entity-state.ts` — add `gap`/`padding` accessors and
+  re-flow on member add/remove/reorder.
+- `src/main/runtime/json-canvas-serializer.ts` — persist new fields.
+- `src/shared/types.ts` — extend enum and entity type.
+- `src/shared/json-canvas-types.ts` — extend persisted shape.
+- `src/renderer/canvas-bg/` — disable member drag when `managedLayout: true`;
+  render the affordance.
+- `docs/file-formats.md` — document `gap`, `padding`, and the extended enum.
+- `tests/unit/group-layout.test.ts` — add/remove/reorder behavior.
+- `tests/smoke/managed-group.test.ts` — end-to-end.
+
+### Edge cases
+
+- Single-member group — degenerate; render as if `freeform`.
+- Nested layout groups — recursion is fine because `layout-math.ts` is pure.
+- Heterogeneous-sized members — align top by default in row; left in column.
+  `align` is v2.
+- Toggling `managedLayout: false` → `true` on an existing group — re-flow on
+  toggle so positions snap to the directive.
+
+## Phase 4 — Skill update
+
+A single edit to `resources/skills/specular/SKILL.md` and
+`.claude/skills/specular/SKILL.md` (kept in sync per the CLAUDE.md skill-files
+note).
+
+Changes:
+
+- Replace the canonical upsert example in `### Upsert tips` with the new
+  `{layout, items}` shape using a 3-frame row at breakpoints.
+- Add a 2-line note: "Use `layout` instead of computing `canvasX`/`canvasY` for
+  more than 2 items."
+- Add 2 lines under groups: "Set `managedLayout: true` to auto-arrange members
+  in a row, column, or grid."
+- Add 1 line at the end of the workflow: "Run `specular workspace --check`
+  after batch creates."
+- Add the spacing-scale table.
+
+Do **not** add a separate "Layout" section. Folding into existing structure
+keeps skill bloat minimal.
+
+## Cross-cutting decisions (settled)
+
+- **Spacing tokens vs. numbers.** Both. Tokens default in skill examples;
+  numbers as escape hatches.
+- **Manual drag in layout-managed groups.** Block in v1; reorder in v2.
+- **Misalignment rule.** Ship in v1, narrow band (1–8px), opt-out via
+  `--rules`.
+- **Backwards compat.** Existing array-form `upsert --json` keeps working
+  unchanged. The object form is additive.
+- **`'column'` on `WorkspaceGroupLayoutMode`.** Add. Required for column
+  layouts in both phase 1 and phase 3.
+
+## Open decisions (decide during phase 1)
+
+- **Anchor vocabulary for `near`.** `near: <id>` plus an implicit "to the right
+  of" for `row` directives, "below" for `column`. Or accept `side: 'right' | 'below'`.
+  Decide once a real example surfaces.
+- **`grid` row-major vs. column-major.** Default row-major (fill rows
+  left-to-right, then wrap). Confirm during implementation if grid examples
+  argue otherwise.
+
+## Risks
+
+- **Layout directive doesn't get adopted** because the skill example isn't
+  compelling. Mitigation: canonical example is the breakpoint comparison
+  scenario — the same shape that motivates the audit use case.
+- **`--check` becomes noisy** and agents start ignoring it. Mitigation: tight
+  tolerances, opt-out flag, only ship rules with high signal-to-noise.
+- **Auto-layout groups confuse humans** when drag is blocked. Mitigation:
+  clear affordance on managed groups; disable drag silently rather than with
+  an error toast.
+- **Schema drift** between the existing `layoutMode` enum and the new
+  `kind` field on the upsert directive. Mitigation: use the same string
+  values everywhere (`'row' | 'column' | 'grid'`); the directive's `kind`
+  is what gets written to the group's `layoutMode` when an upsert creates a
+  managed group.
+
+## Out of scope (this plan)
+
+- Tour mode / ordered traversal (separate plan; relates to Explain use case).
+- Image/video/text export (separate plan; relates to handoff).
+- Compositional grammar primitives (`comparison`, `sequence`, etc.) — these
+  build on the spine; revisit after it lands.
+- Spatial diff / canvas review verb.
+- Quick-capture flow for Research use case.
+- `find-placement` extensions (`--row-of N`, `--grid 3x2`). Useful but
+  redundant with the `layout` directive once it lands.

--- a/resources/skills/specular/SKILL.md
+++ b/resources/skills/specular/SKILL.md
@@ -54,22 +54,65 @@ canvas and frame operations go through the `specular` command.
 
 ### Upsert tips
 
-`upsert --json` is the fastest way to create many entities at once. For
-**frames**, it honors `canvasX`, `canvasY`, `presetIndex`, and
-`orientation: "landscape" | "portrait"` — use it to drop a batch of frames
-at exact positions with the right device preset in one call:
+`upsert --json` is the fastest way to create many entities at once. It accepts
+two shapes on stdin: a bare array of items (legacy), or `{layout, items}` with
+a declarative `layout` directive that places everything for you.
+
+**Use the `layout` directive for any composition of more than 2 items.** It
+takes a `kind` (`row` / `column` / `grid`), a `gap` (token or pixel number),
+and an anchor (`originX`/`originY`, `near: <id>`, or implicit). Same shape
+creates new items *and* reorganizes existing ones — pass an `id` to re-lay-out
+an entity that's already on the canvas.
 
 ```bash
+# Create three frames in a row at breakpoints
 cat << 'EOF' | specular upsert --json
-[
-  {"kind":"frame","url":"https://example.com","presetIndex":6,"orientation":"landscape","canvasX":200,"canvasY":200},
-  {"kind":"frame","url":"https://example.com","presetIndex":0,"canvasX":1520,"canvasY":200}
-]
+{
+  "layout": { "kind": "row", "gap": "m", "originX": 200, "originY": 200 },
+  "items": [
+    {"kind":"frame","url":"https://example.com","presetIndex":0},
+    {"kind":"frame","url":"https://example.com","presetIndex":3},
+    {"kind":"frame","url":"https://example.com","presetIndex":6}
+  ]
+}
 EOF
 ```
 
-For **files** (markdown, wireframe, image) upsert ignores `canvasX/canvasY` —
-the layout engine always places them. Images additionally ignore `width`.
+```bash
+# Reorganize 6 existing frames into a 3x2 grid
+cat << 'EOF' | specular upsert --json
+{
+  "layout": { "kind": "grid", "cols": 3, "gap": "m", "near": "frame_a" },
+  "items": [
+    {"id":"frame_a"}, {"id":"frame_b"}, {"id":"frame_c"},
+    {"id":"frame_d"}, {"id":"frame_e"}, {"id":"frame_f"}
+  ]
+}
+EOF
+```
+
+When a directive is present, per-item `canvasX`/`canvasY` are ignored. Without
+`originX/Y` or `near`, the directive anchors at the bounding box of any
+existing items in `items[]` (so re-layout doesn't teleport the cluster); with
+no existing items, it falls back to `find-placement`.
+
+**Spacing scale.** Tokens are aligned to the canvas grid (20px multiples).
+Numbers work too as an escape hatch:
+
+| Token | Pixels |
+|---|---|
+| `xs` | 20 |
+| `s` | 40 |
+| `m` | 60 |
+| `l` | 100 |
+| `xl` | 160 |
+
+For ad-hoc single drops, the bare-array form still works and honors `canvasX`,
+`canvasY`, `presetIndex`, and `orientation: "landscape" | "portrait"` per item.
+
+For **files** (markdown, wireframe, image) without a directive, upsert ignores
+`canvasX/canvasY` — the layout engine always places them. Images additionally
+ignore `width`.
 
 ### Note colors
 

--- a/src/main/cli-commands.ts
+++ b/src/main/cli-commands.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_BREAKPOINT_PRESET_LABELS } from '../shared/constants'
+import { validateLayoutDirective } from '../shared/types'
 import { callApp } from './shared/app-client'
 import { handleBrowse, shellQuote } from './shared/browse-handler'
 import { upsertEntities, type UpsertOptions, getAnnotationsSlim, getAnnotationDetail } from './shared/entity-ops'
@@ -76,7 +77,14 @@ const upsert: VerbHandler = async (args) => {
     items = parsed
   } else if (parsed && typeof parsed === 'object' && Array.isArray(parsed.items)) {
     items = parsed.items
-    if (parsed.layout) options.directive = parsed.layout as UpsertOptions['directive']
+    if (parsed.layout) {
+      const err = validateLayoutDirective(parsed.layout)
+      if (err) {
+        printError(`upsert: ${err}`)
+        return 1
+      }
+      options.directive = parsed.layout as UpsertOptions['directive']
+    }
   } else {
     printError('upsert: expected an array of items or { layout, items }')
     return 1

--- a/src/main/cli-commands.ts
+++ b/src/main/cli-commands.ts
@@ -62,18 +62,30 @@ const breakpoints: VerbHandler = async (args) => {
 }
 
 const upsert: VerbHandler = async (args) => {
-  // Read JSON items from stdin or positional
-  let items: Array<Record<string, unknown>>
-  if (args.boolFlags.has('json')) {
-    const input = await readStdin()
-    items = JSON.parse(input)
-  } else {
+  // Read JSON from stdin: either an array of items (legacy) or
+  // { layout: LayoutDirective, items: [...] } (directive form).
+  if (!args.boolFlags.has('json')) {
     printError('usage: specular upsert --json < items.json')
     return 1
   }
+  const input = await readStdin()
+  const parsed = JSON.parse(input)
   const options: UpsertOptions = {}
-  if (args.flags.layout) options.layout = args.flags.layout as UpsertOptions['layout']
-  if (args.flags.gap) options.gap = Number(args.flags.gap)
+  let items: Array<Record<string, unknown>>
+  if (Array.isArray(parsed)) {
+    items = parsed
+  } else if (parsed && typeof parsed === 'object' && Array.isArray(parsed.items)) {
+    items = parsed.items
+    if (parsed.layout) options.directive = parsed.layout as UpsertOptions['directive']
+  } else {
+    printError('upsert: expected an array of items or { layout, items }')
+    return 1
+  }
+  // CLI flags still work for the legacy auto-placement path.
+  if (args.flags.layout && !options.directive) {
+    options.layout = args.flags.layout as UpsertOptions['layout']
+  }
+  if (args.flags.gap && !options.directive) options.gap = Number(args.flags.gap)
   printJson(await upsertEntities(items, options))
   return 0
 }

--- a/src/main/layout-math.ts
+++ b/src/main/layout-math.ts
@@ -1,5 +1,4 @@
-// Pure layout math for the upsert layout directive (and the legacy batch
-// placement path). No runtime imports; safe to test in isolation.
+import type { BatchLayoutMode } from '../shared/types'
 
 export interface LayoutBox { width: number; height: number }
 
@@ -13,7 +12,7 @@ export interface LayoutMetrics {
 
 export function computeLayoutMetrics(
   items: LayoutBox[],
-  kind: 'row' | 'column' | 'grid',
+  kind: BatchLayoutMode,
   colGap: number,
   rowGap: number,
   cols?: number,
@@ -57,7 +56,7 @@ export function computeLayoutMetrics(
  */
 export function computeLayoutPositions(
   items: LayoutBox[],
-  kind: 'row' | 'column' | 'grid',
+  kind: BatchLayoutMode,
   colGap: number,
   rowGap: number,
   origin: { x: number; y: number },

--- a/src/main/layout-math.ts
+++ b/src/main/layout-math.ts
@@ -1,0 +1,93 @@
+// Pure layout math for the upsert layout directive (and the legacy batch
+// placement path). No runtime imports; safe to test in isolation.
+
+export interface LayoutBox { width: number; height: number }
+
+export interface LayoutMetrics {
+  cols: number
+  maxW: number
+  maxH: number
+  bbWidth: number
+  bbHeight: number
+}
+
+export function computeLayoutMetrics(
+  items: LayoutBox[],
+  kind: 'row' | 'column' | 'grid',
+  colGap: number,
+  rowGap: number,
+  cols?: number,
+): LayoutMetrics {
+  if (items.length === 0) return { cols: 0, maxW: 0, maxH: 0, bbWidth: 0, bbHeight: 0 }
+  if (kind === 'column') {
+    return {
+      cols: 1,
+      maxW: 0,
+      maxH: 0,
+      bbWidth: Math.max(...items.map((i) => i.width)),
+      bbHeight: items.reduce((s, i) => s + i.height, 0) + (items.length - 1) * rowGap,
+    }
+  }
+  if (kind === 'grid') {
+    const gridCols = cols && cols > 0 ? cols : Math.ceil(Math.sqrt(items.length))
+    const maxW = Math.max(...items.map((i) => i.width))
+    const maxH = Math.max(...items.map((i) => i.height))
+    const rows = Math.ceil(items.length / gridCols)
+    return {
+      cols: gridCols,
+      maxW,
+      maxH,
+      bbWidth: gridCols * maxW + (gridCols - 1) * colGap,
+      bbHeight: rows * maxH + (rows - 1) * rowGap,
+    }
+  }
+  return {
+    cols: 0,
+    maxW: 0,
+    maxH: 0,
+    bbWidth: items.reduce((s, i) => s + i.width, 0) + (items.length - 1) * colGap,
+    bbHeight: Math.max(...items.map((i) => i.height)),
+  }
+}
+
+/**
+ * Place items at an explicit origin in row/column/grid. Grid uses uniform
+ * tracks (each cell sized to the largest item's dim) so heterogeneous content
+ * still aligns to a clean grid.
+ */
+export function computeLayoutPositions(
+  items: LayoutBox[],
+  kind: 'row' | 'column' | 'grid',
+  colGap: number,
+  rowGap: number,
+  origin: { x: number; y: number },
+  cols?: number,
+): Array<{ canvasX: number; canvasY: number }> {
+  if (items.length === 0) return []
+  const positions: Array<{ canvasX: number; canvasY: number }> = []
+
+  if (kind === 'column') {
+    let cursorY = origin.y
+    for (const item of items) {
+      positions.push({ canvasX: origin.x, canvasY: cursorY })
+      cursorY += item.height + rowGap
+    }
+    return positions
+  }
+  if (kind === 'grid') {
+    const m = computeLayoutMetrics(items, 'grid', colGap, rowGap, cols)
+    for (let idx = 0; idx < items.length; idx++) {
+      positions.push({
+        canvasX: origin.x + (idx % m.cols) * (m.maxW + colGap),
+        canvasY: origin.y + Math.floor(idx / m.cols) * (m.maxH + rowGap),
+      })
+    }
+    return positions
+  }
+  let cursorX = origin.x
+  for (const item of items) {
+    positions.push({ canvasX: cursorX, canvasY: origin.y })
+    cursorX += item.width + colGap
+  }
+  return positions
+}

--- a/src/main/routes/workspace.ts
+++ b/src/main/routes/workspace.ts
@@ -7,6 +7,7 @@ import type {
   LayoutComponentStatesRequest,
   PlacementRequest,
 } from '../../shared/types'
+import { validateLayoutDirective } from '../../shared/types'
 import {
   getSelectionState,
   getWorkspaceGraph,
@@ -157,10 +158,16 @@ export const workspaceRoutes: Route[] = [
     method: 'POST',
     pattern: '/layout/apply-directive',
     async handler({ response, body }) {
+      const req = body as ApplyDirectiveRequest
+      const err = validateLayoutDirective(req?.layout)
+      if (err) {
+        writeJson(response, 400, { error: err })
+        return
+      }
       try {
-        writeJson(response, 200, applyLayoutDirective(body as ApplyDirectiveRequest))
-      } catch (err) {
-        writeJson(response, 400, { error: err instanceof Error ? err.message : String(err) })
+        writeJson(response, 200, applyLayoutDirective(req))
+      } catch (e) {
+        writeJson(response, 400, { error: e instanceof Error ? e.message : String(e) })
       }
     },
   },

--- a/src/main/routes/workspace.ts
+++ b/src/main/routes/workspace.ts
@@ -1,5 +1,6 @@
 import type { Route } from './types'
 import type {
+  ApplyDirectiveRequest,
   ApplyTaskLayoutRequest,
   BatchPlacementRequest,
   CanvasEntityKind,
@@ -10,7 +11,7 @@ import {
   getSelectionState,
   getWorkspaceGraph,
 } from '../workspace-entities'
-import { findBatchPlacement, findPlacement } from '../workspace-placement'
+import { applyLayoutDirective, findBatchPlacement, findPlacement } from '../workspace-placement'
 import {
   applyTaskLayout,
   layoutComponentStates,
@@ -150,6 +151,17 @@ export const workspaceRoutes: Route[] = [
     pattern: '/layout/batch-placement',
     async handler({ response, body }) {
       writeJson(response, 200, findBatchPlacement(body as BatchPlacementRequest))
+    },
+  },
+  {
+    method: 'POST',
+    pattern: '/layout/apply-directive',
+    async handler({ response, body }) {
+      try {
+        writeJson(response, 200, applyLayoutDirective(body as ApplyDirectiveRequest))
+      } catch (err) {
+        writeJson(response, 400, { error: err instanceof Error ? err.message : String(err) })
+      }
     },
   },
   {

--- a/src/main/runtime/runtime-geometry.ts
+++ b/src/main/runtime/runtime-geometry.ts
@@ -77,7 +77,7 @@ export function pageCanvasBounds(
   }
 }
 
-function pageShellInsets(
+export function pageShellInsets(
   page: Pick<Page, 'metadata'>,
 ): { top: number; right: number; bottom: number; left: number } | null {
   const show = showDeviceFrameFromMetadata(page.metadata)

--- a/src/main/shared/entity-ops.ts
+++ b/src/main/shared/entity-ops.ts
@@ -76,11 +76,9 @@ function sizeForItem(item: Record<string, unknown>): ItemFootprint {
     const insets = showFrame
       ? (device ? shellInsetsForDevice(device.id, orientation) : CUSTOM_SHELL_INSETS)
       : { top: 0, right: 0, bottom: 0, left: 0 }
-    // Outer footprint includes device-shell bezels (the always-visible chrome
-    // around the page). The chrome action header that floats above each frame
-    // is hover-only and is *not* reserved here — it's handled separately by
-    // occupied-region inflation in workspace-placement so it doesn't widen
-    // user-facing layout gaps.
+    // Footprint includes device-shell bezels only. The hover-only chrome
+    // action header is reserved separately via occupied-region inflation so
+    // it doesn't widen user-facing layout gaps.
     return {
       width: inner.width + insets.left + insets.right,
       height: inner.height + insets.top + insets.bottom,

--- a/src/main/shared/entity-ops.ts
+++ b/src/main/shared/entity-ops.ts
@@ -1,9 +1,15 @@
-import type { BatchLayoutMode } from '../../shared/types'
+import type {
+  ApplyDirectiveResult,
+  BatchLayoutMode,
+  LayoutDirective,
+} from '../../shared/types'
 import {
+  CUSTOM_SHELL_INSETS,
   LAPTOP_PRESET_INDEX,
   VIEWPORT_PRESETS,
   defaultOrientationForDevice,
   deviceForPresetIndex,
+  shellInsetsForDevice,
   sizeForOrientation,
 } from '../../shared/device-catalog'
 import { normalizeUserUrl } from '../../shared/url'
@@ -33,8 +39,61 @@ function deriveNoteName(text: string): string {
 // ---------------------------------------------------------------------------
 
 export interface UpsertOptions {
+  /** Legacy: simple layout flag for auto-placed creates (no canvasX/Y). */
   layout?: BatchLayoutMode
   gap?: number
+  /**
+   * Declarative layout directive. When present, computed positions override
+   * any per-item canvasX/Y for ALL items, including items with an `id` (which
+   * get re-laid-out). Mixed creates + re-layouts in one call are supported.
+   */
+  directive?: LayoutDirective
+}
+
+interface ItemFootprint {
+  /** Outer width (visible footprint, including device-shell bezels). */
+  width: number
+  /** Outer height (visible footprint, including device-shell bezels). */
+  height: number
+  /** Distance from outer top-left to entity data origin (canvasX). */
+  insetX: number
+  /** Distance from outer top-left to entity data origin (canvasY). */
+  insetY: number
+}
+
+function sizeForItem(item: Record<string, unknown>): ItemFootprint {
+  if (item.kind === 'frame') {
+    const presetIndex = (item.presetIndex as number | undefined) ?? LAPTOP_PRESET_INDEX
+    const preset = VIEWPORT_PRESETS[presetIndex]
+    const w = preset?.width ?? 1280
+    const h = preset?.height ?? 800
+    const device = deviceForPresetIndex(presetIndex)
+    const orientation =
+      (item.orientation as 'portrait' | 'landscape' | undefined) ??
+      defaultOrientationForDevice(device)
+    const inner = sizeForOrientation(w, h, orientation)
+    const showFrame = item.showDeviceFrame !== false
+    const insets = showFrame
+      ? (device ? shellInsetsForDevice(device.id, orientation) : CUSTOM_SHELL_INSETS)
+      : { top: 0, right: 0, bottom: 0, left: 0 }
+    // Outer footprint includes device-shell bezels (the always-visible chrome
+    // around the page). The chrome action header that floats above each frame
+    // is hover-only and is *not* reserved here — it's handled separately by
+    // occupied-region inflation in workspace-placement so it doesn't widen
+    // user-facing layout gaps.
+    return {
+      width: inner.width + insets.left + insets.right,
+      height: inner.height + insets.top + insets.bottom,
+      insetX: insets.left,
+      insetY: insets.top,
+    }
+  }
+  return {
+    width: Number(item.width) || 200,
+    height: Number(item.height) || 200,
+    insetX: 0,
+    insetY: 0,
+  }
 }
 
 export async function upsertEntities(
@@ -42,6 +101,48 @@ export async function upsertEntities(
   options?: UpsertOptions,
 ): Promise<{ created: string[]; updated: string[] }> {
   const results: { created: string[]; updated: string[] } = { created: [], updated: [] }
+
+  // Apply layout directive first, if present. Computes positions for all
+  // items (creates and re-layouts), overrides per-item canvasX/Y, and
+  // back-fills `kind` for items with `id` so the bucketer routes correctly.
+  if (options?.directive) {
+    const warnings: string[] = []
+    const directiveItems = items.map((item) => {
+      if (item.id) {
+        const out: { id: string; width?: number; height?: number } = { id: item.id as string }
+        if (item.width !== undefined) out.width = Number(item.width)
+        if (item.height !== undefined) out.height = Number(item.height)
+        return out
+      }
+      const footprint = sizeForItem(item)
+      return {
+        width: footprint.width,
+        height: footprint.height,
+        insetX: footprint.insetX,
+        insetY: footprint.insetY,
+      }
+    })
+    const result = await callApp<ApplyDirectiveResult>('/layout/apply-directive', {
+      method: 'POST',
+      body: JSON.stringify({ layout: options.directive, items: directiveItems }),
+    })
+    for (let i = 0; i < items.length; i++) {
+      if (items[i].canvasX !== undefined || items[i].canvasY !== undefined) {
+        warnings.push(`item[${i}]: canvasX/canvasY ignored under layout directive`)
+      }
+      items[i].canvasX = result.positions[i].canvasX
+      items[i].canvasY = result.positions[i].canvasY
+      // Back-fill kind from runtime so bucketing routes the right way for
+      // items where the agent only passed an id.
+      if (items[i].id && !items[i].kind && result.kinds[i]) {
+        items[i].kind = result.kinds[i]
+      }
+    }
+    if (warnings.length > 0) {
+      // eslint-disable-next-line no-console
+      console.warn('upsert layout directive:', warnings.join('; '))
+    }
+  }
 
   // Single-pass grouping
   const frameCreates: Array<Record<string, unknown>> = []
@@ -77,29 +178,13 @@ export async function upsertEntities(
     (item) => item.canvasX === undefined || item.canvasY === undefined,
   )
   if (needsPlacement.length > 0) {
-    const sizes = needsPlacement.map((item) => {
-      if (item.kind === 'frame') {
-        const presetIndex = (item.presetIndex as number | undefined) ?? LAPTOP_PRESET_INDEX
-        const preset = VIEWPORT_PRESETS[presetIndex]
-        const w = preset?.width ?? 1280
-        const h = preset?.height ?? 800
-        const device = deviceForPresetIndex(presetIndex)
-        const orientation =
-          (item.orientation as 'portrait' | 'landscape' | undefined) ??
-          defaultOrientationForDevice(device)
-        return sizeForOrientation(w, h, orientation)
-      }
-      return {
-        width: Number(item.width) || 200,
-        height: Number(item.height) || 200,
-      }
-    })
+    const footprints = needsPlacement.map(sizeForItem)
     const placement = await callApp<{ positions: Array<{ canvasX: number; canvasY: number }> }>(
       '/layout/batch-placement',
       {
         method: 'POST',
         body: JSON.stringify({
-          items: sizes,
+          items: footprints,
           layout: options?.layout,
           gap: options?.gap,
           anchor: 'selection_or_empty_region',

--- a/src/main/workspace-entities.ts
+++ b/src/main/workspace-entities.ts
@@ -1,4 +1,5 @@
 import type {
+  CanvasEntityKind,
   DeleteFramesRequest,
   DeleteFramesResponse,
   EdgeSide,
@@ -36,6 +37,7 @@ import {
   requestLayout,
   zoom,
 } from './runtime/surface-layout'
+import { pageShellInsets } from './runtime/runtime-geometry'
 import { workspaceEdges, workspaceGroups } from './runtime/workspace-model'
 import { scheduleWorkspaceAutosave } from './runtime/workspace-session'
 import { boundsOverlap } from './runtime/runtime-geometry'
@@ -80,6 +82,38 @@ export function unionBounds(boundsList: WorkspaceBounds[]): WorkspaceBounds | nu
 
 export function entityBoundsById(entityId: string): WorkspaceBounds | null {
   return entityBoundsByIdWithVisited(entityId, new Set<string>())
+}
+
+/**
+ * Offset from the entity's outer top-left (as returned by `entityBoundsById`)
+ * to the entity's data origin (`canvasX`/`canvasY`). For framed pages this is
+ * the device-shell top/left insets; for un-framed pages and non-frame
+ * entities the bounds top-left already coincides with the data origin, so
+ * insets are zero. The hover-only chrome action header is intentionally not
+ * counted — `entityBoundsById` already returns selectable-bounds with
+ * `y = outer.y` (no chrome band above), and reserving chrome here would
+ * double-shift items that re-layout against an existing entity's bbox.
+ */
+export function entityDataInsetsById(entityId: string): { insetX: number; insetY: number } {
+  const page = findPageById(entityId)
+  if (page) {
+    const insets = pageShellInsets(page)
+    return {
+      insetX: insets?.left ?? 0,
+      insetY: insets?.top ?? 0,
+    }
+  }
+  return { insetX: 0, insetY: 0 }
+}
+
+export function entityKindById(entityId: string): CanvasEntityKind | null {
+  if (findPageById(entityId)) return 'frame'
+  if (textEntities.find((t) => t.id === entityId)) return 'text'
+  if (fileEntities.find((f) => f.id === entityId)) return 'file'
+  if (drawingEntities.find((d) => d.id === entityId)) return 'drawing'
+  if (shapeEntities.find((s) => s.id === entityId)) return 'shape'
+  if (workspaceGroups.find((g) => g.id === entityId)) return 'group'
+  return null
 }
 
 function entityBoundsByIdWithVisited(

--- a/src/main/workspace-entities.ts
+++ b/src/main/workspace-entities.ts
@@ -86,13 +86,16 @@ export function entityBoundsById(entityId: string): WorkspaceBounds | null {
 
 /**
  * Offset from the entity's outer top-left (as returned by `entityBoundsById`)
- * to the entity's data origin (`canvasX`/`canvasY`). For framed pages this is
- * the device-shell top/left insets; for un-framed pages and non-frame
- * entities the bounds top-left already coincides with the data origin, so
- * insets are zero. The hover-only chrome action header is intentionally not
- * counted — `entityBoundsById` already returns selectable-bounds with
- * `y = outer.y` (no chrome band above), and reserving chrome here would
- * double-shift items that re-layout against an existing entity's bbox.
+ * to its data origin (`canvasX`/`canvasY`). For framed pages this is the
+ * device-shell top/left insets; otherwise zero.
+ *
+ * Asymmetry to keep in mind: `entityBoundsById` for a frame returns
+ * `frameSelectableBounds` whose `height` includes `page.chromeHeight` (the
+ * hover-only action band). This function does NOT include `chromeHeight` in
+ * `insetY`, because the bounds' `y` is `outer.y` (no chrome band above the
+ * top edge). The consequence is that re-layout against an existing frame in
+ * a column or below-`near` arrangement reserves an extra `chromeHeight` of
+ * vertical space — by design, since the action band needs somewhere to live.
  */
 export function entityDataInsetsById(entityId: string): { insetX: number; insetY: number } {
   const page = findPageById(entityId)
@@ -106,14 +109,38 @@ export function entityDataInsetsById(entityId: string): { insetX: number; insetY
   return { insetX: 0, insetY: 0 }
 }
 
-export function entityKindById(entityId: string): CanvasEntityKind | null {
-  if (findPageById(entityId)) return 'frame'
-  if (textEntities.find((t) => t.id === entityId)) return 'text'
-  if (fileEntities.find((f) => f.id === entityId)) return 'file'
-  if (drawingEntities.find((d) => d.id === entityId)) return 'drawing'
-  if (shapeEntities.find((s) => s.id === entityId)) return 'shape'
-  if (workspaceGroups.find((g) => g.id === entityId)) return 'group'
+type AnyEntity =
+  | { canvasX: number; canvasY: number; width: number; height: number; id: string }
+
+/**
+ * Single dispatch point for "find an entity by id and tell me what kind it is."
+ * `entityKindById` and `entityBoundsByIdWithVisited` both delegate here so the
+ * id-keyed lookup chain runs only once per call. Pages are returned as-is so
+ * the bounds path can use `frameSelectableBounds` (selectable bounds differ
+ * from raw `{canvasX, canvasY, width, height}` for frames).
+ */
+function findEntityById(
+  entityId: string,
+): { kind: 'frame'; page: ReturnType<typeof findPageById> }
+  | { kind: 'text' | 'file' | 'drawing' | 'shape' | 'group'; entity: AnyEntity }
+  | null {
+  const page = findPageById(entityId)
+  if (page) return { kind: 'frame', page }
+  const te = textEntities.find((t) => t.id === entityId)
+  if (te) return { kind: 'text', entity: te }
+  const fe = fileEntities.find((f) => f.id === entityId)
+  if (fe) return { kind: 'file', entity: fe }
+  const de = drawingEntities.find((d) => d.id === entityId)
+  if (de) return { kind: 'drawing', entity: de }
+  const se = shapeEntities.find((s) => s.id === entityId)
+  if (se) return { kind: 'shape', entity: se }
+  const group = workspaceGroups.find((g) => g.id === entityId)
+  if (group) return { kind: 'group', entity: group }
   return null
+}
+
+export function entityKindById(entityId: string): CanvasEntityKind | null {
+  return findEntityById(entityId)?.kind ?? null
 }
 
 function entityBoundsByIdWithVisited(
@@ -121,29 +148,14 @@ function entityBoundsByIdWithVisited(
   visited: Set<string>,
 ): WorkspaceBounds | null {
   if (visited.has(entityId)) return null
-  const nextVisited = new Set(visited)
-  nextVisited.add(entityId)
-
-  const page = findPageById(entityId)
-  if (page) {
-    return frameSelectableBounds(page)
+  const found = findEntityById(entityId)
+  if (!found) return null
+  if (found.kind === 'frame' && found.page) {
+    return frameSelectableBounds(found.page)
   }
-  const te = textEntities.find((t) => t.id === entityId)
-  if (te) return { x: te.canvasX, y: te.canvasY, width: te.width, height: te.height }
-  const fe = fileEntities.find((f) => f.id === entityId)
-  if (fe) return { x: fe.canvasX, y: fe.canvasY, width: fe.width, height: fe.height }
-  const de = drawingEntities.find((d) => d.id === entityId)
-  if (de) return { x: de.canvasX, y: de.canvasY, width: de.width, height: de.height }
-  const se = shapeEntities.find((s) => s.id === entityId)
-  if (se) return { x: se.canvasX, y: se.canvasY, width: se.width, height: se.height }
-  const group = workspaceGroups.find((candidate) => candidate.id === entityId)
-  if (group) {
-    return {
-      x: group.canvasX,
-      y: group.canvasY,
-      width: group.width,
-      height: group.height,
-    }
+  if (found.kind !== 'frame') {
+    const e = found.entity
+    return { x: e.canvasX, y: e.canvasY, width: e.width, height: e.height }
   }
   return null
 }

--- a/src/main/workspace-placement.ts
+++ b/src/main/workspace-placement.ts
@@ -215,7 +215,8 @@ export function findBatchPlacement(request: BatchPlacementRequest): BatchPlaceme
  *
  * Layout runs in OUTER space so `gap` measures visible whitespace between
  * device-shell bezels; positions are offset back to inner data-origin
- * coordinates before returning. No snap-to-grid — directives are precise.
+ * coordinates before returning. User-supplied origins are honored exactly;
+ * the no-anchor fallback uses `findPlacement`, which still snaps to grid.
  */
 export function applyLayoutDirective(request: ApplyDirectiveRequest): ApplyDirectiveResult {
   const directive = request.layout

--- a/src/main/workspace-placement.ts
+++ b/src/main/workspace-placement.ts
@@ -1,4 +1,6 @@
 import type {
+  ApplyDirectiveRequest,
+  ApplyDirectiveResult,
   BatchPlacementRequest,
   BatchPlacementResult,
   PlacementRequest,
@@ -6,6 +8,7 @@ import type {
   WorkspaceBounds,
   WorkspaceFrame,
 } from '../shared/types'
+import { resolveSpacing } from '../shared/types'
 import {
   ANCHOR_OFFSET_X,
   ANCHOR_OFFSET_Y,
@@ -24,7 +27,14 @@ import {
 import { workspaceGroups } from './runtime/workspace-model'
 import { boundsOverlap } from './runtime/runtime-geometry'
 import { CHROME_HEADER_HEIGHT } from './runtime/runtime-constants'
-import { allWorkspaceFrames, selectionBounds } from './workspace-entities'
+import {
+  allWorkspaceFrames,
+  entityBoundsById,
+  entityDataInsetsById,
+  entityKindById,
+  selectionBounds,
+} from './workspace-entities'
+import { computeLayoutMetrics, computeLayoutPositions, type LayoutBox } from './layout-math'
 
 // Chrome headers render above each entity's canvasY (see EntityChromeHeader —
 // translateY(-100%)). Extend the occupied rect upward so placement treats the
@@ -161,63 +171,137 @@ export function findPlacement(request: PlacementRequest): PlacementResult {
 export function findBatchPlacement(request: BatchPlacementRequest): BatchPlacementResult {
   const gap = snapToGrid(request.gap ?? CLUSTER_HORIZONTAL_GUTTER)
   const layout = request.layout ?? 'row'
+  // Items are described as outer (visible) footprints. Layout in outer space
+  // ensures `gap` is the visible whitespace between bezels; positions are then
+  // offset by each item's `insetX/insetY` so callers receive inner data-origin
+  // coordinates (canvasX/canvasY).
   const items = request.items.map((i) => ({
     width: snapToGrid(i.width),
     height: snapToGrid(i.height),
   }))
+  const insets = request.items.map((i) => ({
+    insetX: i.insetX ?? 0,
+    insetY: i.insetY ?? 0,
+  }))
 
   if (items.length === 0) return { positions: [] }
 
-  // Grid metrics used for both bounding box and position phases
-  const gridCols = layout === 'grid' ? Math.ceil(Math.sqrt(items.length)) : 0
-  const gridMaxW = layout === 'grid' ? Math.max(...items.map((i) => i.width)) : 0
-  const gridMaxH = layout === 'grid' ? Math.max(...items.map((i) => i.height)) : 0
-
-  let bbWidth: number
-  let bbHeight: number
-
-  if (layout === 'column') {
-    bbWidth = Math.max(...items.map((i) => i.width))
-    bbHeight = items.reduce((s, i) => s + i.height, 0) + (items.length - 1) * gap
-  } else if (layout === 'grid') {
-    const rows = Math.ceil(items.length / gridCols)
-    bbWidth = gridCols * gridMaxW + (gridCols - 1) * gap
-    bbHeight = rows * gridMaxH + (rows - 1) * gap
-  } else {
-    bbWidth = items.reduce((s, i) => s + i.width, 0) + (items.length - 1) * gap
-    bbHeight = Math.max(...items.map((i) => i.height))
-  }
-
+  const metrics = computeLayoutMetrics(items, layout, gap, gap)
   const placement = findPlacement({
-    width: bbWidth,
-    height: bbHeight,
+    width: metrics.bbWidth,
+    height: metrics.bbHeight,
     anchor: request.anchor ?? 'selection_or_empty_region',
   })
 
-  const positions: Array<{ canvasX: number; canvasY: number }> = []
+  const outerPositions = computeLayoutPositions(
+    items,
+    layout,
+    gap,
+    gap,
+    { x: placement.canvasX, y: placement.canvasY },
+    metrics.cols,
+  )
 
-  if (layout === 'column') {
-    let cursorY = placement.canvasY
-    for (const item of items) {
-      positions.push({ canvasX: placement.canvasX, canvasY: cursorY })
-      cursorY += item.height + gap
+  const positions = outerPositions.map((p, idx) => ({
+    canvasX: p.canvasX + insets[idx].insetX,
+    canvasY: p.canvasY + insets[idx].insetY,
+  }))
+
+  return { positions }
+}
+
+/**
+ * Apply a layout directive: resolve origin (originX/Y → near → bbox of
+ * existing items → findPlacement), look up sizes for items carrying an `id`,
+ * compute positions. Used by upsertEntities when a `layout` directive is
+ * present.
+ */
+export function applyLayoutDirective(request: ApplyDirectiveRequest): ApplyDirectiveResult {
+  const directive = request.layout
+  const kind = directive.kind
+  const baseGap = resolveSpacing(directive.gap, CLUSTER_HORIZONTAL_GUTTER)
+  const colGap = resolveSpacing(directive.colGap, baseGap)
+  const rowGap = resolveSpacing(directive.rowGap, baseGap)
+  const warnings: string[] = []
+
+  // Resolve outer footprints + insets per item. Items with `id` look up the
+  // existing entity's outer bounds and data-origin insets; new items carry
+  // their own outer width/height plus optional insets (default 0). Layout runs
+  // in OUTER space so `gap` is visible whitespace; positions are offset back
+  // to inner data-origin coordinates before returning.
+  // No snap-to-grid — directives are precise; agents choose their own values.
+  const items: LayoutBox[] = []
+  const itemInsets: Array<{ insetX: number; insetY: number }> = []
+  for (let idx = 0; idx < request.items.length; idx++) {
+    const it = request.items[idx]
+    if (it.id) {
+      const bounds = entityBoundsById(it.id)
+      if (!bounds) {
+        throw new Error(`applyLayoutDirective: unknown entity id "${it.id}" at index ${idx}`)
+      }
+      items.push({ width: it.width ?? bounds.width, height: it.height ?? bounds.height })
+      itemInsets.push(entityDataInsetsById(it.id))
+      continue
     }
-  } else if (layout === 'grid') {
-    for (let idx = 0; idx < items.length; idx++) {
-      positions.push({
-        canvasX: placement.canvasX + (idx % gridCols) * (gridMaxW + gap),
-        canvasY: placement.canvasY + Math.floor(idx / gridCols) * (gridMaxH + gap),
-      })
+    if (it.width === undefined || it.height === undefined) {
+      throw new Error(`applyLayoutDirective: item at index ${idx} has no id and no width/height`)
+    }
+    items.push({ width: it.width, height: it.height })
+    itemInsets.push({ insetX: it.insetX ?? 0, insetY: it.insetY ?? 0 })
+  }
+
+  const kinds = request.items.map((it) => (it.id ? entityKindById(it.id) : null))
+
+  if (items.length === 0) return { positions: [], kinds: [] }
+
+  // Resolve origin in OUTER space.
+  let origin: { x: number; y: number }
+  if (directive.originX !== undefined && directive.originY !== undefined) {
+    // User specifies the first item's INNER (data-origin) position; convert
+    // to outer by subtracting that item's insets so layout math operates on
+    // outer footprints consistently.
+    origin = {
+      x: directive.originX - itemInsets[0].insetX,
+      y: directive.originY - itemInsets[0].insetY,
+    }
+  } else if (directive.near) {
+    const near = entityBoundsById(directive.near)
+    if (!near) {
+      throw new Error(`applyLayoutDirective: near entity "${directive.near}" not found`)
+    }
+    // entityBoundsById returns OUTER bounds for frames (inner + shell + chrome).
+    if (kind === 'column') {
+      origin = { x: near.x, y: near.y + near.height + rowGap }
+    } else {
+      origin = { x: near.x + near.width + colGap, y: near.y }
     }
   } else {
-    let cursorX = placement.canvasX
-    for (const item of items) {
-      positions.push({ canvasX: cursorX, canvasY: placement.canvasY })
-      cursorX += item.width + gap
+    // Implicit origin: bbox of existing items being re-laid-out, if any.
+    const existingBounds = request.items
+      .map((it) => (it.id ? entityBoundsById(it.id) : null))
+      .filter((b): b is NonNullable<typeof b> => b !== null)
+    if (existingBounds.length > 0) {
+      const minX = Math.min(...existingBounds.map((b) => b.x))
+      const minY = Math.min(...existingBounds.map((b) => b.y))
+      origin = { x: minX, y: minY }
+    } else {
+      // Pure-create directive with no anchor: fall back to findPlacement.
+      const metrics = computeLayoutMetrics(items, kind, colGap, rowGap, directive.cols)
+      const placement = findPlacement({
+        width: metrics.bbWidth,
+        height: metrics.bbHeight,
+        anchor: 'selection_or_empty_region',
+      })
+      origin = { x: placement.canvasX, y: placement.canvasY }
     }
   }
 
-  return { positions }
+  const outerPositions = computeLayoutPositions(items, kind, colGap, rowGap, origin, directive.cols)
+  const positions = outerPositions.map((p, idx) => ({
+    canvasX: p.canvasX + itemInsets[idx].insetX,
+    canvasY: p.canvasY + itemInsets[idx].insetY,
+  }))
+  return warnings.length > 0 ? { positions, kinds, warnings } : { positions, kinds }
 }
 
 /**

--- a/src/main/workspace-placement.ts
+++ b/src/main/workspace-placement.ts
@@ -33,6 +33,7 @@ import {
   entityDataInsetsById,
   entityKindById,
   selectionBounds,
+  unionBounds,
 } from './workspace-entities'
 import { computeLayoutMetrics, computeLayoutPositions, type LayoutBox } from './layout-math'
 
@@ -171,10 +172,6 @@ export function findPlacement(request: PlacementRequest): PlacementResult {
 export function findBatchPlacement(request: BatchPlacementRequest): BatchPlacementResult {
   const gap = snapToGrid(request.gap ?? CLUSTER_HORIZONTAL_GUTTER)
   const layout = request.layout ?? 'row'
-  // Items are described as outer (visible) footprints. Layout in outer space
-  // ensures `gap` is the visible whitespace between bezels; positions are then
-  // offset by each item's `insetX/insetY` so callers receive inner data-origin
-  // coordinates (canvasX/canvasY).
   const items = request.items.map((i) => ({
     width: snapToGrid(i.width),
     height: snapToGrid(i.height),
@@ -215,6 +212,10 @@ export function findBatchPlacement(request: BatchPlacementRequest): BatchPlaceme
  * existing items → findPlacement), look up sizes for items carrying an `id`,
  * compute positions. Used by upsertEntities when a `layout` directive is
  * present.
+ *
+ * Layout runs in OUTER space so `gap` measures visible whitespace between
+ * device-shell bezels; positions are offset back to inner data-origin
+ * coordinates before returning. No snap-to-grid — directives are precise.
  */
 export function applyLayoutDirective(request: ApplyDirectiveRequest): ApplyDirectiveResult {
   const directive = request.layout
@@ -224,14 +225,13 @@ export function applyLayoutDirective(request: ApplyDirectiveRequest): ApplyDirec
   const rowGap = resolveSpacing(directive.rowGap, baseGap)
   const warnings: string[] = []
 
-  // Resolve outer footprints + insets per item. Items with `id` look up the
-  // existing entity's outer bounds and data-origin insets; new items carry
-  // their own outer width/height plus optional insets (default 0). Layout runs
-  // in OUTER space so `gap` is visible whitespace; positions are offset back
-  // to inner data-origin coordinates before returning.
-  // No snap-to-grid — directives are precise; agents choose their own values.
+  // Single pass: collect everything we need per item — outer footprint, data
+  // insets, kind, and (for re-layouts) the existing entity's bounds for the
+  // implicit-origin fallback. Avoids re-traversing the entity graph 3× per id.
   const items: LayoutBox[] = []
   const itemInsets: Array<{ insetX: number; insetY: number }> = []
+  const kinds: ApplyDirectiveResult['kinds'] = []
+  const existingBounds: WorkspaceBounds[] = []
   for (let idx = 0; idx < request.items.length; idx++) {
     const it = request.items[idx]
     if (it.id) {
@@ -241,6 +241,8 @@ export function applyLayoutDirective(request: ApplyDirectiveRequest): ApplyDirec
       }
       items.push({ width: it.width ?? bounds.width, height: it.height ?? bounds.height })
       itemInsets.push(entityDataInsetsById(it.id))
+      kinds.push(entityKindById(it.id))
+      existingBounds.push(bounds)
       continue
     }
     if (it.width === undefined || it.height === undefined) {
@@ -248,9 +250,8 @@ export function applyLayoutDirective(request: ApplyDirectiveRequest): ApplyDirec
     }
     items.push({ width: it.width, height: it.height })
     itemInsets.push({ insetX: it.insetX ?? 0, insetY: it.insetY ?? 0 })
+    kinds.push(null)
   }
-
-  const kinds = request.items.map((it) => (it.id ? entityKindById(it.id) : null))
 
   if (items.length === 0) return { positions: [], kinds: [] }
 
@@ -258,8 +259,7 @@ export function applyLayoutDirective(request: ApplyDirectiveRequest): ApplyDirec
   let origin: { x: number; y: number }
   if (directive.originX !== undefined && directive.originY !== undefined) {
     // User specifies the first item's INNER (data-origin) position; convert
-    // to outer by subtracting that item's insets so layout math operates on
-    // outer footprints consistently.
+    // to outer by subtracting that item's insets so layout math is consistent.
     origin = {
       x: directive.originX - itemInsets[0].insetX,
       y: directive.originY - itemInsets[0].insetY,
@@ -269,31 +269,22 @@ export function applyLayoutDirective(request: ApplyDirectiveRequest): ApplyDirec
     if (!near) {
       throw new Error(`applyLayoutDirective: near entity "${directive.near}" not found`)
     }
-    // entityBoundsById returns OUTER bounds for frames (inner + shell + chrome).
     if (kind === 'column') {
       origin = { x: near.x, y: near.y + near.height + rowGap }
     } else {
       origin = { x: near.x + near.width + colGap, y: near.y }
     }
+  } else if (existingBounds.length > 0) {
+    const bbox = unionBounds(existingBounds)!
+    origin = { x: bbox.x, y: bbox.y }
   } else {
-    // Implicit origin: bbox of existing items being re-laid-out, if any.
-    const existingBounds = request.items
-      .map((it) => (it.id ? entityBoundsById(it.id) : null))
-      .filter((b): b is NonNullable<typeof b> => b !== null)
-    if (existingBounds.length > 0) {
-      const minX = Math.min(...existingBounds.map((b) => b.x))
-      const minY = Math.min(...existingBounds.map((b) => b.y))
-      origin = { x: minX, y: minY }
-    } else {
-      // Pure-create directive with no anchor: fall back to findPlacement.
-      const metrics = computeLayoutMetrics(items, kind, colGap, rowGap, directive.cols)
-      const placement = findPlacement({
-        width: metrics.bbWidth,
-        height: metrics.bbHeight,
-        anchor: 'selection_or_empty_region',
-      })
-      origin = { x: placement.canvasX, y: placement.canvasY }
-    }
+    const metrics = computeLayoutMetrics(items, kind, colGap, rowGap, directive.cols)
+    const placement = findPlacement({
+      width: metrics.bbWidth,
+      height: metrics.bbHeight,
+      anchor: 'selection_or_empty_region',
+    })
+    origin = { x: placement.canvasX, y: placement.canvasY }
   }
 
   const outerPositions = computeLayoutPositions(items, kind, colGap, rowGap, origin, directive.cols)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1345,7 +1345,14 @@ export interface PlacementResult {
 export type BatchLayoutMode = 'row' | 'column' | 'grid'
 
 export interface BatchPlacementRequest {
-  items: Array<{ width: number; height: number }>
+  /**
+   * Each item's `width`/`height` is the OUTER (visible) footprint, including
+   * device-shell bezels and chrome header. `insetX`/`insetY` (default 0)
+   * describe the offset from the outer top-left to the entity's data origin
+   * (`canvasX`/`canvasY`); the layout engine places outer footprints with
+   * `gap` and returns positions in inner data-origin coordinates.
+   */
+  items: Array<{ width: number; height: number; insetX?: number; insetY?: number }>
   layout?: BatchLayoutMode
   gap?: number
   anchor?: PlacementAnchor
@@ -1353,6 +1360,67 @@ export interface BatchPlacementRequest {
 
 export interface BatchPlacementResult {
   positions: Array<{ canvasX: number; canvasY: number }>
+}
+
+export type SpacingToken = 'xs' | 's' | 'm' | 'l' | 'xl'
+
+// All multiples of GRID_SIZE (20px) so token-spaced gaps stay snap-aligned.
+export const SPACING_TOKEN_PIXELS: Record<SpacingToken, number> = {
+  xs: 20,
+  s: 40,
+  m: 60,
+  l: 100,
+  xl: 160,
+}
+
+export function resolveSpacing(value: number | SpacingToken | undefined, fallback: number): number {
+  if (value === undefined) return fallback
+  if (typeof value === 'number') return value
+  return SPACING_TOKEN_PIXELS[value] ?? fallback
+}
+
+export interface LayoutDirective {
+  kind: BatchLayoutMode
+  gap?: number | SpacingToken
+  rowGap?: number | SpacingToken
+  colGap?: number | SpacingToken
+  cols?: number
+  originX?: number
+  originY?: number
+  near?: string
+}
+
+export interface ApplyDirectiveRequest {
+  layout: LayoutDirective
+  /**
+   * Each item is either an `id` (re-layout an existing entity — server resolves
+   * its outer footprint and data-origin insets) or a new item carrying its own
+   * `width`/`height` (treated as the outer/visible footprint, including any
+   * device-shell bezels and chrome header). `insetX`/`insetY` describe how far
+   * inside the outer top-left the entity's data origin (canvasX/canvasY) sits;
+   * for un-framed items pass `0` or omit. The directive lays out outer
+   * footprints with the configured `gap`, then returns each position offset
+   * back into inner data-origin coordinates.
+   */
+  items: Array<{
+    id?: string
+    width?: number
+    height?: number
+    insetX?: number
+    insetY?: number
+  }>
+}
+
+export interface ApplyDirectiveResult {
+  positions: Array<{ canvasX: number; canvasY: number }>
+  /**
+   * Resolved kind for each item: the kind of the existing entity (when an
+   * `id` was passed) or `null` for items being created. Lets the caller route
+   * updates to the correct entity-update endpoint without forcing the agent
+   * to specify `kind` for every re-layout target.
+   */
+  kinds: Array<CanvasEntityKind | null>
+  warnings?: string[]
 }
 
 export type TaskKind = 'breakpoint_map'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1347,10 +1347,12 @@ export type BatchLayoutMode = 'row' | 'column' | 'grid'
 export interface BatchPlacementRequest {
   /**
    * Each item's `width`/`height` is the OUTER (visible) footprint, including
-   * device-shell bezels and chrome header. `insetX`/`insetY` (default 0)
-   * describe the offset from the outer top-left to the entity's data origin
-   * (`canvasX`/`canvasY`); the layout engine places outer footprints with
-   * `gap` and returns positions in inner data-origin coordinates.
+   * device-shell bezels. The hover-only chrome action header is reserved
+   * separately by occupied-region inflation, so it doesn't widen `gap`.
+   * `insetX`/`insetY` (default 0) describe the offset from the outer top-left
+   * to the entity's data origin (`canvasX`/`canvasY`); the layout engine
+   * places outer footprints with `gap` and returns positions in inner
+   * data-origin coordinates.
    */
   items: Array<{ width: number; height: number; insetX?: number; insetY?: number }>
   layout?: BatchLayoutMode
@@ -1390,17 +1392,58 @@ export interface LayoutDirective {
   near?: string
 }
 
+const SPACING_TOKEN_NAMES: ReadonlySet<string> = new Set(Object.keys(SPACING_TOKEN_PIXELS))
+
+function isSpacingValue(v: unknown): boolean {
+  return typeof v === 'number' || (typeof v === 'string' && SPACING_TOKEN_NAMES.has(v))
+}
+
+/**
+ * Validate an unknown value as a `LayoutDirective`. Returns null on success,
+ * or a human-readable error string describing the first problem found. Call
+ * at the boundary (CLI/HTTP) so bad agent input fails loudly instead of
+ * silently falling through to defaults.
+ */
+export function validateLayoutDirective(value: unknown): string | null {
+  if (!value || typeof value !== 'object') return 'layout: expected an object'
+  const d = value as Record<string, unknown>
+  if (d.kind !== 'row' && d.kind !== 'column' && d.kind !== 'grid') {
+    return `layout.kind: expected 'row' | 'column' | 'grid', got ${JSON.stringify(d.kind)}`
+  }
+  for (const key of ['gap', 'rowGap', 'colGap'] as const) {
+    if (d[key] !== undefined && !isSpacingValue(d[key])) {
+      return `layout.${key}: expected number or one of ${[...SPACING_TOKEN_NAMES].join('|')}, got ${JSON.stringify(d[key])}`
+    }
+  }
+  if (d.cols !== undefined && (typeof d.cols !== 'number' || !Number.isInteger(d.cols) || d.cols < 1)) {
+    return `layout.cols: expected positive integer, got ${JSON.stringify(d.cols)}`
+  }
+  for (const key of ['originX', 'originY'] as const) {
+    if (d[key] !== undefined && typeof d[key] !== 'number') {
+      return `layout.${key}: expected number, got ${JSON.stringify(d[key])}`
+    }
+  }
+  if (d.near !== undefined && typeof d.near !== 'string') {
+    return `layout.near: expected entity id string, got ${JSON.stringify(d.near)}`
+  }
+  if ((d.originX === undefined) !== (d.originY === undefined)) {
+    return 'layout: originX and originY must be specified together'
+  }
+  return null
+}
+
 export interface ApplyDirectiveRequest {
   layout: LayoutDirective
   /**
    * Each item is either an `id` (re-layout an existing entity — server resolves
    * its outer footprint and data-origin insets) or a new item carrying its own
-   * `width`/`height` (treated as the outer/visible footprint, including any
-   * device-shell bezels and chrome header). `insetX`/`insetY` describe how far
-   * inside the outer top-left the entity's data origin (canvasX/canvasY) sits;
-   * for un-framed items pass `0` or omit. The directive lays out outer
-   * footprints with the configured `gap`, then returns each position offset
-   * back into inner data-origin coordinates.
+   * outer-footprint `width`/`height` (device-shell bezels included; the
+   * hover-only chrome action header is reserved separately and is *not* part
+   * of the footprint). `insetX`/`insetY` describe how far inside the outer
+   * top-left the entity's data origin (canvasX/canvasY) sits; for un-framed
+   * items pass `0` or omit. The directive lays out outer footprints with the
+   * configured `gap`, then returns each position offset back into inner
+   * data-origin coordinates.
    */
   items: Array<{
     id?: string

--- a/tests/smoke/app-client.ts
+++ b/tests/smoke/app-client.ts
@@ -127,6 +127,36 @@ export function deleteFrames(frameIds: string[]) {
   return post<{ deletedFrameIds: string[] }>('/frames/delete', { frameIds })
 }
 
+export function updateFrames(frames: Array<{ id: string; canvasX?: number; canvasY?: number; presetIndex?: number }>) {
+  return post<{ updated: string[] }>('/frames/update', { frames })
+}
+
+export function applyLayoutDirective(body: {
+  layout: {
+    kind: 'row' | 'column' | 'grid'
+    gap?: number | string
+    rowGap?: number | string
+    colGap?: number | string
+    cols?: number
+    originX?: number
+    originY?: number
+    near?: string
+  }
+  items: Array<{
+    id?: string
+    width?: number
+    height?: number
+    insetX?: number
+    insetY?: number
+  }>
+}) {
+  return post<{
+    positions: Array<{ canvasX: number; canvasY: number }>
+    kinds: Array<string | null>
+    warnings?: string[]
+  }>('/layout/apply-directive', body)
+}
+
 export function takeScreenshot(frameId?: string) {
   return post<{ base64: string; mimeType: string }>('/frames/screenshot', { frameId })
 }

--- a/tests/smoke/upsert-layout.test.ts
+++ b/tests/smoke/upsert-layout.test.ts
@@ -1,0 +1,142 @@
+import { afterAll, describe, expect, it } from 'vitest'
+import {
+  applyLayoutDirective,
+  createFrames,
+  deleteFrames,
+  getWorkspace,
+} from './app-client'
+
+const trash: string[] = []
+
+afterAll(async () => {
+  if (trash.length) await deleteFrames(trash)
+})
+
+describe('layout directive — pure-create row', () => {
+  it('lays new items out at an explicit origin', async () => {
+    const items = [
+      { width: 200, height: 100 },
+      { width: 200, height: 100 },
+      { width: 200, height: 100 },
+    ]
+    const result = await applyLayoutDirective({
+      layout: { kind: 'row', gap: 'xs', originX: 0, originY: 0 },
+      items,
+    })
+    expect(result.positions).toEqual([
+      { canvasX: 0, canvasY: 0 },
+      { canvasX: 220, canvasY: 0 },
+      { canvasX: 440, canvasY: 0 },
+    ])
+    expect(result.kinds).toEqual([null, null, null])
+  })
+
+  it('honors spacing tokens precisely (no snap-to-grid)', async () => {
+    const result = await applyLayoutDirective({
+      layout: { kind: 'row', gap: 'm', originX: 100, originY: 100 },
+      items: [
+        { width: 100, height: 100 },
+        { width: 100, height: 100 },
+      ],
+    })
+    // m = 60px
+    expect(result.positions[1].canvasX - result.positions[0].canvasX).toBe(160)
+  })
+
+  it('treats per-item dimensions as outer footprints and offsets positions by insets', async () => {
+    // Simulated iPad Pro 11 landscape: 1194x834 inner + 24px shell insets on
+    // all sides. Outer footprint = 1242 x 882, insetX = insetY = 24.
+    const result = await applyLayoutDirective({
+      layout: { kind: 'row', gap: 'm', originX: 100, originY: 200 },
+      items: [
+        { width: 1242, height: 882, insetX: 24, insetY: 24 },
+        { width: 1242, height: 882, insetX: 24, insetY: 24 },
+      ],
+    })
+    // First item's inner top-left lands at the user-supplied origin.
+    expect(result.positions[0]).toEqual({ canvasX: 100, canvasY: 200 })
+    // Second item: outer-step = outerWidth + gap = 1242 + 60 = 1302. Adding
+    // insetX back to convert outer→inner cancels with the origin shift, so
+    // the visible whitespace between bezels is exactly the requested gap.
+    expect(result.positions[1].canvasX - result.positions[0].canvasX).toBe(1302)
+    expect(result.positions[1].canvasY).toBe(200)
+  })
+
+  it('falls back to insets=0 when only width/height given (back-compat)', async () => {
+    const result = await applyLayoutDirective({
+      layout: { kind: 'row', gap: 'xs', originX: 0, originY: 0 },
+      items: [
+        { width: 200, height: 100 },
+        { width: 200, height: 100 },
+      ],
+    })
+    expect(result.positions).toEqual([
+      { canvasX: 0, canvasY: 0 },
+      { canvasX: 220, canvasY: 0 },
+    ])
+  })
+})
+
+describe('layout directive — re-layout existing entities', () => {
+  it('reorganizes existing frames into a 2-col grid and fills in kinds', async () => {
+    // Create frames one at a time (multi-frame batch creation has a known
+    // issue where only the first frame survives — orthogonal to this plan).
+    const ids: string[] = []
+    for (let i = 0; i < 4; i++) {
+      const r = await createFrames([
+        { url: `data:text/html,<div>${i}</div>`, canvasX: i * 500, canvasY: i * 300, presetIndex: 9 },
+      ])
+      ids.push(...r.frameIds)
+    }
+    trash.push(...ids)
+    const created = { frameIds: ids }
+
+    const ws = await getWorkspace()
+    const frameIds = ws.entities.filter((e) => e.kind === 'frame').map((e) => e.id)
+    expect(frameIds).toEqual(expect.arrayContaining(created.frameIds))
+
+    const result = await applyLayoutDirective({
+      layout: { kind: 'grid', cols: 2, gap: 24, originX: 0, originY: 0 },
+      items: created.frameIds.map((id) => ({ id })),
+    })
+
+    expect(result.kinds).toEqual(['frame', 'frame', 'frame', 'frame'])
+    // 2-col grid with uniform tracks. Same-size frames → predictable cells.
+    const rowDelta = result.positions[2].canvasY - result.positions[0].canvasY
+    const colDelta = result.positions[1].canvasX - result.positions[0].canvasX
+    expect(colDelta).toBeGreaterThan(0)
+    expect(rowDelta).toBeGreaterThan(0)
+    expect(result.positions[3].canvasX).toBe(result.positions[1].canvasX)
+    expect(result.positions[3].canvasY).toBe(result.positions[2].canvasY)
+  })
+
+  it('errors on unknown id without partial application', async () => {
+    await expect(
+      applyLayoutDirective({
+        layout: { kind: 'row', gap: 16, originX: 0, originY: 0 },
+        items: [{ id: 'frame_does_not_exist_xyz' }],
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('uses bbox of existing items as implicit origin when no anchor given', async () => {
+    const ids: string[] = []
+    for (let i = 0; i < 2; i++) {
+      const r = await createFrames([
+        { url: `data:text/html,<div>${i}</div>`, canvasX: 500 + i * 1000, canvasY: 400 + i * 400, presetIndex: 9 },
+      ])
+      ids.push(...r.frameIds)
+    }
+    trash.push(...ids)
+    const created = { frameIds: ids }
+
+    const result = await applyLayoutDirective({
+      layout: { kind: 'row', gap: 'xs' },
+      items: created.frameIds.map((id) => ({ id })),
+    })
+
+    // Implicit origin = (min x, min y) of bbox = (500, 400). No snap.
+    expect(result.positions[0].canvasX).toBe(500)
+    expect(result.positions[0].canvasY).toBe(400)
+  })
+})

--- a/tests/smoke/upsert-layout.test.ts
+++ b/tests/smoke/upsert-layout.test.ts
@@ -62,7 +62,7 @@ describe('layout directive — pure-create row', () => {
     expect(result.positions[1].canvasY).toBe(200)
   })
 
-  it('falls back to insets=0 when only width/height given (back-compat)', async () => {
+  it('treats items without insets as un-framed (insets default to 0)', async () => {
     const result = await applyLayoutDirective({
       layout: { kind: 'row', gap: 'xs', originX: 0, originY: 0 },
       items: [
@@ -79,8 +79,6 @@ describe('layout directive — pure-create row', () => {
 
 describe('layout directive — re-layout existing entities', () => {
   it('reorganizes existing frames into a 2-col grid and fills in kinds', async () => {
-    // Create frames one at a time (multi-frame batch creation has a known
-    // issue where only the first frame survives — orthogonal to this plan).
     const ids: string[] = []
     for (let i = 0; i < 4; i++) {
       const r = await createFrames([

--- a/tests/unit/layout-math.test.ts
+++ b/tests/unit/layout-math.test.ts
@@ -4,7 +4,11 @@ import {
   computeLayoutPositions,
   type LayoutBox,
 } from '../../src/main/layout-math'
-import { resolveSpacing, SPACING_TOKEN_PIXELS } from '../../src/shared/types'
+import {
+  resolveSpacing,
+  SPACING_TOKEN_PIXELS,
+  validateLayoutDirective,
+} from '../../src/shared/types'
 
 const ORIGIN = { x: 0, y: 0 }
 
@@ -19,6 +23,39 @@ describe('resolveSpacing', () => {
   })
   it('falls back when undefined', () => {
     expect(resolveSpacing(undefined, 24)).toBe(24)
+  })
+})
+
+describe('validateLayoutDirective', () => {
+  it('accepts a minimal valid directive', () => {
+    expect(validateLayoutDirective({ kind: 'row' })).toBeNull()
+  })
+  it('accepts the full surface', () => {
+    expect(validateLayoutDirective({
+      kind: 'grid', gap: 'm', rowGap: 24, colGap: 'l', cols: 3,
+      originX: 100, originY: 200, near: 'frame_x',
+    })).toBeNull()
+  })
+  it('rejects bad kind', () => {
+    expect(validateLayoutDirective({ kind: 'flex' })).toMatch(/layout\.kind/)
+  })
+  it('rejects bad spacing tokens', () => {
+    expect(validateLayoutDirective({ kind: 'row', gap: 'huge' })).toMatch(/layout\.gap/)
+  })
+  it('rejects non-positive cols', () => {
+    expect(validateLayoutDirective({ kind: 'grid', cols: 0 })).toMatch(/layout\.cols/)
+    expect(validateLayoutDirective({ kind: 'grid', cols: 1.5 })).toMatch(/layout\.cols/)
+  })
+  it('requires originX and originY together', () => {
+    expect(validateLayoutDirective({ kind: 'row', originX: 100 })).toMatch(/originX and originY/)
+    expect(validateLayoutDirective({ kind: 'row', originY: 100 })).toMatch(/originX and originY/)
+  })
+  it('rejects non-string near', () => {
+    expect(validateLayoutDirective({ kind: 'row', near: 42 })).toMatch(/layout\.near/)
+  })
+  it('rejects non-object', () => {
+    expect(validateLayoutDirective(null)).toMatch(/expected an object/)
+    expect(validateLayoutDirective('row')).toMatch(/expected an object/)
   })
 })
 

--- a/tests/unit/layout-math.test.ts
+++ b/tests/unit/layout-math.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeLayoutMetrics,
+  computeLayoutPositions,
+  type LayoutBox,
+} from '../../src/main/layout-math'
+import { resolveSpacing, SPACING_TOKEN_PIXELS } from '../../src/shared/types'
+
+const ORIGIN = { x: 0, y: 0 }
+
+describe('resolveSpacing', () => {
+  it('maps tokens to pixels', () => {
+    expect(resolveSpacing('xs', 0)).toBe(SPACING_TOKEN_PIXELS.xs)
+    expect(resolveSpacing('m', 0)).toBe(SPACING_TOKEN_PIXELS.m)
+    expect(resolveSpacing('xl', 0)).toBe(SPACING_TOKEN_PIXELS.xl)
+  })
+  it('passes through numbers unchanged', () => {
+    expect(resolveSpacing(37, 0)).toBe(37)
+  })
+  it('falls back when undefined', () => {
+    expect(resolveSpacing(undefined, 24)).toBe(24)
+  })
+})
+
+describe('computeLayoutPositions — row', () => {
+  it('places homogeneous items left-to-right with gap', () => {
+    const items: LayoutBox[] = [
+      { width: 100, height: 80 },
+      { width: 100, height: 80 },
+      { width: 100, height: 80 },
+    ]
+    const positions = computeLayoutPositions(items, 'row', 16, 16, ORIGIN)
+    expect(positions).toEqual([
+      { canvasX: 0, canvasY: 0 },
+      { canvasX: 116, canvasY: 0 },
+      { canvasX: 232, canvasY: 0 },
+    ])
+  })
+
+  it('flows heterogeneous widths by item width (not max)', () => {
+    const items: LayoutBox[] = [
+      { width: 100, height: 80 },
+      { width: 200, height: 80 },
+      { width: 50, height: 80 },
+    ]
+    const positions = computeLayoutPositions(items, 'row', 10, 10, ORIGIN)
+    expect(positions.map((p) => p.canvasX)).toEqual([0, 110, 320])
+  })
+
+  it('respects origin offset', () => {
+    const items: LayoutBox[] = [
+      { width: 100, height: 80 },
+      { width: 100, height: 80 },
+    ]
+    const positions = computeLayoutPositions(items, 'row', 16, 16, { x: 200, y: 50 })
+    expect(positions).toEqual([
+      { canvasX: 200, canvasY: 50 },
+      { canvasX: 316, canvasY: 50 },
+    ])
+  })
+
+  it('handles single item without gap', () => {
+    const items: LayoutBox[] = [{ width: 300, height: 200 }]
+    const positions = computeLayoutPositions(items, 'row', 24, 24, { x: 10, y: 20 })
+    expect(positions).toEqual([{ canvasX: 10, canvasY: 20 }])
+  })
+
+  it('returns empty for empty items', () => {
+    expect(computeLayoutPositions([], 'row', 16, 16, ORIGIN)).toEqual([])
+  })
+})
+
+describe('computeLayoutPositions — column', () => {
+  it('flows top-to-bottom by item height', () => {
+    const items: LayoutBox[] = [
+      { width: 100, height: 80 },
+      { width: 100, height: 120 },
+      { width: 100, height: 60 },
+    ]
+    const positions = computeLayoutPositions(items, 'column', 10, 10, ORIGIN)
+    expect(positions.map((p) => p.canvasY)).toEqual([0, 90, 220])
+    expect(positions.every((p) => p.canvasX === 0)).toBe(true)
+  })
+
+  it('uses rowGap distinct from colGap', () => {
+    const items: LayoutBox[] = [
+      { width: 100, height: 100 },
+      { width: 100, height: 100 },
+    ]
+    const positions = computeLayoutPositions(items, 'column', 999, 50, ORIGIN)
+    expect(positions[1].canvasY).toBe(150)
+  })
+})
+
+describe('computeLayoutPositions — grid', () => {
+  it('uses uniform tracks (max width × max height) for clean alignment', () => {
+    const items: LayoutBox[] = [
+      { width: 100, height: 100 },
+      { width: 200, height: 100 },
+      { width: 100, height: 200 },
+      { width: 100, height: 100 },
+    ]
+    const positions = computeLayoutPositions(items, 'grid', 10, 10, ORIGIN, 2)
+    // Tracks: maxW=200, maxH=200. Cells start at (0,0), (210,0), (0,210), (210,210).
+    expect(positions).toEqual([
+      { canvasX: 0, canvasY: 0 },
+      { canvasX: 210, canvasY: 0 },
+      { canvasX: 0, canvasY: 210 },
+      { canvasX: 210, canvasY: 210 },
+    ])
+  })
+
+  it('fills row-major', () => {
+    const items: LayoutBox[] = Array.from({ length: 6 }, () => ({ width: 100, height: 100 }))
+    const positions = computeLayoutPositions(items, 'grid', 10, 10, ORIGIN, 3)
+    // Indices 0,1,2 on row 0; 3,4,5 on row 1.
+    expect(positions[0]).toEqual({ canvasX: 0, canvasY: 0 })
+    expect(positions[2]).toEqual({ canvasX: 220, canvasY: 0 })
+    expect(positions[3]).toEqual({ canvasX: 0, canvasY: 110 })
+    expect(positions[5]).toEqual({ canvasX: 220, canvasY: 110 })
+  })
+
+  it('defaults cols to ceil(sqrt(n))', () => {
+    const items: LayoutBox[] = Array.from({ length: 5 }, () => ({ width: 100, height: 100 }))
+    const positions = computeLayoutPositions(items, 'grid', 10, 10, ORIGIN)
+    // ceil(sqrt(5)) = 3 cols → indices 0,1,2 on row 0; 3,4 on row 1.
+    expect(positions[2]).toEqual({ canvasX: 220, canvasY: 0 })
+    expect(positions[3]).toEqual({ canvasX: 0, canvasY: 110 })
+  })
+
+  it('respects origin offset', () => {
+    const items: LayoutBox[] = [
+      { width: 100, height: 100 },
+      { width: 100, height: 100 },
+    ]
+    const positions = computeLayoutPositions(items, 'grid', 10, 10, { x: 50, y: 50 }, 2)
+    expect(positions[0]).toEqual({ canvasX: 50, canvasY: 50 })
+    expect(positions[1]).toEqual({ canvasX: 160, canvasY: 50 })
+  })
+})
+
+describe('computeLayoutMetrics', () => {
+  it('returns bbox for row', () => {
+    const items: LayoutBox[] = [
+      { width: 100, height: 80 },
+      { width: 100, height: 80 },
+      { width: 100, height: 80 },
+    ]
+    const m = computeLayoutMetrics(items, 'row', 16, 16)
+    expect(m.bbWidth).toBe(332)
+    expect(m.bbHeight).toBe(80)
+  })
+
+  it('returns bbox for grid using uniform tracks', () => {
+    const items: LayoutBox[] = [
+      { width: 100, height: 100 },
+      { width: 200, height: 100 },
+      { width: 100, height: 200 },
+      { width: 100, height: 100 },
+    ]
+    const m = computeLayoutMetrics(items, 'grid', 10, 10, 2)
+    // 2 cols × 200 + 1 × 10 = 410; 2 rows × 200 + 1 × 10 = 410
+    expect(m.bbWidth).toBe(410)
+    expect(m.bbHeight).toBe(410)
+    expect(m.cols).toBe(2)
+  })
+
+  it('handles empty', () => {
+    const m = computeLayoutMetrics([], 'row', 16, 16)
+    expect(m).toEqual({ cols: 0, maxW: 0, maxH: 0, bbWidth: 0, bbHeight: 0 })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `{layout, items}` shape to `specular upsert --json` so a single call can create or re-lay-out many entities in a row/column/grid with token-based spacing (`xs`/`s`/`m`/`l`/`xl`, or raw numbers).
- Origin resolves from `originX/Y`, `near: <id>`, the bounding box of existing items being re-laid-out, or `findPlacement` as a last resort.
- Layout math operates on outer (visible) footprints, so `gap: "m"` is 60px of real whitespace between device-shell bezels — not 60px between inner content edges. Verified end-to-end: same input that produced 12px visible gap before now produces 60px.
- Skill docs updated with the new shape, spacing tokens, and the existing color-preset gotcha.
- Adds the design doc `docs/plans/agent-layout-spine.md` plus unit + smoke tests for the layout math and directive.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test:unit` — 414 passed (38 files)
- [x] `pnpm test:smoke -- upsert-layout` — all 11 directive tests pass, including chrome-aware row, re-layout grid, implicit-bbox origin, and back-compat (insets default to 0)
- [x] End-to-end in dev app: A/B compared two 8-frame iPad landscape rows at `gap: "m"` — old code (pre-fix) gave 12px visible gap, new code gives 60px

🤖 Generated with [Claude Code](https://claude.com/claude-code)