### PR TITLE
Inspector: rich tooltip + Chrome-style box model overlay

### DIFF
--- a/src/preload/dom-element-utils.ts
+++ b/src/preload/dom-element-utils.ts
@@ -29,15 +29,20 @@ export function bestElementName(element: Element): string {
   return text ? `${element.tagName.toLowerCase()} "${text}"` : element.tagName.toLowerCase()
 }
 
-function simpleElementSegment(element: Element): string {
-  const tagName = element.tagName.toLowerCase()
+export function elementSelectorParts(element: Element): { tag: string; remainder: string } {
+  const tag = element.tagName.toLowerCase()
   const id = element.getAttribute('id')
-  if (id) return `${tagName}#${id}`
+  if (id) return { tag, remainder: `#${id}` }
   const role = element.getAttribute('role')
-  if (role) return `${tagName}[role="${role}"]`
+  if (role) return { tag, remainder: `[role="${role}"]` }
   const classes = elementClasses(element)
-  if (classes.length) return `${tagName}.${classes.slice(0, 2).join('.')}`
-  return tagName
+  if (classes.length) return { tag, remainder: `.${classes.slice(0, 2).join('.')}` }
+  return { tag, remainder: '' }
+}
+
+function simpleElementSegment(element: Element): string {
+  const { tag, remainder } = elementSelectorParts(element)
+  return `${tag}${remainder}`
 }
 
 export function buildElementPath(element: Element, maxDepth: number): string {

--- a/src/preload/dom-element-utils.ts
+++ b/src/preload/dom-element-utils.ts
@@ -101,10 +101,13 @@ function computedStyleLines(element: Element): string[] {
   return [
     `display=${styles.display}`,
     `position=${styles.position}`,
+    `font-family=${styles.fontFamily}`,
     `font-size=${styles.fontSize}`,
     `font-weight=${styles.fontWeight}`,
     `color=${styles.color}`,
     `background=${styles.backgroundColor}`,
+    `padding=${styles.padding}`,
+    `margin=${styles.margin}`,
   ]
 }
 

--- a/src/preload/dom-inspection.ts
+++ b/src/preload/dom-inspection.ts
@@ -1,6 +1,7 @@
 import { ipcRenderer } from 'electron'
 import {
   deepElementFromPoint,
+  elementClasses,
   inspectionPayload,
 } from './dom-element-utils'
 import { isPageOverlayTarget } from './gesture-forwarding'
@@ -189,7 +190,7 @@ function shortFontFamily(fontFamily: string): string {
   return first.replace(/^['"]|['"]$/g, '')
 }
 
-function buildLabelContent(label: HTMLDivElement, element: Element, payload: ReturnType<typeof inspectionPayload>): void {
+function buildLabelContent(label: HTMLDivElement, element: Element): void {
   const styles = window.getComputedStyle(element)
   label.replaceChildren()
 
@@ -202,10 +203,14 @@ function buildLabelContent(label: HTMLDivElement, element: Element, payload: Ret
     minWidth: '0',
   })
 
-  const labelText = payload.name.trim()
-  const labelMatch = /^([a-zA-Z][\w:-]*)(.*)$/.exec(labelText)
-  const elementType = labelMatch?.[1] ?? labelText
-  const remainder = labelMatch?.[2] ?? ''
+  const elementType = element.tagName.toLowerCase()
+  const idAttr = element.getAttribute('id')
+  const classes = elementClasses(element)
+  const selectorRemainder = idAttr
+    ? `#${idAttr}`
+    : classes.length
+      ? `.${classes.slice(0, 2).join('.')}`
+      : ''
 
   const chip = document.createElement('span')
   Object.assign(chip.style, {
@@ -219,7 +224,7 @@ function buildLabelContent(label: HTMLDivElement, element: Element, payload: Ret
   chip.textContent = elementType
   headerRow.appendChild(chip)
 
-  if (remainder.trim()) {
+  if (selectorRemainder) {
     const name = document.createElement('span')
     Object.assign(name.style, {
       whiteSpace: 'nowrap',
@@ -228,12 +233,12 @@ function buildLabelContent(label: HTMLDivElement, element: Element, payload: Ret
       minWidth: '0',
       opacity: '0.9',
     })
-    name.textContent = remainder.trim()
+    name.textContent = selectorRemainder
     headerRow.appendChild(name)
   }
+
   label.appendChild(headerRow)
 
-  // Row 2: font family rendered in the actual font, plus size/weight
   const fontFamily = shortFontFamily(styles.fontFamily)
   if (fontFamily) {
     const fontRow = document.createElement('div')
@@ -241,7 +246,8 @@ function buildLabelContent(label: HTMLDivElement, element: Element, payload: Ret
       display: 'flex',
       alignItems: 'baseline',
       gap: '6px',
-      marginTop: '4px',
+      marginTop: '6px',
+      whiteSpace: 'nowrap',
       minWidth: '0',
     })
 
@@ -249,10 +255,8 @@ function buildLabelContent(label: HTMLDivElement, element: Element, payload: Ret
     Object.assign(familyName.style, {
       fontFamily: styles.fontFamily,
       fontWeight: styles.fontWeight,
-      fontSize: '14px',
-      lineHeight: '1.1',
+      fontStyle: styles.fontStyle,
       color: '#fff',
-      whiteSpace: 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       minWidth: '0',
@@ -260,14 +264,18 @@ function buildLabelContent(label: HTMLDivElement, element: Element, payload: Ret
     familyName.textContent = fontFamily
     fontRow.appendChild(familyName)
 
-    const fontMeta = document.createElement('span')
-    Object.assign(fontMeta.style, {
-      whiteSpace: 'nowrap',
+    const metaParts = [styles.fontSize, styles.fontWeight]
+    if (styles.letterSpacing && styles.letterSpacing !== 'normal') {
+      metaParts.push(styles.letterSpacing)
+    }
+    const metaRest = document.createElement('span')
+    Object.assign(metaRest.style, {
       opacity: '0.7',
       flexShrink: '0',
     })
-    fontMeta.textContent = `${styles.fontSize} · ${styles.fontWeight}`
-    fontRow.appendChild(fontMeta)
+    metaRest.textContent = `· ${metaParts.join(' · ')}`
+    fontRow.appendChild(metaRest)
+
     label.appendChild(fontRow)
   }
 
@@ -277,7 +285,7 @@ function buildLabelContent(label: HTMLDivElement, element: Element, payload: Ret
     display: 'flex',
     alignItems: 'center',
     gap: '10px',
-    marginTop: '4px',
+    marginTop: '6px',
   })
 
   const addSwatch = (name: string, color: string) => {
@@ -361,7 +369,7 @@ export function updateDomInspectionOverlay(
   updateBoxModelOverlay(element, rect)
 
   domInspectionLabelEl.style.display = 'block'
-  buildLabelContent(domInspectionLabelEl, element, payload)
+  buildLabelContent(domInspectionLabelEl, element)
   const outerPadding = 2
   const labelRect = domInspectionLabelEl.getBoundingClientRect()
   const maxLeft = Math.max(outerPadding, window.innerWidth - Math.ceil(labelRect.width) - outerPadding)

--- a/src/preload/dom-inspection.ts
+++ b/src/preload/dom-inspection.ts
@@ -13,6 +13,17 @@ let domInspectionLabelEl: HTMLDivElement | null = null
 let domInspectionLastTarget: Element | null = null
 let domInspectionPinnedTarget: Element | null = null
 
+// Chrome-style box model overlay: 4 strips for margin (orange, hashed),
+// 4 strips for padding (green, solid). Rendered as fixed-position divs.
+type Side = 'top' | 'right' | 'bottom' | 'left'
+const SIDES: readonly Side[] = ['top', 'right', 'bottom', 'left'] as const
+let domInspectionMarginEls: Record<Side, HTMLDivElement> | null = null
+let domInspectionPaddingEls: Record<Side, HTMLDivElement> | null = null
+
+const MARGIN_COLOR = 'rgba(246, 178, 107, 0.55)'
+const PADDING_COLOR = 'rgba(147, 196, 125, 0.55)'
+const MARGIN_HASH = `repeating-linear-gradient(45deg, ${MARGIN_COLOR} 0 4px, rgba(246, 178, 107, 0.25) 4px 8px)`
+
 export function isDomInspectionEnabled(): boolean {
   return domInspectionEnabled
 }
@@ -57,30 +68,254 @@ export function ensureDomInspectionOverlay(): void {
     position: 'fixed',
     zIndex: '2147483647',
     pointerEvents: 'none',
-    maxWidth: '320px',
-    padding: '3px 4px',
+    maxWidth: '360px',
+    padding: '5px 6px',
     borderRadius: '6px',
-    background: 'rgba(59, 130, 246, 0.95)',
+    background: 'rgba(30, 41, 59, 0.96)',
     color: '#ffffff',
-    font: '11px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace',
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
+    font: '11px/1.25 ui-monospace, SFMono-Regular, Menlo, monospace',
+    boxShadow: '0 2px 8px rgba(0,0,0,0.25)',
     display: 'none',
   })
 
+  const makeStrip = (id: string, hashed: boolean) => {
+    const strip = document.createElement('div')
+    strip.id = id
+    Object.assign(strip.style, {
+      position: 'fixed',
+      zIndex: '2147483644',
+      pointerEvents: 'none',
+      display: 'none',
+      background: hashed ? MARGIN_HASH : PADDING_COLOR,
+    })
+    return strip
+  }
+
+  const margins = {} as Record<Side, HTMLDivElement>
+  const paddings = {} as Record<Side, HTMLDivElement>
+  for (const side of SIDES) {
+    margins[side] = makeStrip(`__canvas-dom-inspection-margin-${side}`, true)
+    paddings[side] = makeStrip(`__canvas-dom-inspection-padding-${side}`, false)
+  }
+
+  for (const side of SIDES) document.documentElement.appendChild(margins[side])
+  for (const side of SIDES) document.documentElement.appendChild(paddings[side])
   document.documentElement.appendChild(pinnedHighlight)
   document.documentElement.appendChild(highlight)
   document.documentElement.appendChild(label)
   domInspectionPinnedHighlightEl = pinnedHighlight
   domInspectionHighlightEl = highlight
   domInspectionLabelEl = label
+  domInspectionMarginEls = margins
+  domInspectionPaddingEls = paddings
+}
+
+function hideBoxModelOverlay(): void {
+  if (domInspectionMarginEls) {
+    for (const side of SIDES) domInspectionMarginEls[side].style.display = 'none'
+  }
+  if (domInspectionPaddingEls) {
+    for (const side of SIDES) domInspectionPaddingEls[side].style.display = 'none'
+  }
+}
+
+function setStripRect(
+  strip: HTMLDivElement,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): void {
+  if (width <= 0 || height <= 0) {
+    strip.style.display = 'none'
+    return
+  }
+  strip.style.display = 'block'
+  strip.style.left = `${Math.round(x)}px`
+  strip.style.top = `${Math.round(y)}px`
+  strip.style.width = `${Math.round(width)}px`
+  strip.style.height = `${Math.round(height)}px`
+}
+
+function parsePx(value: string): number {
+  const n = parseFloat(value)
+  return Number.isFinite(n) ? n : 0
+}
+
+function updateBoxModelOverlay(element: Element, rect: DOMRect): void {
+  if (!domInspectionMarginEls || !domInspectionPaddingEls) return
+  const styles = window.getComputedStyle(element)
+  const mt = parsePx(styles.marginTop)
+  const mr = parsePx(styles.marginRight)
+  const mb = parsePx(styles.marginBottom)
+  const ml = parsePx(styles.marginLeft)
+  const pt = parsePx(styles.paddingTop)
+  const pr = parsePx(styles.paddingRight)
+  const pb = parsePx(styles.paddingBottom)
+  const pl = parsePx(styles.paddingLeft)
+  const bt = parsePx(styles.borderTopWidth)
+  const br = parsePx(styles.borderRightWidth)
+  const bb = parsePx(styles.borderBottomWidth)
+  const bl = parsePx(styles.borderLeftWidth)
+
+  // Margin strips lie OUTSIDE the border-box. Draw top/bottom full-width
+  // (extending across margin corners), and left/right between them.
+  setStripRect(domInspectionMarginEls.top, rect.left - ml, rect.top - mt, rect.width + ml + mr, mt)
+  setStripRect(domInspectionMarginEls.bottom, rect.left - ml, rect.bottom, rect.width + ml + mr, mb)
+  setStripRect(domInspectionMarginEls.left, rect.left - ml, rect.top, ml, rect.height)
+  setStripRect(domInspectionMarginEls.right, rect.right, rect.top, mr, rect.height)
+
+  // Padding strips lie INSIDE the border-box, between border and content.
+  const padBoxX = rect.left + bl
+  const padBoxY = rect.top + bt
+  const padBoxW = Math.max(0, rect.width - bl - br)
+  const padBoxH = Math.max(0, rect.height - bt - bb)
+  setStripRect(domInspectionPaddingEls.top, padBoxX, padBoxY, padBoxW, pt)
+  setStripRect(domInspectionPaddingEls.bottom, padBoxX, padBoxY + padBoxH - pb, padBoxW, pb)
+  setStripRect(domInspectionPaddingEls.left, padBoxX, padBoxY + pt, pl, Math.max(0, padBoxH - pt - pb))
+  setStripRect(
+    domInspectionPaddingEls.right,
+    padBoxX + padBoxW - pr,
+    padBoxY + pt,
+    pr,
+    Math.max(0, padBoxH - pt - pb),
+  )
+}
+
+function shortFontFamily(fontFamily: string): string {
+  // Computed font-family is a comma-separated stack; the first family is the
+  // resolved primary. Strip surrounding quotes for display.
+  const first = fontFamily.split(',')[0]?.trim() ?? ''
+  return first.replace(/^['"]|['"]$/g, '')
+}
+
+function buildLabelContent(label: HTMLDivElement, element: Element, payload: ReturnType<typeof inspectionPayload>): void {
+  const styles = window.getComputedStyle(element)
+  label.replaceChildren()
+
+  // Row 1: tag chip + name
+  const headerRow = document.createElement('div')
+  Object.assign(headerRow.style, {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    minWidth: '0',
+  })
+
+  const labelText = payload.name.trim()
+  const labelMatch = /^([a-zA-Z][\w:-]*)(.*)$/.exec(labelText)
+  const elementType = labelMatch?.[1] ?? labelText
+  const remainder = labelMatch?.[2] ?? ''
+
+  const chip = document.createElement('span')
+  Object.assign(chip.style, {
+    display: 'inline-block',
+    padding: '1px 5px',
+    borderRadius: '4px',
+    background: 'rgba(59, 130, 246, 0.95)',
+    color: '#fff',
+    flexShrink: '0',
+  })
+  chip.textContent = elementType
+  headerRow.appendChild(chip)
+
+  if (remainder.trim()) {
+    const name = document.createElement('span')
+    Object.assign(name.style, {
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      minWidth: '0',
+      opacity: '0.9',
+    })
+    name.textContent = remainder.trim()
+    headerRow.appendChild(name)
+  }
+  label.appendChild(headerRow)
+
+  // Row 2: font preview (rendered in the actual font) + size/weight
+  const fontFamily = shortFontFamily(styles.fontFamily)
+  if (fontFamily) {
+    const fontRow = document.createElement('div')
+    Object.assign(fontRow.style, {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '6px',
+      marginTop: '4px',
+    })
+
+    const aa = document.createElement('span')
+    Object.assign(aa.style, {
+      fontFamily: styles.fontFamily,
+      fontWeight: styles.fontWeight,
+      fontSize: '14px',
+      lineHeight: '1',
+      color: '#fff',
+      flexShrink: '0',
+      minWidth: '18px',
+      textAlign: 'center',
+    })
+    aa.textContent = 'Aa'
+    fontRow.appendChild(aa)
+
+    const fontMeta = document.createElement('span')
+    Object.assign(fontMeta.style, {
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      minWidth: '0',
+      opacity: '0.85',
+    })
+    fontMeta.textContent = `${fontFamily} · ${styles.fontSize} · ${styles.fontWeight}`
+    fontRow.appendChild(fontMeta)
+    label.appendChild(fontRow)
+  }
+
+  // Row 3: color swatches (text + background)
+  const colorRow = document.createElement('div')
+  Object.assign(colorRow.style, {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px',
+    marginTop: '4px',
+  })
+
+  const addSwatch = (name: string, color: string) => {
+    const item = document.createElement('span')
+    Object.assign(item.style, {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '4px',
+      opacity: '0.85',
+    })
+    const sw = document.createElement('span')
+    Object.assign(sw.style, {
+      display: 'inline-block',
+      width: '10px',
+      height: '10px',
+      borderRadius: '2px',
+      background: color,
+      boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.35)',
+      flexShrink: '0',
+    })
+    const text = document.createElement('span')
+    text.textContent = `${name} ${color}`
+    item.appendChild(sw)
+    item.appendChild(text)
+    colorRow.appendChild(item)
+  }
+  addSwatch('text', styles.color)
+  if (styles.backgroundColor && styles.backgroundColor !== 'rgba(0, 0, 0, 0)') {
+    addSwatch('bg', styles.backgroundColor)
+  }
+  label.appendChild(colorRow)
 }
 
 export function hideDomInspectionOverlay(): void {
   if (domInspectionHighlightEl) domInspectionHighlightEl.style.display = 'none'
   if (domInspectionPinnedHighlightEl) domInspectionPinnedHighlightEl.style.display = 'none'
   if (domInspectionLabelEl) domInspectionLabelEl.style.display = 'none'
+  hideBoxModelOverlay()
 }
 
 export function updateDomInspectionOverlay(
@@ -122,27 +357,11 @@ export function updateDomInspectionOverlay(
   const rect = setHighlightRect(domInspectionHighlightEl, element)
   if (!rect) return
 
-  domInspectionLabelEl.style.display = 'block'
-  const labelText = payload.name.trim()
-  const labelMatch = /^([a-zA-Z][\w:-]*)(.*)$/.exec(labelText)
-  if (labelMatch) {
-    const [, elementType, remainder] = labelMatch
-    domInspectionLabelEl.replaceChildren()
+  // Box-model overlay tracks the active (hovered) target.
+  updateBoxModelOverlay(element, rect)
 
-    const elementTypeChip = document.createElement('span')
-    Object.assign(elementTypeChip.style, {
-      display: 'inline-block',
-      padding: '1px 4px',
-      marginRight: '6px',
-      borderRadius: '4px',
-      background: 'color-mix(in srgb, #000000 30%, transparent)',
-    })
-    elementTypeChip.textContent = elementType
-    domInspectionLabelEl.appendChild(elementTypeChip)
-    domInspectionLabelEl.appendChild(document.createTextNode(remainder))
-  } else {
-    domInspectionLabelEl.textContent = payload.name
-  }
+  domInspectionLabelEl.style.display = 'block'
+  buildLabelContent(domInspectionLabelEl, element, payload)
   const outerPadding = 2
   const labelRect = domInspectionLabelEl.getBoundingClientRect()
   const maxLeft = Math.max(outerPadding, window.innerWidth - Math.ceil(labelRect.width) - outerPadding)

--- a/src/preload/dom-inspection.ts
+++ b/src/preload/dom-inspection.ts
@@ -233,40 +233,40 @@ function buildLabelContent(label: HTMLDivElement, element: Element, payload: Ret
   }
   label.appendChild(headerRow)
 
-  // Row 2: font preview (rendered in the actual font) + size/weight
+  // Row 2: font family rendered in the actual font, plus size/weight
   const fontFamily = shortFontFamily(styles.fontFamily)
   if (fontFamily) {
     const fontRow = document.createElement('div')
     Object.assign(fontRow.style, {
       display: 'flex',
-      alignItems: 'center',
+      alignItems: 'baseline',
       gap: '6px',
       marginTop: '4px',
+      minWidth: '0',
     })
 
-    const aa = document.createElement('span')
-    Object.assign(aa.style, {
+    const familyName = document.createElement('span')
+    Object.assign(familyName.style, {
       fontFamily: styles.fontFamily,
       fontWeight: styles.fontWeight,
       fontSize: '14px',
-      lineHeight: '1',
+      lineHeight: '1.1',
       color: '#fff',
-      flexShrink: '0',
-      minWidth: '18px',
-      textAlign: 'center',
-    })
-    aa.textContent = 'Aa'
-    fontRow.appendChild(aa)
-
-    const fontMeta = document.createElement('span')
-    Object.assign(fontMeta.style, {
       whiteSpace: 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       minWidth: '0',
-      opacity: '0.85',
     })
-    fontMeta.textContent = `${fontFamily} · ${styles.fontSize} · ${styles.fontWeight}`
+    familyName.textContent = fontFamily
+    fontRow.appendChild(familyName)
+
+    const fontMeta = document.createElement('span')
+    Object.assign(fontMeta.style, {
+      whiteSpace: 'nowrap',
+      opacity: '0.7',
+      flexShrink: '0',
+    })
+    fontMeta.textContent = `${styles.fontSize} · ${styles.fontWeight}`
     fontRow.appendChild(fontMeta)
     label.appendChild(fontRow)
   }

--- a/src/preload/dom-inspection.ts
+++ b/src/preload/dom-inspection.ts
@@ -1,7 +1,7 @@
 import { ipcRenderer } from 'electron'
 import {
   deepElementFromPoint,
-  elementClasses,
+  elementSelectorParts,
   inspectionPayload,
 } from './dom-element-utils'
 import { isPageOverlayTarget } from './gesture-forwarding'
@@ -17,9 +17,10 @@ let domInspectionPinnedTarget: Element | null = null
 // Chrome-style box model overlay: 4 strips for margin (orange, hashed),
 // 4 strips for padding (green, solid). Rendered as fixed-position divs.
 type Side = 'top' | 'right' | 'bottom' | 'left'
+type StripKind = 'margin' | 'padding'
 const SIDES: readonly Side[] = ['top', 'right', 'bottom', 'left'] as const
-let domInspectionMarginEls: Record<Side, HTMLDivElement> | null = null
-let domInspectionPaddingEls: Record<Side, HTMLDivElement> | null = null
+const STRIP_KINDS: readonly StripKind[] = ['margin', 'padding'] as const
+let domInspectionStripEls: Record<StripKind, Record<Side, HTMLDivElement>> | null = null
 
 const MARGIN_COLOR = 'rgba(246, 178, 107, 0.55)'
 const PADDING_COLOR = 'rgba(147, 196, 125, 0.55)'
@@ -79,44 +80,42 @@ export function ensureDomInspectionOverlay(): void {
     display: 'none',
   })
 
-  const makeStrip = (id: string, hashed: boolean) => {
+  const makeStrip = (kind: StripKind, side: Side) => {
     const strip = document.createElement('div')
-    strip.id = id
+    strip.id = `__canvas-dom-inspection-${kind}-${side}`
     Object.assign(strip.style, {
       position: 'fixed',
       zIndex: '2147483644',
       pointerEvents: 'none',
       display: 'none',
-      background: hashed ? MARGIN_HASH : PADDING_COLOR,
+      background: kind === 'margin' ? MARGIN_HASH : PADDING_COLOR,
     })
     return strip
   }
 
-  const margins = {} as Record<Side, HTMLDivElement>
-  const paddings = {} as Record<Side, HTMLDivElement>
-  for (const side of SIDES) {
-    margins[side] = makeStrip(`__canvas-dom-inspection-margin-${side}`, true)
-    paddings[side] = makeStrip(`__canvas-dom-inspection-padding-${side}`, false)
+  const strips = {} as Record<StripKind, Record<Side, HTMLDivElement>>
+  for (const kind of STRIP_KINDS) {
+    const sideMap = {} as Record<Side, HTMLDivElement>
+    for (const side of SIDES) {
+      sideMap[side] = makeStrip(kind, side)
+      document.documentElement.appendChild(sideMap[side])
+    }
+    strips[kind] = sideMap
   }
 
-  for (const side of SIDES) document.documentElement.appendChild(margins[side])
-  for (const side of SIDES) document.documentElement.appendChild(paddings[side])
   document.documentElement.appendChild(pinnedHighlight)
   document.documentElement.appendChild(highlight)
   document.documentElement.appendChild(label)
   domInspectionPinnedHighlightEl = pinnedHighlight
   domInspectionHighlightEl = highlight
   domInspectionLabelEl = label
-  domInspectionMarginEls = margins
-  domInspectionPaddingEls = paddings
+  domInspectionStripEls = strips
 }
 
 function hideBoxModelOverlay(): void {
-  if (domInspectionMarginEls) {
-    for (const side of SIDES) domInspectionMarginEls[side].style.display = 'none'
-  }
-  if (domInspectionPaddingEls) {
-    for (const side of SIDES) domInspectionPaddingEls[side].style.display = 'none'
+  if (!domInspectionStripEls) return
+  for (const kind of STRIP_KINDS) {
+    for (const side of SIDES) domInspectionStripEls[kind][side].style.display = 'none'
   }
 }
 
@@ -143,9 +142,8 @@ function parsePx(value: string): number {
   return Number.isFinite(n) ? n : 0
 }
 
-function updateBoxModelOverlay(element: Element, rect: DOMRect): void {
-  if (!domInspectionMarginEls || !domInspectionPaddingEls) return
-  const styles = window.getComputedStyle(element)
+function updateBoxModelOverlay(rect: DOMRect, styles: CSSStyleDeclaration): void {
+  if (!domInspectionStripEls) return
   const mt = parsePx(styles.marginTop)
   const mr = parsePx(styles.marginRight)
   const mb = parsePx(styles.marginBottom)
@@ -159,28 +157,25 @@ function updateBoxModelOverlay(element: Element, rect: DOMRect): void {
   const bb = parsePx(styles.borderBottomWidth)
   const bl = parsePx(styles.borderLeftWidth)
 
-  // Margin strips lie OUTSIDE the border-box. Draw top/bottom full-width
-  // (extending across margin corners), and left/right between them.
-  setStripRect(domInspectionMarginEls.top, rect.left - ml, rect.top - mt, rect.width + ml + mr, mt)
-  setStripRect(domInspectionMarginEls.bottom, rect.left - ml, rect.bottom, rect.width + ml + mr, mb)
-  setStripRect(domInspectionMarginEls.left, rect.left - ml, rect.top, ml, rect.height)
-  setStripRect(domInspectionMarginEls.right, rect.right, rect.top, mr, rect.height)
+  const margins = domInspectionStripEls.margin
+  const paddings = domInspectionStripEls.padding
+
+  // Margin strips lie OUTSIDE the border-box. Top/bottom span full width
+  // (covering margin corners); left/right fit between them.
+  setStripRect(margins.top, rect.left - ml, rect.top - mt, rect.width + ml + mr, mt)
+  setStripRect(margins.bottom, rect.left - ml, rect.bottom, rect.width + ml + mr, mb)
+  setStripRect(margins.left, rect.left - ml, rect.top, ml, rect.height)
+  setStripRect(margins.right, rect.right, rect.top, mr, rect.height)
 
   // Padding strips lie INSIDE the border-box, between border and content.
   const padBoxX = rect.left + bl
   const padBoxY = rect.top + bt
   const padBoxW = Math.max(0, rect.width - bl - br)
   const padBoxH = Math.max(0, rect.height - bt - bb)
-  setStripRect(domInspectionPaddingEls.top, padBoxX, padBoxY, padBoxW, pt)
-  setStripRect(domInspectionPaddingEls.bottom, padBoxX, padBoxY + padBoxH - pb, padBoxW, pb)
-  setStripRect(domInspectionPaddingEls.left, padBoxX, padBoxY + pt, pl, Math.max(0, padBoxH - pt - pb))
-  setStripRect(
-    domInspectionPaddingEls.right,
-    padBoxX + padBoxW - pr,
-    padBoxY + pt,
-    pr,
-    Math.max(0, padBoxH - pt - pb),
-  )
+  setStripRect(paddings.top, padBoxX, padBoxY, padBoxW, pt)
+  setStripRect(paddings.bottom, padBoxX, padBoxY + padBoxH - pb, padBoxW, pb)
+  setStripRect(paddings.left, padBoxX, padBoxY + pt, pl, Math.max(0, padBoxH - pt - pb))
+  setStripRect(paddings.right, padBoxX + padBoxW - pr, padBoxY + pt, pr, Math.max(0, padBoxH - pt - pb))
 }
 
 function shortFontFamily(fontFamily: string): string {
@@ -190,11 +185,9 @@ function shortFontFamily(fontFamily: string): string {
   return first.replace(/^['"]|['"]$/g, '')
 }
 
-function buildLabelContent(label: HTMLDivElement, element: Element): void {
-  const styles = window.getComputedStyle(element)
+function buildLabelContent(label: HTMLDivElement, element: Element, styles: CSSStyleDeclaration): void {
   label.replaceChildren()
 
-  // Row 1: tag chip + name
   const headerRow = document.createElement('div')
   Object.assign(headerRow.style, {
     display: 'flex',
@@ -203,28 +196,20 @@ function buildLabelContent(label: HTMLDivElement, element: Element): void {
     minWidth: '0',
   })
 
-  const elementType = element.tagName.toLowerCase()
-  const idAttr = element.getAttribute('id')
-  const classes = elementClasses(element)
-  const selectorRemainder = idAttr
-    ? `#${idAttr}`
-    : classes.length
-      ? `.${classes.slice(0, 2).join('.')}`
-      : ''
+  const { tag, remainder } = elementSelectorParts(element)
 
   const chip = document.createElement('span')
   Object.assign(chip.style, {
-    display: 'inline-block',
     padding: '1px 5px',
     borderRadius: '4px',
     background: 'rgba(59, 130, 246, 0.95)',
     color: '#fff',
     flexShrink: '0',
   })
-  chip.textContent = elementType
+  chip.textContent = tag
   headerRow.appendChild(chip)
 
-  if (selectorRemainder) {
+  if (remainder) {
     const name = document.createElement('span')
     Object.assign(name.style, {
       whiteSpace: 'nowrap',
@@ -233,7 +218,7 @@ function buildLabelContent(label: HTMLDivElement, element: Element): void {
       minWidth: '0',
       opacity: '0.9',
     })
-    name.textContent = selectorRemainder
+    name.textContent = remainder
     headerRow.appendChild(name)
   }
 
@@ -279,7 +264,6 @@ function buildLabelContent(label: HTMLDivElement, element: Element): void {
     label.appendChild(fontRow)
   }
 
-  // Row 3: color swatches (text + background)
   const colorRow = document.createElement('div')
   Object.assign(colorRow.style, {
     display: 'flex',
@@ -365,11 +349,11 @@ export function updateDomInspectionOverlay(
   const rect = setHighlightRect(domInspectionHighlightEl, element)
   if (!rect) return
 
-  // Box-model overlay tracks the active (hovered) target.
-  updateBoxModelOverlay(element, rect)
+  const styles = window.getComputedStyle(element)
+  updateBoxModelOverlay(rect, styles)
 
   domInspectionLabelEl.style.display = 'block'
-  buildLabelContent(domInspectionLabelEl, element)
+  buildLabelContent(domInspectionLabelEl, element, styles)
   const outerPadding = 2
   const labelRect = domInspectionLabelEl.getBoundingClientRect()
   const maxLeft = Math.max(outerPadding, window.innerWidth - Math.ceil(labelRect.width) - outerPadding)


### PR DESCRIPTION
## Summary
- Box-model overlay: 8 fixed-position strips (margin hashed orange, padding solid green) tracking the hovered element, mirroring Chrome DevTools.
- Rich tooltip: tag chip + selector remainder (id/class/role), font row showing family in the actual font plus size · weight · letter-spacing, and color swatches for text + background.
- Selector remainder uses the shared `elementSelectorParts` helper (also backs the existing path builder), so id/class/role logic isn't duplicated.
- Single `getComputedStyle` per overlay update, shared between the box-model overlay and the label.

## Test plan
- [ ] Hover elements with margin and padding — orange hashed strips outside, green solid strips inside the border-box
- [ ] Hover an `h1` with classes — tooltip shows `h1` chip + `.foo.bar`, font row in the heading's actual font, letter-spacing appears when not `normal`
- [ ] Hover an element with `id` and an element with `role` — selector remainder reflects each
- [ ] Pin a selection then move pointer over a different element — pinned highlight stays, hovered overlay updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)