### PR TITLE
Naming decisions: glossary, ADRs 0003–0005, groupKind cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,14 @@ Specular is a spatial canvas for designers and frontend developers. Part browser
 part design iteration surface. Users pull live web content onto a freeform canvas
 to think, arrange, and iterate spatially.
 
+Read CONTEXT.md for the canonical glossary (canvas items, entities, tools, text styles, edges).
 Read docs/product.md for product philosophy and audience.
 Read docs/architecture.md for the full system map.
 Read docs/file-formats.md for .canvas spec and persistence details.
 Read docs/interaction-layer.md before adding gestures, overlays, focus
 handoffs, or drop targets — the invariants in §6 are load-bearing.
+
+When a domain term resolves during a session (rename, new concept, deprecation), update CONTEXT.md inline. If the decision is hard to reverse and surprising without context, add an ADR under docs/adr/ and link it from the relevant CONTEXT.md entry.
 
 ## Build & verify
 
@@ -95,19 +98,6 @@ tag on every file scene entity; the renderer reads `entity.rendererTag` and
 - `src/preload/` bridges IPC only — no business logic
 - `src/main/runtime/` is the single owner of workspace state
 - Renderer state is derived from IPC broadcasts, never authoritative
-
-## Terminology
-
-We follow the JSON Canvas spec (jsoncanvas.org) for our data model nouns:
-
-- **Node** — any entity on the canvas (text, link, file, group)
-- **Edge** — a connection between two nodes
-- **Canvas** — a single .canvas file; the spatial document
-- **Space** — a folder of canvases (like an Obsidian vault)
-- **Frame** — our current UI term for link nodes (live web pages). This may
-  align with the spec term "link" over time.
-
-See docs/file-formats.md for the full .canvas schema.
 
 ## File format principles
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,13 +6,15 @@ Canonical terms used across the codebase, ADRs, and plans. Resolve language conf
 
 ## Canvas data model
 
-Follows [JSON Canvas v1.0](https://jsoncanvas.org).
+Follows [JSON Canvas v1.0](https://jsoncanvas.org) on disk; uses Specular-native terms in runtime and UI.
 
-- **Node** — any entity on the canvas. Kinds: frame, file, group, text, drawing, shape.
-- **Edge** — a connection between two nodes.
+- **Canvas item** — the user-facing and component-naming term for a thing on the canvas. Kinds: frame, file, group, text, drawing, shape. Use this in docs, UI copy, and component names (`CanvasItemChrome`, `SidebarCanvasItem`).
+- **Entity** — the runtime / persistence term for the same concept. Use this in `src/main/runtime/` types (`PersistedFrameEntity`, `CanvasEntityKind`, `CanvasSceneEntity`). One entity ⇔ one canvas item.
+- **Node** — JSON Canvas spec term. Use **only** in the disk-schema layer (`src/shared/json-canvas-types.ts`, `json-canvas-serializer.ts`). Never as a synonym for entity in runtime code.
+- **Edge** — a connection between two canvas items. Same name across all three layers.
 - **Canvas** — a single `.canvas` file; the spatial document.
 - **Space** — a folder of canvases (Obsidian-vault analogue).
-- **Frame** — Specular's UI term for live web-page nodes. May fold into the spec term "link" over time.
+- **Frame** — Specular's term for live web-page items. Serialized as JSON Canvas `link` nodes; the serializer is the only place the two names meet.
 
 ## Entity geometry
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,6 +75,32 @@ Per [ADR 0002](./docs/adr/0002-canvas-anchored-overlay-ui.md). All canvas-anchor
 - **`useAnchoredPosition(entityId, slot)`** — pure positioning hook. Reads the layout broadcast aboveView already receives, returns screen-space coords for the entity's chrome slot.
 - **`EntityChrome` compound** — the `Root / DragTrigger / Title / Actions / Button` primitives composed inside `CanvasItemChrome` consumers. Style once, compose differently per consumer.
 
+## Tools
+
+A **Tool** is the single representation of "what does my next click/gesture do?" There is exactly one active tool at any moment. Tools are mutually exclusive; you switch by toolbar click, keyboard shortcut, or Escape (which returns to `select`). See [ADR 0005](./docs/adr/0005-unified-tool-concept.md).
+
+```ts
+type Tool =
+  | { kind: 'select' }                                                       // default
+  | { kind: 'add-page' }                                                     // one-shot
+  | { kind: 'add-text', style: 'plain' | 'sticky' }                          // one-shot
+  | { kind: 'add-document' }                                                 // one-shot
+  | { kind: 'add-shape', shapeKind: 'rectangle' | 'ellipse' | 'diamond' }    // one-shot
+  | { kind: 'comment' }                                                      // persistent
+  | { kind: 'draw' }                                                         // persistent — creates drawing entities
+  | { kind: 'region-select' }                                                // persistent
+  | { kind: 'inspect' }                                                      // persistent
+```
+
+- **One-shot tools** auto-revert to `select` after one placement.
+- **Persistent tools** stay active until toggled off, replaced, or Escape.
+- The toolbar does **not** visually distinguish one-shot from persistent — users learn the duration by use.
+- Tool name → cursor-label gerund: `select` → "selecting", `add-page` → "adding page", `comment` → "commenting", `draw` → "drawing", `region-select` → "selecting region", `inspect` → "inspecting".
+
+Replaces three previously-parallel state machines: `pendingPlacement`, `AnnotationMode`, and the `inspect` boolean. The legacy term "annotation mode" no longer names a state — annotations themselves remain, but the *mode of being in the comment tool* is just a tool.
+
+**Not a tool:** **View mode** (canvas vs browser). View mode answers "which surface am I looking at?", not "what does my next click do?" — it's structural, not transient. Stays in its own state.
+
 ## UI copy voice
 
 - **Sentence case** — capitalize the first word only. Default for menus, buttons, dialog text, chrome labels: "Reveal codebase in finder", "Delete project…", "Rename".

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,24 +8,24 @@ Canonical terms used across the codebase, ADRs, and plans. Resolve language conf
 
 Follows [JSON Canvas v1.0](https://jsoncanvas.org) on disk; uses Specular-native terms in runtime and UI.
 
-- **Canvas item** — the user-facing and component-naming term for a thing on the canvas. Kinds: frame, file, group, text, drawing, shape. Use this in docs, UI copy, and component names (`CanvasItemChrome`, `SidebarCanvasItem`).
-- **Entity** — the runtime / persistence term for the same concept. Use this in `src/main/runtime/` types (`PersistedFrameEntity`, `CanvasEntityKind`, `CanvasSceneEntity`). One entity ⇔ one canvas item.
+- **Canvas item** — the user-facing and component-naming term for a thing on the canvas. Kinds: page, file, group, text, drawing, shape. Use this in docs, UI copy, and component names (`CanvasItemChrome`, `SidebarCanvasItem`).
+- **Entity** — the runtime / persistence term for the same concept. Use this in `src/main/runtime/` types (`PersistedPageEntity`, `CanvasEntityKind`, `CanvasSceneEntity`). One entity ⇔ one canvas item.
 - **Node** — JSON Canvas spec term. Use **only** in the disk-schema layer (`src/shared/json-canvas-types.ts`, `json-canvas-serializer.ts`). Never as a synonym for entity in runtime code.
 - **Edge** — a connection between two canvas items. Same name across all three layers.
 - **Canvas** — a single `.canvas` file; the spatial document.
 - **Space** — a folder of canvases (Obsidian-vault analogue).
-- **Frame** — Specular's term for live web-page items. Serialized as JSON Canvas `link` nodes; the serializer is the only place the two names meet.
+- **Page** — Specular's term for live web items: a URL rendered at a particular viewport size at a particular position on the canvas. The runtime `Page` (the `WebContentsView` wrapper in `src/main/runtime/page-factory.ts`) is the same concept — there is no separate "frame entity vs page wrapper" duality. Multiple pages can share the same URL (the multi-breakpoint workflow). Serialized as JSON Canvas `link` nodes; the serializer is the only place the two names meet. See [ADR 0003](./docs/adr/0003-page-as-canonical-name-for-live-web-items.md).
 
 ## Entity geometry
 
-- **Entity rect** — the full bounding rect of a node, body + chrome as one layout unit ([ADR 0002](./docs/adr/0002-canvas-anchored-overlay-ui.md)). Pan / zoom / drag / resize operate on this rect.
-- **Body sub-rect** — the part of the entity rect that holds the node's content (the live page for a frame, the image for a file, etc.). Resize handles and edge anchors attach here.
+- **Entity rect** — the full bounding rect of an entity, body + chrome as one layout unit ([ADR 0002](./docs/adr/0002-canvas-anchored-overlay-ui.md)). Pan / zoom / drag / resize operate on this rect.
+- **Body sub-rect** — the part of the entity rect that holds the entity's content (the live document for a page, the image for a file, etc.). Resize handles and edge anchors attach here.
 - **Chrome slot** — the part of the entity rect reserved for canvas-anchored overlay UI. Per-kind, runtime-derived, **not persisted** in the `.canvas` schema.
 
 ## Input authority
 
-- **Frame focus** — runtime state `{ id, since } | null` in main. When set, the focused frame receives native pointer input; aboveView's gate is closed. When null, aboveView is the sole input authority. See [ADR 0001](./docs/adr/0001-click-to-enter-frame-focus.md).
-- **Gate** (a.k.a. **input gate**) — `aboveView.setVisible(...)` predicate. Open in canvas mode iff `frameFocus === null`. The single arbiter of who receives canvas-region pointer events.
+- **Page focus** — runtime state `{ id, since } | null` in main. When set, the focused page receives native pointer input; aboveView's gate is closed. When null, aboveView is the sole input authority. See [ADR 0001](./docs/adr/0001-click-to-enter-frame-focus.md). (ADR 0001 was authored under the old "frame" name; the runtime variable is currently `frameFocus` and renames to `pageFocus` in the migration.)
+- **Gate** (a.k.a. **input gate**) — `aboveView.setVisible(...)` predicate. Open in canvas mode iff `pageFocus === null`. The single arbiter of who receives canvas-region pointer events.
 - **Pointer router** — `src/renderer/above-view/useCanvasPointerRouter.ts`. Single window-level capture-phase pointerdown listener that runs the shared `hitTest` and dispatches a typed `CanvasPointerAction`. Yields to any element inside `[data-overlay-ui]`.
 - **Hit-test priority table** — 5 layers, top wins: `resize-handles > chrome (geometric) > anchors > body > background`. Lives in `src/shared/hit-test.ts`. Geometric only — DOM overlay UI in aboveView resolves above all of them structurally.
 
@@ -33,7 +33,7 @@ Follows [JSON Canvas v1.0](https://jsoncanvas.org) on disk; uses Specular-native
 
 Per [ADR 0002](./docs/adr/0002-canvas-anchored-overlay-ui.md). All canvas-anchored UI renders in aboveView's React tree, marked `data-overlay-ui` so the pointer router yields.
 
-- **`CanvasItemChrome`** — persistent overlay UI rendered while an entity exists. Examples: frame URL bar / nav buttons, file chrome buttons, group rename label.
+- **`CanvasItemChrome`** — persistent overlay UI rendered while an entity exists. Examples: page URL bar / nav buttons, file chrome buttons, group rename label.
 - **`CanvasItemPopup`** — selection-state-driven overlay UI. Mounts when an entity is in a particular selection sub-state, unmounts when it leaves. Right-click context menus are out of scope.
 - **`useAnchoredPosition(entityId, slot)`** — pure positioning hook. Reads the layout broadcast aboveView already receives, returns screen-space coords for the entity's chrome slot.
 - **`EntityChrome` compound** — the `Root / DragTrigger / Title / Actions / Button` primitives composed inside `CanvasItemChrome` consumers. Style once, compose differently per consumer.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,43 @@ Follows [JSON Canvas v1.0](https://jsoncanvas.org) on disk; uses Specular-native
 - **Space** — a folder of canvases (Obsidian-vault analogue).
 - **Page** — Specular's term for live web items: a URL rendered at a particular viewport size at a particular position on the canvas. The runtime `Page` (the `WebContentsView` wrapper in `src/main/runtime/page-factory.ts`) is the same concept — there is no separate "frame entity vs page wrapper" duality. Multiple pages can share the same URL (the multi-breakpoint workflow). Serialized as JSON Canvas `link` nodes; the serializer is the only place the two names meet. See [ADR 0003](./docs/adr/0003-page-as-canonical-name-for-live-web-items.md).
 
+## Text affordances
+
+The `text` and `file` kinds back three user-facing affordances. The toolbar exposes them under a single **`Add text ▾`** dropdown.
+
+| UX affordance | What it is | Spec mapping |
+|---|---|---|
+| **Text** | Short text, no background. Plain floating text on the canvas. | `text` node + `specular.textStyle: 'plain'` |
+| **Sticky note** | Short text inside a colored card. Padding, bg color. The default. | `text` node + `specular.textStyle: 'sticky'` |
+| **Document** | Longer markdown content as a `.md` file on disk; reusable across canvases. | `file` node, markdown renderer (selected by extension via `src/main/plugins/registry.ts`) |
+
+Text and Sticky note are the same `text` kind with a render-style toggle. Document is a separate `file` kind because its content lives on disk, not in the `.canvas` JSON.
+
+Default `textStyle` when the field is absent is `'sticky'` — preserves rendering of legacy canvases without migration. New "Add text" placements stamp `'plain'`.
+
+## Specular extensions to JSON Canvas
+
+JSON Canvas v1.0 tolerates additional fields on nodes; Specular adds its own under a single namespaced object so they don't collide with other tools' extensions and so this glossary can list them in one place:
+
+```jsonc
+{
+  "id": "...",
+  "type": "text",
+  "x": 0, "y": 0, "width": 200, "height": 60,
+  "text": "...",
+  "specular": {
+    "textStyle": "plain"   // 'plain' | 'sticky'
+    // future Specular-only fields go here
+  }
+}
+```
+
+Conventions:
+- Specular-only fields live under the top-level `specular: {}` object.
+- Reading other tools' canvases: missing fields fall back to documented defaults.
+- Reading our canvases in other tools: the `specular` object is silently ignored; nodes still render as standard JSON Canvas (text/file/link/group).
+- Genuinely new node kinds (`drawing`, `shape`) remain top-level `type` values, since they aren't JSON Canvas spec kinds and no fallback rendering is meaningful.
+
 ## Entity geometry
 
 - **Entity rect** — the full bounding rect of an entity, body + chrome as one layout unit ([ADR 0002](./docs/adr/0002-canvas-anchored-overlay-ui.md)). Pan / zoom / drag / resize operate on this rect.

--- a/docs/adr/0003-page-as-canonical-name-for-live-web-items.md
+++ b/docs/adr/0003-page-as-canonical-name-for-live-web-items.md
@@ -1,6 +1,7 @@
 # ADR 0003 — `Page` as the canonical name for live web items
 
 **Status:** Accepted
+**Implementation:** Not started — see Migration plan section. CONTEXT.md uses the new vocabulary; runtime / IPC / components still use `frame`.
 **Date:** 2026-05-08
 **Supersedes premise of:** the `frame` entity-kind name and the parallel runtime/entity vocabulary that came with it (e.g. `PersistedFrameEntity` ↔ runtime `Page` WCV wrapper).
 **Related:** [ADR 0001 — click-to-enter frame focus](./0001-click-to-enter-frame-focus.md), [ADR 0002 — canvas-anchored overlay UI](./0002-canvas-anchored-overlay-ui.md). Both ADRs were authored under the old name and are not being rewritten; their behavior is unchanged.

--- a/docs/adr/0003-page-as-canonical-name-for-live-web-items.md
+++ b/docs/adr/0003-page-as-canonical-name-for-live-web-items.md
@@ -1,0 +1,92 @@
+# ADR 0003 — `Page` as the canonical name for live web items
+
+**Status:** Accepted
+**Date:** 2026-05-08
+**Supersedes premise of:** the `frame` entity-kind name and the parallel runtime/entity vocabulary that came with it (e.g. `PersistedFrameEntity` ↔ runtime `Page` WCV wrapper).
+**Related:** [ADR 0001 — click-to-enter frame focus](./0001-click-to-enter-frame-focus.md), [ADR 0002 — canvas-anchored overlay UI](./0002-canvas-anchored-overlay-ui.md). Both ADRs were authored under the old name and are not being rewritten; their behavior is unchanged.
+
+## Context
+
+Specular's data model originally used three different names for the same concept depending on the layer:
+
+- **Disk format (JSON Canvas spec):** `link` node — a URL-pointing node in `.canvas` files.
+- **Runtime / persistence (entity layer):** `frame` — `PersistedFrameEntity`, `entity.kind === 'frame'`, `frameFocus`, `serializeFrameToLinkNode`, etc.
+- **Runtime / lifecycle (the `WebContentsView` wrapper):** `Page` — `page-factory.ts`, `findPageById`, the actual Electron-side object that loads, paints, and runs JS.
+
+The entity-side `frame` and the WCV-side `Page` are 1:1 with each other. They were never two concepts; they were one concept with two names because the WCV wrapper landed first and the entity vocabulary was added later under "frame" by analogy with HTML `<iframe>`.
+
+The split was tolerable but had ongoing costs:
+
+1. **Two redundant nouns** for the same thing in code, requiring everyone (and every future agent) to learn the mapping.
+2. **Figma vocabulary friction.** Specular's audience is designers and frontend developers (`docs/product.md`). Figma's "Frame" is a *container/artboard* primitive — closer to Specular's `Group` than to a URL viewport. Users brought the Figma mental model and had to unlearn it.
+3. **The `Browser mode` view toggle** introduced in 2026-Q1 reads naturally as showing pages-as-tabs — not "frames-as-tabs." The toolbar already half-leaned toward a different vocabulary.
+4. **The multi-breakpoint workflow** (`docs/product.md` "common workflows") describes "the same site at phone, tablet, desktop widths." `Page` extends naturally to that ("three pages of stripe.com at three breakpoints"); `Frame` is narrower and required a separate "breakpoint cluster" concept to talk about variants.
+
+Candidates considered: `Frame` (status quo), `Page`, `Site`, `Link`, `URL`, `View`, `Tab`, `Window`, `Web view`, `Embed`. Evaluation matrix:
+
+| Term | Reads as noun | Multi-of-same-URL workflow | Implies live + rendered | No edge collision | No Figma collision | No internal-codebase clash | Spec-aligned |
+|---|---|---|---|---|---|---|---|
+| **Page** | ✓ | slight weirdness (page = URL) | neutral | ✓ | ✓ | **unifies with runtime `Page`** | ✗ |
+| Frame | ✓ | requires separate "variant" noun | yes (iframe heritage) | ✓ | ✗ Figma | ✓ | ✗ |
+| Link | ✓ | "three links to stripe" — passive | ✗ | ✗ collides with edges | ✓ | ✓ | ✓ exact spec match |
+| URL | ✗ it's a string | ✗ | ✗ | ✓ | ✓ | conflicts with the `url` field on the entity | ✗ |
+| Site | ✓ | ✗ a site IS the URL | ✓ | ✓ | ✓ | ✓ | ✗ |
+| View | ⚠️ generic | ✓ "phone view, tablet view" | ⚠️ | ✓ | ✓ | ✗✗ overloaded (`bgView`, `aboveView`, view-mode) | ✗ |
+| Tab | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ workspace tabs | ✗ |
+| Window | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ Electron `BrowserWindow` | ✗ |
+
+`Page` is the only candidate that survives every cut **and** unifies a redundant pair of names already in the codebase. The slight weakness — that *"three pages of stripe.com"* is mildly weird because casually a page = a URL — is handled by giving the variant relationship its own noun (a "breakpoint", or a "breakpoint variant"), not by overloading the entity name.
+
+## Decision
+
+`Page` is the canonical name for the live-web-item entity kind, end-to-end:
+
+- **User-facing** — toolbar says "Add page", sidebar lists pages, docs talk about pages.
+- **Component layer** — `<PageChrome>`, `PageBodyLayer`, etc.
+- **Runtime / persistence** — `entity.kind === 'page'`, `PersistedPageEntity`, `pageFocus`, `serializePageToLinkNode`. The runtime WCV wrapper (already called `Page`) is the same concept — no longer a separate noun.
+- **JSON Canvas disk format** — still serialized as `type: 'link'` per spec. The serializer is the *only* place the two names meet.
+
+A page is defined as: **a URL rendered at a particular viewport size at a particular position on the canvas.** Multiple pages can share the same URL (multi-breakpoint workflow); they remain independent entities.
+
+ADRs 0001 and 0002 are not rewritten. They use "frame" for historical accuracy. The CONTEXT.md glossary entry for `Page` notes the rename.
+
+## Consequences
+
+**Replaces:**
+- The `frame` entity-kind name across `src/main/runtime/`, `src/shared/types.ts`, IPC channel names (`canvas-frame-*` → `canvas-page-*`), preload bridges, and component names. One sweeping rename PR.
+- The "frame entity vs page wrapper" mental-model split. They are now one concept with one name.
+- The toolbar label "Add Frame" → "Add page".
+
+**Enables:**
+- One vocabulary across all four layers (UI / runtime / IPC / persistence) for the most common entity kind.
+- A clean home for breakpoint-variant terminology (a *breakpoint* is a property of a page, not a separate entity kind).
+- Removes the Figma-Frame mental-model friction for new users.
+
+**Costs:**
+- Sweeping rename touching ~100 identifiers, ~5 IPC channel names, type aliases, smoke-test references, and comments. Mechanical but real.
+- ADRs 0001 and 0002 retain "frame" terminology; readers of those documents must mentally translate. The CONTEXT.md glossary points them at this ADR.
+- The serializer translation (`PersistedPageEntity` ↔ JSON Canvas `link`) remains. The function renames from `serializeFrameToLinkNode` to `serializePageToLinkNode` but the bridge persists. We accept the divergence from spec because spec alignment alone is not enough to outweigh the internal unification win and the Figma-friction cost.
+
+**Out of scope:**
+- Renaming JSON Canvas `link` nodes upstream. The spec is what it is; we serialize to it.
+- Folding the `Page` runtime wrapper into the entity layer. They remain in their respective process layers (main vs runtime mutation), they just share a name now.
+- Renaming `Browser mode` (the view toggle). It already reads correctly with the new vocabulary ("Browser mode shows pages as tabs").
+
+## Migration plan
+
+The rename ships as one PR (rather than incrementally) so partial states don't confuse contributors. Sequence within the PR:
+
+1. `src/shared/types.ts` — `CanvasEntityKind` `'frame'` → `'page'`; type aliases `PersistedFrameEntity` → `PersistedPageEntity`, etc.
+2. `src/main/runtime/` — rename all `frame` references in entity state, selection, layout. The existing runtime `Page` (in `page-factory.ts`) keeps its name and now has matching entity vocabulary.
+3. IPC channels — `canvas-frame-*` → `canvas-page-*`; update preload bridges and renderer subscribers.
+4. Components — `<FrameChrome>` → `<PageChrome>`, `FrameBodyLayer` → `PageBodyLayer`, etc.
+5. `serializeFrameToLinkNode` → `serializePageToLinkNode`; serializer continues to emit/read `type: 'link'`.
+6. Toolbar copy: "Add Frame" → "Add page"; sidebar labels; cursor labels.
+7. Tests — smoke and unit tests follow the rename.
+8. Docs — `CLAUDE.md`, `docs/product.md`, `docs/architecture.md`, `docs/file-formats.md` updated. ADRs 0001/0002 left as-is with a brief note.
+
+## Tests
+
+- Smoke: existing `frame`-named scenarios renamed; behavior unchanged.
+- Unit: serializer round-trip test verifies `PersistedPageEntity` → `link` node → `PersistedPageEntity`.
+- Type checking: `pnpm typecheck` is the primary gate for the rename.

--- a/docs/adr/0004-text-affordances-and-spec-extensions.md
+++ b/docs/adr/0004-text-affordances-and-spec-extensions.md
@@ -1,0 +1,133 @@
+# ADR 0004 — Text affordances (Text / Sticky note / Document) and the Specular spec-extension convention
+
+**Status:** Accepted
+**Date:** 2026-05-08
+**Supersedes premise of:** the toolbar's "Add Text Block" + "Add Note" buttons, and the implicit assumption that a single `text` kind has one render style.
+**Related:** [ADR 0003 — Page as canonical name for live web items](./0003-page-as-canonical-name-for-live-web-items.md). Both ADRs originate from a single naming pass on canvas items and tools (CONTEXT.md update, 2026-05-08).
+
+## Context
+
+Users want **three** distinct text-ish affordances on the canvas:
+
+1. **Short titles** — plain text, no background. Headings, labels, captions.
+2. **Sticky notes** — short text in a colored card. Quick thoughts, comments.
+3. **Longer markdown documents** — full markdown content, reusable across canvases.
+
+The codebase had only **two** placement tools, neither of which matched the desired model:
+
+- **"Add Text Block"** (sticky-note icon) → `text` entity, rendered with the sticky-note treatment. No way to create plain unbacked text.
+- **"Add Note"** (file-text icon) → `file` entity, markdown-rendered. Confusing: "Note" sounded like the sticky-note button, but actually created a file-backed document.
+
+Icons and labels were inverted (StickyNote icon for "Text Block", FileText icon for "Note"), and there was no toolbar entry for the most basic case — a plain title on the canvas.
+
+JSON Canvas v1.0 (`https://jsoncanvas.org/spec/1.0/`) defines four node types as a flat list: `text` (inline), `file` (path on disk), `link` (URL), `group` (container). It does *not* define a third text kind, but it tolerates additional fields on nodes — every JSON Canvas tool ignores fields it doesn't recognize.
+
+So the design problem split in two:
+
+1. **How to express three affordances on top of a spec with only two relevant kinds.**
+2. **What conventions to use for Specular-only fields on disk** so they don't collide with other tools' extensions and so future Specular-only fields are easy to find and document.
+
+## Decision
+
+### 1. Three text affordances mapped to the spec
+
+| UX affordance | Toolbar label | Spec mapping |
+|---|---|---|
+| Short text, no background | **Text** | `text` node + `specular.textStyle: 'plain'` |
+| Sticky note (short text + bg color) | **Sticky note** | `text` node + `specular.textStyle: 'sticky'` (the default) |
+| Longer markdown document | **Document** | `file` node, markdown renderer (selected by extension via `src/main/plugins/registry.ts`) |
+
+Text and Sticky note are the same `text` kind, distinguished only by a render-style toggle. Document is a separate kind because its content lives on disk, not in the `.canvas` JSON — that distinction is meaningful (file-backed documents can be referenced from other canvases, edited outside Specular, version-controlled independently).
+
+The three placement tools are grouped under a single **`Add text ▾`** dropdown in the toolbar (mirroring the existing `Add Shape ▾` pattern):
+
+```
+Select | Add page ▾ | Add text ▾ | Add shape ▾ | Comments | Draw | Region select | Inspect
+                       ↓
+                       Text
+                       Sticky note
+                       Document
+```
+
+### 2. Spec-extension convention: namespaced `specular: {}` object
+
+Specular-only fields live under a top-level `specular: {}` object on each node:
+
+```jsonc
+{
+  "id": "...",
+  "type": "text",
+  "x": 0, "y": 0, "width": 200, "height": 60,
+  "text": "...",
+  "specular": {
+    "textStyle": "plain"
+  }
+}
+```
+
+Conventions:
+- Specular-only fields live under `specular: {}`. No other Specular fields go at the top level.
+- Reading our canvases in other tools: the `specular` object is silently ignored; the node still renders as a standard JSON Canvas `text`/`file`/`link`/`group`.
+- Reading other tools' canvases in Specular: missing `specular` fields fall back to documented defaults (e.g. missing `textStyle` → `'sticky'`).
+- Genuinely new node *kinds* (`drawing`, `shape`) remain top-level `type` values rather than going under `specular: {}`. They aren't spec kinds and no fallback rendering would be meaningful, so namespacing the kind itself buys nothing and would just complicate the discriminated union.
+
+### 3. Default `textStyle` is `'sticky'`
+
+Every existing `text` entity in every existing canvas has no `specular.textStyle` field. The renderer treats missing as `'sticky'`, preserving current rendering for all legacy canvases. New "Add text" placements stamp `'plain'` explicitly. No file migration needed.
+
+### 4. `color` interpretation is style-dependent
+
+The spec's optional `color` field has different meaning per style:
+- `textStyle: 'sticky'` — `color` is the bg color of the card.
+- `textStyle: 'plain'` — `color` is the text color.
+
+Both interpretations are reasonable readings of "node color"; this choice keeps the spec field useful in both modes.
+
+## Alternatives considered
+
+**A. Top-level `textStyle` field, no namespacing.** Simplest. Risks collision if another JSON Canvas tool ever adopts the same field name with different semantics. Rejected — namespacing is cheap insurance.
+
+**B. Use absence/presence of `color` to imply plain vs sticky.** Conflates color and style; can't have a colored plain title. Rejected.
+
+**C. Add a third spec-extension kind (e.g. `note` for sticky, `text` for plain).** Adds disk-format complexity for what is one kind with two render modes; serializer would have to translate; other tools wouldn't render the new kind at all. Rejected — `drawing` and `shape` are kinds because they have *no* spec equivalent, but sticky vs plain text is one kind with two appearances.
+
+**D. Names: Title / Sticky note / Document.** Considered as the toolbar labels. "Text" beat "Title" because (i) "Text" is more discoverable for users scanning for "how do I add text?", (ii) it matches the Figma "T" tool muscle memory, and (iii) it agrees with the underlying spec node name `text`.
+
+**E. Three separate top-level toolbar buttons instead of an `Add text ▾` dropdown.** Considered. The dropdown wins for symmetry with `Add Shape ▾` and reduces toolbar visual weight; users still get one click + one menu pick.
+
+## Consequences
+
+**Replaces:**
+- Toolbar buttons "Add Text Block" and "Add Note" → folded into the `Add text ▾` dropdown with three items: Text / Sticky note / Document.
+- The implicit one-style-per-`text`-kind assumption.
+
+**Enables:**
+- A single namespaced extension point (`specular: {}`) for any future Specular-only field — text variants, layout hints, agent metadata, etc.
+- Future text styles (`callout`, `quote`, `code`) added as new `textStyle` values without schema changes.
+- Round-trip compatibility with other JSON Canvas tools: our canvases open elsewhere as plain text/file/link/group; their canvases open in Specular with sticky-default rendering.
+
+**Costs:**
+- Existing `text` entities pick up an implicit `'sticky'` reading. New "Add text" tool stamps `'plain'` explicitly. The renderer must handle both.
+- The `Add text ▾` dropdown is one more interaction layer than three separate buttons — one click + one menu pick instead of one click. Mitigated by toolbar real estate gain and symmetry with `Add Shape`.
+- Codebase needs a `textStyle` field on the `text` entity type, the persistence layer, the serializer, and a render branch in the text-entity renderer. Mechanical change.
+
+**Out of scope:**
+- Folding `drawing` and `shape` under `specular: {}`. They remain top-level `type` values for the reasons above.
+- Right-click conversion between text styles (Text ↔ Sticky note). Selection-driven affordance to change style is plausible but separate from this ADR.
+- Document chrome — what UI sits next to a `file`-rendered markdown document. ADR 0002 already covers the `CanvasItemChrome` pattern; specifics of Document chrome are implementation detail.
+
+## Migration
+
+1. Add `textStyle: 'plain' | 'sticky'` to `PersistedTextEntity` (optional — reader defaults to `'sticky'`).
+2. Update `text-entity-state.ts` mutations to accept and persist `textStyle`.
+3. Update serializer: write `specular.textStyle` when set; read it on deserialize.
+4. Toolbar: collapse "Add Text Block" and "Add Note" into the new `Add text ▾` dropdown with three options. IPC channels: `toolbar-add-text-entity` becomes `toolbar-add-text-plain` (or carries a payload `{ style: 'plain' | 'sticky' }`); `toolbar-add-note` renames to `toolbar-add-document`.
+5. Renderer: text-entity renderer branches on `textStyle`. Sticky path is the existing renderer; plain path is new (no card background, just text + position).
+6. Tests: serializer round-trip for both styles; smoke test for the new `Add text ▾` dropdown.
+
+## Tests
+
+- Unit: serializer round-trip — `PersistedTextEntity` with `textStyle: 'plain'` ↔ JSON Canvas `text` node with `specular.textStyle: 'plain'`.
+- Unit: legacy canvas parse — `text` node without `specular.textStyle` deserializes to `textStyle: 'sticky'`.
+- Smoke: `Add text ▾ → Text` places a plain text entity. `Add text ▾ → Sticky note` places a sticky entity. `Add text ▾ → Document` creates a file entity with a markdown extension.
+- Manual: open a Specular-saved canvas in Obsidian; verify text and sticky nodes render as plain text, ignoring the `specular` field.

--- a/docs/adr/0004-text-affordances-and-spec-extensions.md
+++ b/docs/adr/0004-text-affordances-and-spec-extensions.md
@@ -1,6 +1,7 @@
 # ADR 0004 — Text affordances (Text / Sticky note / Document) and the Specular spec-extension convention
 
 **Status:** Accepted
+**Implementation:** Not started — see Migration section. CONTEXT.md documents the three affordances and the `specular.textStyle` field; toolbar still has the old "Add Text Block" + "Add Note" buttons; the renderer has no plain/sticky branch yet; the `specular: {}` extension object is not yet emitted by the serializer.
 **Date:** 2026-05-08
 **Supersedes premise of:** the toolbar's "Add Text Block" + "Add Note" buttons, and the implicit assumption that a single `text` kind has one render style.
 **Related:** [ADR 0003 — Page as canonical name for live web items](./0003-page-as-canonical-name-for-live-web-items.md). Both ADRs originate from a single naming pass on canvas items and tools (CONTEXT.md update, 2026-05-08).

--- a/docs/adr/0005-unified-tool-concept.md
+++ b/docs/adr/0005-unified-tool-concept.md
@@ -1,0 +1,110 @@
+# ADR 0005 — Unified `Tool` concept
+
+**Status:** Accepted
+**Date:** 2026-05-08
+**Supersedes premise of:** the three parallel state machines for `pendingPlacement`, `AnnotationMode` (`'off' | 'comment' | 'draw' | 'region_select'`), and the standalone `inspect` boolean. Also retires the term "annotation mode" as a name for runtime state.
+**Related:** [ADR 0004 — Text affordances](./0004-text-affordances-and-spec-extensions.md). The tool list reflects the post-0004 toolbar (`add-text` carries a `style` field for plain vs sticky; `add-document` replaces `add-note`).
+
+## Context
+
+The codebase had three parallel state machines that all answered the same user-level question — *"what does my next click/gesture do?"* — but used different names, different storage, and different IPC channels:
+
+1. **Placement tools** — runtime variable `pendingPlacement: { entityKind, ... } | null`. One-shot: click toolbar button, place once on canvas, auto-revert.
+2. **Annotation modes** — `AnnotationMode = 'off' | 'comment' | 'draw' | 'region_select'`. Persistent: toggle on, do gestures, toggle off.
+3. **Inspect** — separate boolean. Persistent.
+
+Plus the implicit `select` default, which had no representation in state at all.
+
+The same user concept ("I'm currently in the comment tool") had three different expressions in code. Effects:
+
+- **Toolbar wiring is duplicated**: each tool family has its own IPC handlers, its own click-to-toggle pattern, its own cursor-label logic.
+- **Mutual exclusion isn't enforced**: in principle you could be in placement-mode + annotation-mode + inspect simultaneously. Today only convention prevents it.
+- **Keyboard shortcuts are absent**: there's no single state to bind keys against. Adding `T` for text or `P` for page would touch three subsystems.
+- **Onboarding burden**: new users (and new contributors) have to learn three vocabularies for one concept.
+
+This is the kind of accidental complexity that compounds — every new tool adds another branch in another state machine.
+
+## Decision
+
+A **Tool** is the single representation of *"what does my next click/gesture do?"* There is exactly one active tool at any moment.
+
+```ts
+type Tool =
+  | { kind: 'select' }                                                       // default
+  | { kind: 'add-page' }                                                     // one-shot
+  | { kind: 'add-text'; style: 'plain' | 'sticky' }                          // one-shot
+  | { kind: 'add-document' }                                                 // one-shot
+  | { kind: 'add-shape'; shapeKind: 'rectangle' | 'ellipse' | 'diamond' }    // one-shot
+  | { kind: 'comment' }                                                      // persistent
+  | { kind: 'draw' }                                                         // persistent — creates drawing entities
+  | { kind: 'region-select' }                                                // persistent
+  | { kind: 'inspect' }                                                      // persistent
+```
+
+Stored in main runtime as `activeTool: Tool` (default `{ kind: 'select' }`). A small per-kind lookup table `toolDuration: Record<Tool['kind'], 'one-shot' | 'persistent'>` lets the runtime decide when to auto-revert to `select`.
+
+**One-shot tools** revert to `select` after one placement.
+**Persistent tools** stay active until replaced by another tool, toggled off (clicking the same toolbar button while active), or Escape.
+
+**Naming choices made within the decision:**
+
+- **"Tool"** as the umbrella concept — universal industry term (Figma, Sketch, Photoshop, Illustrator). Alternatives considered: *Mode* (overloaded with view mode), *Cursor* (too presentational), *Action* (too verb-y).
+- **`add-` prefix for placement tools** — matches the toolbar verbiage ("Add page", "Add text"). Alternatives: *place-* (less natural in the UI), bare nouns (collide with entity-kind names).
+- **`select` is a tool**, not the absence of one. Gives the default a real name and makes `activeTool` always-defined, simplifying every consumer.
+
+**Toolbar does NOT visually distinguish one-shot from persistent tools.** Users learn duration by use, matching Figma's convention. The toolbar is a single uniform palette.
+
+**View mode (canvas vs browser) is NOT a tool.** It's structural — *"which surface am I looking at?"* — not transient. Stays in its own state.
+
+## Alternatives considered
+
+**A. Keep three state machines, just align names.** Cosmetic fix, leaves accidental complexity, doesn't enable keyboard shortcuts cleanly. Rejected.
+
+**B. Unify only placement + annotation; keep inspect separate.** Half-measure; inspect behaves identically to annotation tools (persistent, gesture-driven, exit-on-Escape). No reason for it to be its own state. Rejected.
+
+**C. Encode `duration` on each Tool variant rather than a lookup table.** Adds a property to every variant, forcing every consumer to think about durations they don't care about. Lookup table keeps the union narrow. Rejected.
+
+**D. Distinguish one-shot vs persistent in the toolbar (e.g. dotted border on persistent ones).** Considered. Figma doesn't bother and users adapt fast; visual indicators are visual noise without a real payoff. Rejected.
+
+**E. Include view mode in the Tool union.** Conflates two different state dimensions: the active tool can change inside either view mode. Rejected.
+
+## Consequences
+
+**Replaces:**
+- `pendingPlacement` runtime variable, `AnnotationMode` enum, the `inspect` boolean → all three collapse into `activeTool: Tool`.
+- IPC channels: `toolbar-add-page`, `toolbar-add-text-entity`, `toolbar-add-note`, `toolbar-add-shape`, `toolbar-toggle-annotate-mode`, `toolbar-toggle-draw-mode`, `toolbar-toggle-region-select-mode`, `toolbar-toggle-inspect-mode` → one channel `toolbar-set-tool` carrying a `Tool` payload.
+- The term "annotation mode" as a name for runtime state. Annotations themselves remain (comments and drawings are still annotations); the *mode of being in the comment tool* is just a tool.
+
+**Enables:**
+- Single source of truth for "what's the active tool" — derive cursor labels, toolbar highlight, hit-test branching, keyboard shortcuts from one state.
+- Keyboard shortcuts trivial to add (`V` → select, `T` → add-text, `P` → add-page, `S` → add-shape, `C` → comment, `D` → draw, `I` → inspect — exact bindings TBD).
+- New tools added by extending the union and the duration table, not by inventing a new state machine.
+- Glossary gets one entry; ADRs reference one concept.
+
+**Costs:**
+- Real refactor: three state machines collapse into one. Touches main runtime, IPC, toolbar, cursor-label rendering, and any code that branched on `pendingPlacement` / `AnnotationMode` / `inspect`.
+- Existing tests that reference annotation-mode terminology need renaming (mechanical).
+- `frame-focus` and `editing-text` carve-outs in `gate-predicate.test.ts` need to be re-expressed in terms of `activeTool` where they intersected with `AnnotationMode`.
+
+**Out of scope:**
+- Keyboard shortcut bindings — enabled by this ADR but the specific keys are a follow-up.
+- Right-click context-menu integration — separate concern.
+- Tool palette UI redesign — toolbar layout is unchanged; only the underlying state collapses.
+- Multi-tool / "modifier" tools (e.g. hold Space to temporarily activate pan) — orthogonal; modifier state is layered over `activeTool`, not part of the union.
+
+## Migration
+
+1. Define the `Tool` discriminated union and `toolDuration` table in `src/shared/tool.ts`.
+2. Add `activeTool: Tool` to main runtime; default `{ kind: 'select' }`. Remove `pendingPlacement`, `AnnotationMode`, `inspect` boolean.
+3. Replace toolbar IPC with one channel: `toolbar-set-tool` (renderer → main) and `tool-changed` (main → renderers, layered on the existing layout broadcast).
+4. Toolbar buttons fire `setTool({ kind: ... })` and read `activeTool` to highlight the active button. Add the `Add text ▾` dropdown items per ADR 0004.
+5. Cursor-label and status-bar narration derive from `activeTool` via the gerund mapping (`select` → "selecting", `add-page` → "adding page", etc.).
+6. Hit-test / pointer router branches that depended on annotation-mode flags re-route through `activeTool`.
+7. Tests: smoke tests that toggled `AnnotationMode` now call `setTool`. Unit tests cover the duration auto-revert and Escape behavior.
+
+## Tests
+
+- Unit: `setTool` auto-reverts a one-shot tool to `select` after a placement event; persistent tools do not auto-revert; Escape returns to `select` from any tool; `select` ↔ `select` is a no-op.
+- Unit: cursor-label gerund mapping for every tool kind.
+- Smoke: clicking each toolbar button sets `activeTool` correctly; the active button is highlighted; placing a one-shot tool entity returns to `select`; toggling a persistent tool a second time returns to `select`.
+- Smoke: keyboard `Escape` exits any active tool to `select`.

--- a/docs/adr/0005-unified-tool-concept.md
+++ b/docs/adr/0005-unified-tool-concept.md
@@ -1,6 +1,7 @@
 # ADR 0005 — Unified `Tool` concept
 
 **Status:** Accepted
+**Implementation:** Not started — see Migration section. CONTEXT.md documents the `Tool` union; runtime still has the three parallel state machines (`pendingPlacement`, `AnnotationMode`, the `inspect` boolean) and three corresponding IPC families.
 **Date:** 2026-05-08
 **Supersedes premise of:** the three parallel state machines for `pendingPlacement`, `AnnotationMode` (`'off' | 'comment' | 'draw' | 'region_select'`), and the standalone `inspect` boolean. Also retires the term "annotation mode" as a name for runtime state.
 **Related:** [ADR 0004 — Text affordances](./0004-text-affordances-and-spec-extensions.md). The tool list reflects the post-0004 toolbar (`add-text` carries a `style` field for plain vs sticky; `add-document` replaces `add-note`).

--- a/src/main/runtime/group-entity-state.ts
+++ b/src/main/runtime/group-entity-state.ts
@@ -3,7 +3,6 @@ import type {
   CanvasSceneGroupEntity,
   PersistedGroupEntity,
   WorkspaceGroup,
-  WorkspaceGroupKind,
   WorkspaceGroupLayoutMode,
 } from '../../shared/types'
 import { workspaceGroups } from './workspace-model'
@@ -23,7 +22,6 @@ export function createGroupEntity(input: {
   width?: number
   height?: number
   parentGroupId?: string
-  groupKind?: WorkspaceGroupKind
   layoutMode?: WorkspaceGroupLayoutMode
   managedLayout?: boolean
   sourceTaskId?: string
@@ -39,7 +37,6 @@ export function createGroupEntity(input: {
     width: input.width ?? DEFAULT_GROUP_WIDTH,
     height: input.height ?? DEFAULT_GROUP_HEIGHT,
     parentGroupId: input.parentGroupId,
-    groupKind: input.groupKind ?? 'manual',
     layoutMode: input.layoutMode ?? 'freeform',
     managedLayout: input.managedLayout ?? false,
     sourceTaskId: input.sourceTaskId,
@@ -63,7 +60,6 @@ export function updateGroupEntity(
   if (patch.width !== undefined) group.width = patch.width
   if (patch.height !== undefined) group.height = patch.height
   if (patch.parentGroupId !== undefined) group.parentGroupId = patch.parentGroupId
-  if (patch.groupKind !== undefined) group.groupKind = patch.groupKind
   if (patch.layoutMode !== undefined) group.layoutMode = patch.layoutMode
   if (patch.managedLayout !== undefined) group.managedLayout = patch.managedLayout
   if (patch.sourceTaskId !== undefined) group.sourceTaskId = patch.sourceTaskId
@@ -109,7 +105,6 @@ export function buildGroupSceneEntity(
     screenWidth: group.width * zoom,
     screenHeight: group.height * zoom,
     parentGroupId: group.parentGroupId,
-    groupKind: group.groupKind,
     layoutMode: group.layoutMode,
     managedLayout: group.managedLayout,
     entityIds,
@@ -127,7 +122,6 @@ export function persistGroupEntity(group: WorkspaceGroup): PersistedGroupEntity 
     width: group.width,
     height: group.height,
     parentGroupId: group.parentGroupId,
-    groupKind: group.groupKind,
     layoutMode: group.layoutMode,
     managedLayout: group.managedLayout,
     sourceTaskId: group.sourceTaskId,

--- a/src/main/runtime/inspect-session.ts
+++ b/src/main/runtime/inspect-session.ts
@@ -368,7 +368,6 @@ function buildGroupEntityDetail(entityId: string): PanelGroupEntityDetail | unde
     id: group.id,
     label: group.label,
     color: group.color,
-    groupKind: group.groupKind,
     layoutMode: group.layoutMode,
     entityIds: group.entityIds ?? [],
   }

--- a/src/main/runtime/json-canvas-serializer.ts
+++ b/src/main/runtime/json-canvas-serializer.ts
@@ -205,7 +205,6 @@ function serializeGroupEntityToGroupNode(entity: PersistedGroupEntity): JsonCanv
     label: entity.label,
     color: entity.color,
     // App-specific extensions
-    groupKind: entity.groupKind,
     layoutMode: entity.layoutMode,
     parentGroupId: entity.parentGroupId,
     managedLayout: entity.managedLayout,
@@ -395,7 +394,6 @@ function deserializeGroupNodeToGroup(node: JsonCanvasGroupNode): PersistedGroupE
     height: node.height,
     parentGroupId: node.parentGroupId,
     color: node.groupColor ?? node.color,
-    groupKind: (node.groupKind as PersistedGroupEntity['groupKind']) ?? 'manual',
     layoutMode: (node.layoutMode as PersistedGroupEntity['layoutMode']) ?? 'freeform',
     managedLayout: node.managedLayout ?? false,
     sourceTaskId: node.sourceTaskId,

--- a/src/main/runtime/workspace-restore.ts
+++ b/src/main/runtime/workspace-restore.ts
@@ -169,7 +169,6 @@ export function restoreWorkspaceSnapshot(snapshot: WorkspaceSnapshot): boolean {
             height: entity.height,
             parentGroupId: entity.parentGroupId,
             color: entity.color,
-            groupKind: entity.groupKind,
             layoutMode: entity.layoutMode,
             managedLayout: entity.managedLayout,
             sourceTaskId: entity.sourceTaskId,

--- a/src/main/workspace-frames.ts
+++ b/src/main/workspace-frames.ts
@@ -87,7 +87,6 @@ function ensureManualRowGroup(sourceFrameId: string, url: string): WorkspaceGrou
     width: sourceBounds.width + USER_GROUP_PADDING * 2,
     height: sourceBounds.height + USER_GROUP_PADDING * 2,
     parentGroupId: existingPage?.parentGroupId,
-    groupKind: 'breakpoint_cluster',
     layoutMode: 'row',
     managedLayout: true,
     metadata: {

--- a/src/main/workspace-groups.ts
+++ b/src/main/workspace-groups.ts
@@ -115,7 +115,6 @@ export function createUserGroup(entityIds: string[], label?: string): WorkspaceG
     width: Math.max(USER_GROUP_PADDING * 2, contentBounds.width + USER_GROUP_PADDING * 2),
     height: Math.max(USER_GROUP_PADDING * 2, contentBounds.height + USER_GROUP_PADDING * 2),
     parentGroupId,
-    groupKind: 'manual',
     layoutMode: 'freeform',
     managedLayout: false,
   }

--- a/src/main/workspace-layout-tasks.ts
+++ b/src/main/workspace-layout-tasks.ts
@@ -55,7 +55,7 @@ function clusterBoundsForPresets(presetIndexes: number[]): { width: number; heig
 
 function duplicateClusterWarning(url: string, presetLabels: string[]): string[] {
   const duplicates = workspaceGroups.filter((group) => {
-    if (group.kind !== 'breakpoint_cluster') return false
+    if (group.metadata?.taskKind !== 'breakpoint_map') return false
     return (
       group.metadata?.url === url &&
       JSON.stringify(group.metadata?.presets ?? []) === JSON.stringify(presetLabels)
@@ -208,7 +208,6 @@ export function layoutComponentStates(
     canvasY: placement.canvasY - USER_GROUP_PADDING,
     width: width + USER_GROUP_PADDING * 2,
     height: height + USER_GROUP_PADDING * 2,
-    groupKind: 'component_states',
     layoutMode: 'row',
     managedLayout: true,
     frameIds: [],
@@ -318,7 +317,6 @@ export function applyTaskLayout(
     canvasY: placement.canvasY - USER_GROUP_PADDING,
     width: clusterSize.width + USER_GROUP_PADDING * 2,
     height: clusterSize.height + USER_GROUP_PADDING * 2,
-    groupKind: 'breakpoint_cluster',
     layoutMode: 'row',
     managedLayout: true,
     frameIds: [],

--- a/src/shared/json-canvas-types.ts
+++ b/src/shared/json-canvas-types.ts
@@ -55,7 +55,6 @@ export interface JsonCanvasGroupNode extends JsonCanvasNodeBase {
   background?: string
   backgroundStyle?: 'cover' | 'ratio' | 'repeat'
   // App-specific extensions
-  groupKind?: string
   layoutMode?: string
   frameIds?: string[]
   entityIds?: string[]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -195,7 +195,6 @@ export interface CanvasSceneGroupEntity {
   screenWidth: number
   screenHeight: number
   parentGroupId?: string
-  groupKind: WorkspaceGroupKind
   layoutMode: WorkspaceGroupLayoutMode
   managedLayout: boolean
   entityIds: string[]
@@ -305,7 +304,6 @@ export interface PersistedFileEntity extends CanvasEntityBase {
   metadata?: Record<string, unknown>
 }
 
-export type WorkspaceGroupKind = 'manual' | 'breakpoint_cluster' | 'component_states'
 export type WorkspaceGroupLayoutMode = 'freeform' | 'row' | 'grid'
 
 export interface PersistedGroupEntity extends CanvasEntityBase {
@@ -314,7 +312,6 @@ export interface PersistedGroupEntity extends CanvasEntityBase {
   color?: string
   width: number
   height: number
-  groupKind: WorkspaceGroupKind
   layoutMode: WorkspaceGroupLayoutMode
   managedLayout: boolean
   sourceTaskId?: string
@@ -791,7 +788,6 @@ export interface PanelGroupEntityDetail {
   id: string
   label: string
   color?: string
-  groupKind: WorkspaceGroupKind
   layoutMode: WorkspaceGroupLayoutMode
   entityIds: string[]
 }
@@ -1237,7 +1233,7 @@ export interface ClipboardEntitySelectionPayload {
 
 export interface WorkspaceGroup {
   id: string
-  kind: 'group' | 'breakpoint_cluster' | 'user'
+  kind: 'group'
   label: string
   canvasX: number
   canvasY: number
@@ -1245,7 +1241,6 @@ export interface WorkspaceGroup {
   height: number
   parentGroupId?: string
   color?: string
-  groupKind: WorkspaceGroupKind
   layoutMode: WorkspaceGroupLayoutMode
   managedLayout: boolean
   frameIds?: string[]

--- a/tests/unit/group-membership.test.ts
+++ b/tests/unit/group-membership.test.ts
@@ -24,7 +24,6 @@ function group(
     screenWidth: 100,
     screenHeight: 100,
     parentGroupId,
-    groupKind: 'manual',
     layoutMode: 'freeform',
     managedLayout: false,
     entityIds,

--- a/tests/unit/hit-test.test.ts
+++ b/tests/unit/hit-test.test.ts
@@ -68,7 +68,6 @@ function group(id: string, screenX: number, screenY: number, w = 600, h = 500): 
     screenY,
     screenWidth: w,
     screenHeight: h,
-    groupKind: 'manual',
     layoutMode: 'freeform',
     managedLayout: false,
     entityIds: [],


### PR DESCRIPTION
## Summary

Glossary + decisions of record from a `/grill-with-docs` session on naming canvas items and tools. **This PR is mostly docs. The three new ADRs document decisions; their implementations are deliberate followups, not part of this PR.** Each ADR has an `Implementation: Not started` line in its header so the status is unambiguous.

## What's in this PR

- **CONTEXT.md** — canonical glossary established:
  - Canvas item / Entity / Node split (UI / runtime / disk-spec layers)
  - **Page** replacing **Frame** as the user-facing name for live web items (unifies with the existing runtime `Page` WebContentsView wrapper)
  - **Text / Sticky note / Document** affordances mapped onto JSON Canvas's `text` and `file` kinds via a `specular.textStyle` extension field
  - Unified **`Tool`** concept with one-shot vs persistent durations (replaces three parallel state machines, conceptually)
  - **`specular: {}`** extension namespace convention on JSON Canvas nodes
  - Decision to keep canvas-item kinds **flat** (no families) per the spec

- **CLAUDE.md** — points at CONTEXT.md as required reading; removes the stale `## Terminology` section that had drifted out of sync with the resolved vocabulary.

- **ADR 0003** — Page as canonical name for live web items. *Implementation pending.*
- **ADR 0004** — Text affordances + spec-extension convention. *Implementation pending.*
- **ADR 0005** — Unified `Tool` concept. *Implementation pending.*

- **Code (one small change)** — drops the half-built `WorkspaceGroupKind` discriminator (zero runtime branches consumed it; `layoutMode`, `managedLayout`, and `metadata.taskKind` keep doing the actual work). Fixes a latent bug at `src/main/workspace-layout-tasks.ts:58` where the duplicate-cluster check was comparing `group.kind !== 'breakpoint_cluster'` but `group.kind` is always `'group'` — the warning never fired. Now uses `metadata.taskKind`, which matches what writers set.

## Followup PRs (not in this PR)

Each ADR has a Migration plan; each will land as its own focused PR off `main`:

1. `claude/page-rename` — `frame` → `page` rename per ADR 0003 (sweeps types, IPC channels, runtime variables, components, serializer, toolbar copy)
2. `claude/text-affordances` — `Add text ▾` dropdown + `specular.textStyle` per ADR 0004
3. `claude/unified-tool` — collapse `pendingPlacement` + `AnnotationMode` + `inspect` boolean into `activeTool: Tool` per ADR 0005

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 422/422 passing
- [ ] No smoke tests run — only runtime change is the `groupKind` cleanup, which has unit-test coverage. The bug fix at line 58 is exercise-able by running a `breakpoint_map` task twice with the same URL/presets, but that's an agent-driven path not covered by smoke today.

https://claude.ai/code/session_01FV4rdp4CwbQS5AEQZwzHUy