### PR TITLE
Add URL detection and paste-from-clipboard URL support

### DIFF
--- a/src/main/ipc/register-canvas-entity-ipc.ts
+++ b/src/main/ipc/register-canvas-entity-ipc.ts
@@ -1,5 +1,6 @@
 import { clipboard, ipcMain, Menu, shell } from 'electron'
-import { VIEWPORT_PRESETS } from '../../shared/constants'
+import { DESKTOP_PRESET_INDEX, VIEWPORT_PRESETS } from '../../shared/constants'
+import { looksLikeUrl, normalizeUserUrl } from '../../shared/url'
 import { DRAWING_FEATURE_ENABLED } from '../../shared/featureFlags'
 import type {
   AnnotationCreateRequest,
@@ -478,12 +479,32 @@ export function registerCanvasEntityIpc(): void {
         return
       }
 
-      const payload = parseClipboardSelection(clipboard.readText())
-      if (!payload) return
-      if (payload.version === 2) {
-        pasteEntitiesFromClipboard({ payload, canvasX, canvasY })
-      } else {
-        pastePagesFromClipboard({ payload, canvasX, canvasY })
+      const text = clipboard.readText()
+      const payload = parseClipboardSelection(text)
+      if (payload) {
+        if (payload.version === 2) {
+          pasteEntitiesFromClipboard({ payload, canvasX, canvasY })
+        } else {
+          pastePagesFromClipboard({ payload, canvasX, canvasY })
+        }
+        return
+      }
+
+      const trimmed = text.trim()
+      if (trimmed && !trimmed.includes('\n') && looksLikeUrl(trimmed)) {
+        try {
+          const url = normalizeUserUrl(trimmed)
+          createPageAtPosition({
+            presetIndex: DESKTOP_PRESET_INDEX,
+            canvasX,
+            canvasY,
+            mode: 'paste_url',
+            focus: true,
+            url,
+          })
+        } catch {
+          // Not a valid URL after normalisation — ignore the paste.
+        }
       }
     },
   )

--- a/src/main/workspace-clipboard.ts
+++ b/src/main/workspace-clipboard.ts
@@ -179,6 +179,7 @@ export function pastePagesFromClipboard(input: {
       source: 'manual',
       metadata: {
         createdFrom: 'paste',
+        showDeviceFrame: true,
       },
     })
     return page.id

--- a/src/main/workspace-pages.ts
+++ b/src/main/workspace-pages.ts
@@ -157,7 +157,14 @@ export function addPageFromSource(input: {
       canvasX: placement.canvasX,
       canvasY: placement.canvasY,
       source: 'manual',
-      metadata: setDeviceIdMetadata({ createdFrom: input.mode, deviceOrientation: defaultOrientationForDevice(device) }, device?.id ?? null),
+      metadata: setDeviceIdMetadata(
+        {
+          createdFrom: input.mode,
+          deviceOrientation: defaultOrientationForDevice(device),
+          showDeviceFrame: true,
+        },
+        device?.id ?? null,
+      ),
     })
     if (input.customSize) {
       page.metadata = setCustomPageSizeMetadata(page.metadata, pageContentSize(page))
@@ -210,19 +217,24 @@ export function createPageAtPosition(input: {
   customSize?: boolean
   canvasX: number
   canvasY: number
-  mode: 'add_from_toolbar' | 'duplicate'
+  mode: 'add_from_toolbar' | 'duplicate' | 'paste_url'
   focus?: boolean
+  url?: string
 }): { pageId: string } {
   const preset = VIEWPORT_PRESETS[input.presetIndex]
   if (!preset) {
     throw new Error(`Unknown preset index: ${input.presetIndex}`)
   }
 
-  const url = pageCurrentUrl(input.sourcePageId) ?? 'about:blank'
+  const url = input.url ?? pageCurrentUrl(input.sourcePageId) ?? 'about:blank'
   // Auto-assign device based on the preset so orientation tabs appear immediately
   const matchedDevice = deviceForPresetIndex(input.presetIndex)
   const metadata = setDeviceIdMetadata(
-    { createdFrom: input.mode, deviceOrientation: defaultOrientationForDevice(matchedDevice) },
+    {
+      createdFrom: input.mode,
+      deviceOrientation: defaultOrientationForDevice(matchedDevice),
+      showDeviceFrame: true,
+    },
     matchedDevice?.id ?? null,
   )
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,7 +1,7 @@
 import type { PageConfig } from './types'
 
 // Device dimensions are defined in device-catalog.ts (single source of truth).
-export { VIEWPORT_PRESETS, LAPTOP_PRESET_INDEX } from './device-catalog'
+export { VIEWPORT_PRESETS, LAPTOP_PRESET_INDEX, DESKTOP_PRESET_INDEX } from './device-catalog'
 
 export const TOOLBAR_HEIGHT = 44
 export const GRID_SIZE = 20

--- a/src/shared/device-catalog.ts
+++ b/src/shared/device-catalog.ts
@@ -192,6 +192,7 @@ function buildViewportPresets(): ViewportPreset[] {
 
 export const VIEWPORT_PRESETS: ViewportPreset[] = buildViewportPresets()
 export const LAPTOP_PRESET_INDEX = entries.find((d) => d.id === 'laptop')!.presetIndex
+export const DESKTOP_PRESET_INDEX = entries.find((d) => d.id === 'desktop')!.presetIndex
 
 // --- Custom (no-device) shell constants — uniform balanced bezel ---
 

--- a/src/shared/url.ts
+++ b/src/shared/url.ts
@@ -46,3 +46,27 @@ export function normalizeUserUrl(value: string): string {
 
   return new URL(withScheme).toString()
 }
+
+// A trimmed single-line string is treated as a URL when it either has an
+// explicit http(s) scheme or looks like a bare host (`host.tld[:port][/…]`,
+// `localhost[:port][/…]`). Other schemes (file:, mailto:, javascript:) are
+// rejected so pasting them into the canvas doesn't create a page.
+const BARE_HOST_PATTERN = /^[^\s:/?#]+(?:\.[^\s:/?#]+)+(?::\d+)?(?:[/?#].*)?$/i
+const LOCAL_HOST_PATTERN = /^(?:localhost|\[?::1\]?)(?::\d+)?(?:[/?#].*)?$/i
+const ANY_SCHEME_PREFIX = /^[a-z][a-z0-9+.-]*:/i
+
+export function looksLikeUrl(value: string): boolean {
+  const trimmed = value.trim()
+  if (!trimmed || /\s/.test(trimmed)) return false
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      new URL(trimmed)
+      return true
+    } catch {
+      return false
+    }
+  }
+  if (LOCAL_HOST_PATTERN.test(trimmed)) return true
+  if (ANY_SCHEME_PREFIX.test(trimmed)) return false
+  return BARE_HOST_PATTERN.test(trimmed)
+}

--- a/tests/unit/url.test.ts
+++ b/tests/unit/url.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { looksLikeUrl } from '../../src/shared/url'
+
+describe('looksLikeUrl', () => {
+  it('accepts urls with explicit http(s) scheme', () => {
+    expect(looksLikeUrl('https://example.com')).toBe(true)
+    expect(looksLikeUrl('http://example.com/path?q=1')).toBe(true)
+  })
+
+  it('accepts bare host.tld inputs', () => {
+    expect(looksLikeUrl('example.com')).toBe(true)
+    expect(looksLikeUrl('sub.example.com/path')).toBe(true)
+  })
+
+  it('accepts localhost with optional port', () => {
+    expect(looksLikeUrl('localhost')).toBe(true)
+    expect(looksLikeUrl('localhost:4321')).toBe(true)
+    expect(looksLikeUrl('localhost:4321/garden')).toBe(true)
+  })
+
+  it('rejects plain prose', () => {
+    expect(looksLikeUrl('hello world')).toBe(false)
+    expect(looksLikeUrl('hello')).toBe(false)
+    expect(looksLikeUrl('')).toBe(false)
+  })
+
+  it('rejects multi-line and whitespace-bearing strings', () => {
+    expect(looksLikeUrl('https://a.com\nhttps://b.com')).toBe(false)
+    expect(looksLikeUrl('  https://example.com extra')).toBe(false)
+  })
+
+  it('rejects non-http schemes (avoid file://, javascript:, etc.)', () => {
+    expect(looksLikeUrl('file:///tmp/foo')).toBe(false)
+    expect(looksLikeUrl('javascript:alert(1)')).toBe(false)
+    expect(looksLikeUrl('mailto:hi@example.com')).toBe(false)
+  })
+
+  it('trims surrounding whitespace before evaluating', () => {
+    expect(looksLikeUrl('   https://example.com   ')).toBe(true)
+    expect(looksLikeUrl('   example.com   ')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
This PR adds the ability to paste URLs directly from the clipboard into the canvas, automatically creating a new page at the paste location. It includes a new `looksLikeUrl()` utility function to intelligently detect whether clipboard content appears to be a URL before attempting to create a page.

## Key Changes
- **New URL detection utility** (`src/shared/url.ts`): Added `looksLikeUrl()` function that:
  - Accepts explicit `http://` and `https://` URLs
  - Accepts bare hostnames with optional TLD, port, and path (e.g., `example.com`, `localhost:4321/path`)
  - Rejects non-HTTP schemes (`file://`, `javascript:`, `mailto:`, etc.) for security
  - Rejects multi-line strings and strings with embedded whitespace
  - Trims surrounding whitespace before evaluation

- **Clipboard paste enhancement** (`src/main/ipc/register-canvas-entity-ipc.ts`): Extended paste handler to:
  - First attempt to parse clipboard content as serialized canvas entities (existing behavior)
  - Fall back to URL detection if clipboard contains a single-line string that looks like a URL
  - Create a new page at the paste position with the detected URL using the desktop preset
  - Gracefully ignore invalid URLs after normalization

- **Page creation updates** (`src/main/workspace-pages.ts`):
  - Added `'paste_url'` mode to `createPageAtPosition()` function
  - Added optional `url` parameter to allow specifying the page URL directly
  - Added `showDeviceFrame: true` to metadata for pages created via toolbar, duplication, and URL paste

- **Clipboard paste updates** (`src/main/workspace-clipboard.ts`): Added `showDeviceFrame: true` to metadata for pasted pages

- **Constants export** (`src/shared/constants.ts` and `src/shared/device-catalog.ts`): Exported `DESKTOP_PRESET_INDEX` for use in URL paste operations

## Testing
Added comprehensive unit tests for `looksLikeUrl()` covering:
- HTTP(S) URLs with and without paths/query strings
- Bare hostnames with optional ports and paths
- Localhost with optional ports
- Rejection of plain prose and whitespace-bearing strings
- Rejection of non-HTTP schemes
- Whitespace trimming behavior

https://claude.ai/code/session_01REqQryVN2P78t4N8ofFkz5