### PR TITLE
fix(marquee): paint marquee box above opaque body layers

### DIFF
--- a/src/renderer/above-view/MarqueeLayer.tsx
+++ b/src/renderer/above-view/MarqueeLayer.tsx
@@ -27,6 +27,11 @@ export function MarqueeLayer({ overlay }: { overlay: SelectionOverlayPayload | n
           ? 'rgba(232, 180, 184, 0.22)'
           : 'rgba(59, 130, 246, 0.12)',
         pointerEvents: 'none',
+        // Body layers (file/sticky/shape) wrap their cards in a viewport
+        // div with `transform: scale`, which creates a stacking context.
+        // Without an explicit z-index the marquee paints under opaque
+        // bodies because it appears earlier in DOM order.
+        zIndex: 10,
       }}
     />
   )


### PR DESCRIPTION
## Summary

The marquee (drag-select) rectangle was painting under file, sticky, and image bodies. Each body layer wraps its cards in a viewport div with \`transform: scale(...)\`, which creates a stacking context — and \`MarqueeLayer\` is rendered earlier in DOM order than those bodies, so they paint over it. Shapes have transparent fills so the marquee showed through; opaque bodies occluded it.

Add an explicit \`zIndex: 10\` to the marquee div so it wins regardless of DOM order.

## Test plan

- [ ] Drag a marquee on empty canvas across files, stickies, and images — the rectangle stays visible over all of them
- [ ] Same drag across shapes — still visible (was already fine)
- [ ] Region-select annotation (red marquee) also stays on top
- [ ] Pre-existing place-shape preview path still suppresses the marquee correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)