### PR TITLE
feat(drawing): add highlighter brush

### DIFF
--- a/src/renderer/above-view/DrawingsLayer.tsx
+++ b/src/renderer/above-view/DrawingsLayer.tsx
@@ -1,5 +1,10 @@
 import { getStroke } from 'perfect-freehand'
-import type { AnnotationDrawing, CanvasSceneEntity, LayoutUpdateData } from '../../shared/types'
+import type {
+  AnnotationDrawing,
+  AnnotationDrawingStroke,
+  CanvasSceneEntity,
+  LayoutUpdateData,
+} from '../../shared/types'
 import { canvasToScreenX, canvasToScreenY } from '../../shared/gesture-utils'
 import { PERFECT_FREEHAND_ENABLED } from '../../shared/featureFlags'
 import { pathD } from './annotationMath'
@@ -24,6 +29,101 @@ function freehandPathD(points: { x: number; y: number }[], size: number): string
   return d + ' Z'
 }
 
+// Parse '#rgb' or '#rrggbb' to {r,g,b}. Returns null if not a hex color.
+function hexToRgb(color: string): { r: number; g: number; b: number } | null {
+  const m3 = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i.exec(color)
+  if (m3) {
+    return {
+      r: parseInt(m3[1] + m3[1], 16),
+      g: parseInt(m3[2] + m3[2], 16),
+      b: parseInt(m3[3] + m3[3], 16),
+    }
+  }
+  const m6 = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(color)
+  if (m6) {
+    return {
+      r: parseInt(m6[1], 16),
+      g: parseInt(m6[2], 16),
+      b: parseInt(m6[3], 16),
+    }
+  }
+  return null
+}
+
+function rgba(color: string, alpha: number): string {
+  const rgb = hexToRgb(color)
+  if (!rgb) return color
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`
+}
+
+// Stops mirror the agentation.com highlight: denser at the ends, lighter in the
+// middle, applied along the stroke's first→last direction.
+const HIGHLIGHT_ALPHA_STOPS: Array<{ offset: string; alpha: number }> = [
+  { offset: '0%', alpha: 0.5 },
+  { offset: '4%', alpha: 0.15 },
+  { offset: '96%', alpha: 0.3 },
+  { offset: '100%', alpha: 0.6 },
+]
+
+// Future: try `mix-blend-mode: multiply` so crossing strokes darken naturally,
+// and a wider blurred under-pass for a paper-bleed look.
+
+function HighlightStroke({
+  stroke,
+  points,
+  visibleWidth,
+  active,
+  filterId,
+}: {
+  stroke: AnnotationDrawingStroke
+  points: { x: number; y: number }[]
+  visibleWidth: number
+  active: boolean
+  filterId: string
+}) {
+  if (points.length === 0) return null
+  const first = points[0]
+  const last = points[points.length - 1]
+  // If the stroke is essentially a dot, nudge the gradient axis so it still
+  // renders something instead of degenerating to a point.
+  const dx = last.x - first.x
+  const dy = last.y - first.y
+  const len = Math.hypot(dx, dy)
+  const x1 = first.x
+  const y1 = first.y
+  const x2 = len < 1 ? first.x + 1 : last.x
+  const y2 = len < 1 ? first.y : last.y
+  const gradientId = `hl-grad-${stroke.id}`
+  return (
+    <>
+      <defs>
+        <linearGradient
+          id={gradientId}
+          gradientUnits="userSpaceOnUse"
+          x1={x1}
+          y1={y1}
+          x2={x2}
+          y2={y2}
+        >
+          {HIGHLIGHT_ALPHA_STOPS.map((s) => (
+            <stop key={s.offset} offset={s.offset} stopColor={rgba(stroke.color, s.alpha)} />
+          ))}
+        </linearGradient>
+      </defs>
+      <path
+        d={pathD(points)}
+        fill="none"
+        stroke={`url(#${gradientId})`}
+        strokeWidth={visibleWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        filter={`url(#${filterId})`}
+        opacity={active ? 1 : 0.95}
+      />
+    </>
+  )
+}
+
 export function DrawingLayer({
   drawing,
   layout,
@@ -35,6 +135,8 @@ export function DrawingLayer({
   active?: boolean
   onSelect?: () => void
 }) {
+  const grainFilterId = 'highlight-grain'
+  const hasHighlight = drawing.strokes.some((s) => s.brushType === 'highlight')
   return (
     <svg
       className="pointer-events-none absolute inset-0"
@@ -43,6 +145,38 @@ export function DrawingLayer({
       viewBox={`0 0 ${window.innerWidth} ${window.innerHeight}`}
       aria-hidden="true"
     >
+      {hasHighlight ? (
+        <defs>
+          <filter
+            id={grainFilterId}
+            x="-5%"
+            y="-5%"
+            width="110%"
+            height="110%"
+            filterUnits="objectBoundingBox"
+            primitiveUnits="userSpaceOnUse"
+          >
+            <feTurbulence
+              type="fractalNoise"
+              baseFrequency="0.85"
+              numOctaves={2}
+              seed={4}
+              stitchTiles="stitch"
+              result="noise"
+            />
+            <feColorMatrix
+              in="noise"
+              type="matrix"
+              values="0 0 0 0 0
+                      0 0 0 0 0
+                      0 0 0 0 0
+                      0.35 0 0 0 0.78"
+              result="noiseAlpha"
+            />
+            <feComposite in="SourceGraphic" in2="noiseAlpha" operator="in" />
+          </filter>
+        </defs>
+      ) : null}
       {drawing.strokes.map((stroke) => {
         const points = stroke.points.map((point) => ({
           x: canvasToScreenX(layout, point.x),
@@ -51,7 +185,9 @@ export function DrawingLayer({
         const visibleWidth = Math.max(1, stroke.width * layout.zoom)
         const hitWidth = Math.max(12, visibleWidth + 10)
         const strokedD = pathD(points)
-        const filledD = PERFECT_FREEHAND_ENABLED ? freehandPathD(points, visibleWidth) : ''
+        const isHighlight = stroke.brushType === 'highlight'
+        const filledD =
+          PERFECT_FREEHAND_ENABLED && !isHighlight ? freehandPathD(points, visibleWidth) : ''
         return (
           <g key={stroke.id}>
             {onSelect ? (
@@ -71,7 +207,15 @@ export function DrawingLayer({
                 }}
               />
             ) : null}
-            {PERFECT_FREEHAND_ENABLED ? (
+            {isHighlight ? (
+              <HighlightStroke
+                stroke={stroke}
+                points={points}
+                visibleWidth={visibleWidth}
+                active={active ?? false}
+                filterId={grainFilterId}
+              />
+            ) : PERFECT_FREEHAND_ENABLED ? (
               <path
                 d={filledD}
                 fill={stroke.color}

--- a/src/renderer/above-view/DrawingsLayer.tsx
+++ b/src/renderer/above-view/DrawingsLayer.tsx
@@ -6,6 +6,7 @@ import type {
   LayoutUpdateData,
 } from '../../shared/types'
 import { canvasToScreenX, canvasToScreenY } from '../../shared/gesture-utils'
+import { withAlpha } from '../../shared/canvas-colors'
 import { PERFECT_FREEHAND_ENABLED } from '../../shared/featureFlags'
 import { pathD } from './annotationMath'
 
@@ -35,35 +36,8 @@ function freehandPathD(
   return d + ' Z'
 }
 
-// Parse '#rgb' or '#rrggbb' to {r,g,b}. Returns null if not a hex color.
-function hexToRgb(color: string): { r: number; g: number; b: number } | null {
-  const m3 = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i.exec(color)
-  if (m3) {
-    return {
-      r: parseInt(m3[1] + m3[1], 16),
-      g: parseInt(m3[2] + m3[2], 16),
-      b: parseInt(m3[3] + m3[3], 16),
-    }
-  }
-  const m6 = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(color)
-  if (m6) {
-    return {
-      r: parseInt(m6[1], 16),
-      g: parseInt(m6[2], 16),
-      b: parseInt(m6[3], 16),
-    }
-  }
-  return null
-}
-
-function rgba(color: string, alpha: number): string {
-  const rgb = hexToRgb(color)
-  if (!rgb) return color
-  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`
-}
-
-// Stops mirror the agentation.com highlight: denser at the ends, lighter in the
-// middle, applied along the stroke's first→last direction.
+// Stops applied along the stroke's first→last direction: denser at the ends,
+// lighter in the middle, to mimic ink pooling at the start/end of a swipe.
 const HIGHLIGHT_ALPHA_STOPS: Array<{ offset: string; alpha: number }> = [
   { offset: '0%', alpha: 0.5 },
   { offset: '4%', alpha: 0.15 },
@@ -71,8 +45,7 @@ const HIGHLIGHT_ALPHA_STOPS: Array<{ offset: string; alpha: number }> = [
   { offset: '100%', alpha: 0.6 },
 ]
 
-// Future: try `mix-blend-mode: multiply` so crossing strokes darken naturally,
-// and a wider blurred under-pass for a paper-bleed look.
+const GRAIN_FILTER_ID = 'highlight-grain'
 
 function HighlightStroke({
   stroke,
@@ -119,7 +92,7 @@ function HighlightStroke({
           y2={y2}
         >
           {HIGHLIGHT_ALPHA_STOPS.map((s) => (
-            <stop key={s.offset} offset={s.offset} stopColor={rgba(stroke.color, s.alpha)} />
+            <stop key={s.offset} offset={s.offset} stopColor={withAlpha(stroke.color, s.alpha)} />
           ))}
         </linearGradient>
       </defs>
@@ -130,6 +103,52 @@ function HighlightStroke({
         opacity={active ? 1 : 0.95}
       />
     </>
+  )
+}
+
+function renderStrokeBody({
+  stroke,
+  points,
+  strokedD,
+  visibleWidth,
+  active,
+}: {
+  stroke: AnnotationDrawingStroke
+  points: { x: number; y: number }[]
+  strokedD: string
+  visibleWidth: number
+  active: boolean
+}) {
+  if (stroke.brushType === 'highlight') {
+    return (
+      <HighlightStroke
+        stroke={stroke}
+        points={points}
+        visibleWidth={visibleWidth}
+        active={active}
+        filterId={GRAIN_FILTER_ID}
+      />
+    )
+  }
+  if (PERFECT_FREEHAND_ENABLED) {
+    return (
+      <path
+        d={freehandPathD(points, visibleWidth)}
+        fill={stroke.color}
+        opacity={active ? 1 : 0.92}
+      />
+    )
+  }
+  return (
+    <path
+      d={strokedD}
+      fill="none"
+      stroke={stroke.color}
+      strokeWidth={visibleWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      opacity={active ? 1 : 0.92}
+    />
   )
 }
 
@@ -144,7 +163,6 @@ export function DrawingLayer({
   active?: boolean
   onSelect?: () => void
 }) {
-  const grainFilterId = 'highlight-grain'
   const hasHighlight = drawing.strokes.some((s) => s.brushType === 'highlight')
   return (
     <svg
@@ -165,7 +183,7 @@ export function DrawingLayer({
             space, the region is the SVG viewport so any stroke geometry works.
           */}
           <filter
-            id={grainFilterId}
+            id={GRAIN_FILTER_ID}
             x="0"
             y="0"
             width={window.innerWidth}
@@ -202,9 +220,6 @@ export function DrawingLayer({
         const visibleWidth = Math.max(1, stroke.width * layout.zoom)
         const hitWidth = Math.max(12, visibleWidth + 10)
         const strokedD = pathD(points)
-        const isHighlight = stroke.brushType === 'highlight'
-        const filledD =
-          PERFECT_FREEHAND_ENABLED && !isHighlight ? freehandPathD(points, visibleWidth) : ''
         return (
           <g key={stroke.id}>
             {onSelect ? (
@@ -224,31 +239,7 @@ export function DrawingLayer({
                 }}
               />
             ) : null}
-            {isHighlight ? (
-              <HighlightStroke
-                stroke={stroke}
-                points={points}
-                visibleWidth={visibleWidth}
-                active={active ?? false}
-                filterId={grainFilterId}
-              />
-            ) : PERFECT_FREEHAND_ENABLED ? (
-              <path
-                d={filledD}
-                fill={stroke.color}
-                opacity={active ? 1 : 0.92}
-              />
-            ) : (
-              <path
-                d={strokedD}
-                fill="none"
-                stroke={stroke.color}
-                strokeWidth={visibleWidth}
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                opacity={active ? 1 : 0.92}
-              />
-            )}
+            {renderStrokeBody({ stroke, points, strokedD, visibleWidth, active: active ?? false })}
           </g>
         )
       })}

--- a/src/renderer/above-view/DrawingsLayer.tsx
+++ b/src/renderer/above-view/DrawingsLayer.tsx
@@ -9,7 +9,11 @@ import { canvasToScreenX, canvasToScreenY } from '../../shared/gesture-utils'
 import { PERFECT_FREEHAND_ENABLED } from '../../shared/featureFlags'
 import { pathD } from './annotationMath'
 
-function freehandPathD(points: { x: number; y: number }[], size: number): string {
+function freehandPathD(
+  points: { x: number; y: number }[],
+  size: number,
+  cap: boolean = true,
+): string {
   const outline = getStroke(
     points.map((p) => [p.x, p.y]),
     {
@@ -19,6 +23,8 @@ function freehandPathD(points: { x: number; y: number }[], size: number): string
       streamline: 0.75,
       simulatePressure: false,
       last: true,
+      start: { cap, taper: 0 },
+      end: { cap, taper: 0 },
     },
   )
   if (!outline.length) return ''
@@ -82,10 +88,17 @@ function HighlightStroke({
   filterId: string
 }) {
   if (points.length === 0) return null
+  // Render as a perfect-freehand outline filled with the gradient instead of a
+  // stroked polyline. The streamline/smoothing params absorb pointer jitter at
+  // pointerdown/pointerup, which would otherwise show up as flag-shaped
+  // artifacts at the start/end of strokes (the butt cap is perpendicular to
+  // the first/last segment direction, so any micro-diagonal jitter there
+  // becomes a visible angled tail).
+  const filledD = freehandPathD(points, visibleWidth, false)
+  if (!filledD) return null
+
   const first = points[0]
   const last = points[points.length - 1]
-  // If the stroke is essentially a dot, nudge the gradient axis so it still
-  // renders something instead of degenerating to a point.
   const dx = last.x - first.x
   const dy = last.y - first.y
   const len = Math.hypot(dx, dy)
@@ -111,12 +124,8 @@ function HighlightStroke({
         </linearGradient>
       </defs>
       <path
-        d={pathD(points)}
-        fill="none"
-        stroke={`url(#${gradientId})`}
-        strokeWidth={visibleWidth}
-        strokeLinecap="round"
-        strokeLinejoin="round"
+        d={filledD}
+        fill={`url(#${gradientId})`}
         filter={`url(#${filterId})`}
         opacity={active ? 1 : 0.95}
       />
@@ -147,13 +156,21 @@ export function DrawingLayer({
     >
       {hasHighlight ? (
         <defs>
+          {/*
+            filterUnits="userSpaceOnUse" is load-bearing: the default
+            ("objectBoundingBox") sizes the filter region as a percentage of the
+            path's geometric bbox, which does NOT include strokeWidth. A purely
+            horizontal stroke has bbox height = 0 → filter region height = 0 →
+            the whole 22px-thick stroke gets clipped to nothing. With user
+            space, the region is the SVG viewport so any stroke geometry works.
+          */}
           <filter
             id={grainFilterId}
-            x="-5%"
-            y="-5%"
-            width="110%"
-            height="110%"
-            filterUnits="objectBoundingBox"
+            x="0"
+            y="0"
+            width={window.innerWidth}
+            height={window.innerHeight}
+            filterUnits="userSpaceOnUse"
             primitiveUnits="userSpaceOnUse"
           >
             <feTurbulence

--- a/src/renderer/above-view/useAnnotationDrawingGestures.ts
+++ b/src/renderer/above-view/useAnnotationDrawingGestures.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from 'react'
 import type { CanvasBgElectronAPI, LayoutUpdateData } from '../../shared/types'
+import { activeDrawBrush } from '../../shared/tool'
 import { isOverlayUiTarget, screenPointToCanvasPoint } from '../../shared/gesture-utils'
 import { drawingBounds, snapPointTo45Degrees, type DrawingSession } from './annotationMath'
 
@@ -94,11 +95,7 @@ export function useAnnotationDrawingGestures({
         setDrawingStrokeActive(true)
         closeThread()
         setPendingAnnotation(null)
-        const activeTool = layoutRef.current.activeTool
-        const brush: 'pen' | 'highlight' =
-          activeTool.kind === 'draw' && activeTool.brush === 'highlight'
-            ? 'highlight'
-            : 'pen'
+        const brush = activeDrawBrush(layoutRef.current.activeTool) ?? 'pen'
         const nextStrokes = [
           {
             id: strokeId,

--- a/src/renderer/above-view/useAnnotationDrawingGestures.ts
+++ b/src/renderer/above-view/useAnnotationDrawingGestures.ts
@@ -3,8 +3,10 @@ import type { CanvasBgElectronAPI, LayoutUpdateData } from '../../shared/types'
 import { isOverlayUiTarget, screenPointToCanvasPoint } from '../../shared/gesture-utils'
 import { drawingBounds, snapPointTo45Degrees, type DrawingSession } from './annotationMath'
 
-const DRAW_STROKE_COLOR = '#ef4444'
-const DRAW_STROKE_WIDTH = 6
+const PEN_STROKE_COLOR = '#ef4444'
+const PEN_STROKE_WIDTH = 6
+const HIGHLIGHT_STROKE_COLOR = '#facc15'
+const HIGHLIGHT_STROKE_WIDTH = 22
 
 export function useAnnotationDrawingGestures({
   api,
@@ -92,12 +94,18 @@ export function useAnnotationDrawingGestures({
         setDrawingStrokeActive(true)
         closeThread()
         setPendingAnnotation(null)
+        const activeTool = layoutRef.current.activeTool
+        const brush: 'pen' | 'highlight' =
+          activeTool.kind === 'draw' && activeTool.brush === 'highlight'
+            ? 'highlight'
+            : 'pen'
         const nextStrokes = [
           {
             id: strokeId,
-            color: DRAW_STROKE_COLOR,
-            width: DRAW_STROKE_WIDTH,
+            color: brush === 'highlight' ? HIGHLIGHT_STROKE_COLOR : PEN_STROKE_COLOR,
+            width: brush === 'highlight' ? HIGHLIGHT_STROKE_WIDTH : PEN_STROKE_WIDTH,
             points: [startPoint],
+            brushType: brush,
           },
         ]
         const nextSession: DrawingSession = {

--- a/src/renderer/toolbar/toolbarSections.tsx
+++ b/src/renderer/toolbar/toolbarSections.tsx
@@ -34,6 +34,7 @@ import type {
   Tool,
   ToolbarSelectionData,
 } from '../../shared/types'
+import { activeDrawBrush } from '../../shared/tool'
 import { summarizePresenceCursor } from '../../shared/agent-presence'
 import { normalizeUserUrl } from '../../shared/url'
 import { PagePresetDropdown } from '../shared/PagePresetDropdown'
@@ -303,17 +304,12 @@ export function CenterActions({
   const onClearToolMode = () => onSetTool({ kind: 'select' })
   const onToggleAnnotateMode = () =>
     onSetTool(activeTool.kind === 'comment' ? { kind: 'select' } : { kind: 'comment' })
+  const drawBrush = activeDrawBrush(activeTool)
   const onToggleDrawMode = () =>
-    onSetTool(
-      activeTool.kind === 'draw' && activeTool.brush !== 'highlight'
-        ? { kind: 'select' }
-        : { kind: 'draw', brush: 'pen' },
-    )
+    onSetTool(drawBrush === 'pen' ? { kind: 'select' } : { kind: 'draw', brush: 'pen' })
   const onToggleHighlightMode = () =>
     onSetTool(
-      activeTool.kind === 'draw' && activeTool.brush === 'highlight'
-        ? { kind: 'select' }
-        : { kind: 'draw', brush: 'highlight' },
+      drawBrush === 'highlight' ? { kind: 'select' } : { kind: 'draw', brush: 'highlight' },
     )
   const onToggleRegionSelectMode = () =>
     onSetTool(activeTool.kind === 'region-select' ? { kind: 'select' } : { kind: 'region-select' })
@@ -384,7 +380,7 @@ export function CenterActions({
             <>
               <button
                 onClick={onToggleDrawMode}
-                className={`${activeTool.kind === 'draw' && activeTool.brush !== 'highlight' ? activeIconButtonClassName : iconButtonClassName} flex items-center gap-1`}
+                className={`${drawBrush === 'pen' ? activeIconButtonClassName : iconButtonClassName} flex items-center gap-1`}
                 title="Draw"
                 disabled={!annotateAvailable}
                 type="button"
@@ -393,7 +389,7 @@ export function CenterActions({
               </button>
               <button
                 onClick={onToggleHighlightMode}
-                className={`${activeTool.kind === 'draw' && activeTool.brush === 'highlight' ? activeIconButtonClassName : iconButtonClassName} flex items-center gap-1`}
+                className={`${drawBrush === 'highlight' ? activeIconButtonClassName : iconButtonClassName} flex items-center gap-1`}
                 title="Highlight"
                 disabled={!annotateAvailable}
                 type="button"

--- a/src/renderer/toolbar/toolbarSections.tsx
+++ b/src/renderer/toolbar/toolbarSections.tsx
@@ -9,6 +9,7 @@ import {
   Circle,
   Diamond,
   Frame,
+  Highlighter,
   LayoutTemplate,
   MessageCircle,
   Moon,
@@ -303,7 +304,17 @@ export function CenterActions({
   const onToggleAnnotateMode = () =>
     onSetTool(activeTool.kind === 'comment' ? { kind: 'select' } : { kind: 'comment' })
   const onToggleDrawMode = () =>
-    onSetTool(activeTool.kind === 'draw' ? { kind: 'select' } : { kind: 'draw' })
+    onSetTool(
+      activeTool.kind === 'draw' && activeTool.brush !== 'highlight'
+        ? { kind: 'select' }
+        : { kind: 'draw', brush: 'pen' },
+    )
+  const onToggleHighlightMode = () =>
+    onSetTool(
+      activeTool.kind === 'draw' && activeTool.brush === 'highlight'
+        ? { kind: 'select' }
+        : { kind: 'draw', brush: 'highlight' },
+    )
   const onToggleRegionSelectMode = () =>
     onSetTool(activeTool.kind === 'region-select' ? { kind: 'select' } : { kind: 'region-select' })
   const onToggleInspectMode = () =>
@@ -370,15 +381,26 @@ export function CenterActions({
           </button>
 
           {drawingEnabled ? (
-            <button
-              onClick={onToggleDrawMode}
-              className={`${activeTool.kind === 'draw' ? activeIconButtonClassName : iconButtonClassName} flex items-center gap-1`}
-              title="Draw Feedback"
-              disabled={!annotateAvailable}
-              type="button"
-            >
-              <PencilLine size={14} />
-            </button>
+            <>
+              <button
+                onClick={onToggleDrawMode}
+                className={`${activeTool.kind === 'draw' && activeTool.brush !== 'highlight' ? activeIconButtonClassName : iconButtonClassName} flex items-center gap-1`}
+                title="Draw"
+                disabled={!annotateAvailable}
+                type="button"
+              >
+                <PencilLine size={14} />
+              </button>
+              <button
+                onClick={onToggleHighlightMode}
+                className={`${activeTool.kind === 'draw' && activeTool.brush === 'highlight' ? activeIconButtonClassName : iconButtonClassName} flex items-center gap-1`}
+                title="Highlight"
+                disabled={!annotateAvailable}
+                type="button"
+              >
+                <Highlighter size={14} />
+              </button>
+            </>
           ) : null}
 
           <button

--- a/src/shared/tool.ts
+++ b/src/shared/tool.ts
@@ -10,7 +10,7 @@ export type Tool =
   | { kind: 'add-document' }
   | { kind: 'add-shape'; shapeKind: ToolShapeKind }
   | { kind: 'comment' }
-  | { kind: 'draw' }
+  | { kind: 'draw'; brush?: 'pen' | 'highlight' }
   | { kind: 'region-select' }
   | { kind: 'inspect' }
 

--- a/src/shared/tool.ts
+++ b/src/shared/tool.ts
@@ -3,6 +3,8 @@
 // Mirror of `ShapeKind` to avoid types.ts → tool.ts circular import.
 type ToolShapeKind = 'rectangle' | 'ellipse' | 'diamond'
 
+export type DrawingBrushType = 'pen' | 'highlight'
+
 export type Tool =
   | { kind: 'select' }
   | { kind: 'add-page'; presetIndex?: number; customSize?: boolean; sourcePageId?: string }
@@ -10,9 +12,17 @@ export type Tool =
   | { kind: 'add-document' }
   | { kind: 'add-shape'; shapeKind: ToolShapeKind }
   | { kind: 'comment' }
-  | { kind: 'draw'; brush?: 'pen' | 'highlight' }
+  | { kind: 'draw'; brush?: DrawingBrushType }
   | { kind: 'region-select' }
   | { kind: 'inspect' }
+
+// Returns the active brush for a draw tool (defaulting to 'pen'), or null if
+// the tool isn't a draw tool. Use this everywhere instead of re-deriving the
+// `kind === 'draw' && brush === ...` discriminator inline.
+export function activeDrawBrush(tool: Tool): DrawingBrushType | null {
+  if (tool.kind !== 'draw') return null
+  return tool.brush ?? 'pen'
+}
 
 export type ToolKind = Tool['kind']
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1939,11 +1939,14 @@ export interface AnnotationDrawingPoint {
   y: number
 }
 
+export type DrawingBrushType = 'pen' | 'highlight'
+
 export interface AnnotationDrawingStroke {
   id: string
   color: string
   width: number
   points: AnnotationDrawingPoint[]
+  brushType?: DrawingBrushType
 }
 
 export interface AnnotationDrawing {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -8,9 +8,9 @@ import type {
 } from './cursor-motion'
 import type { CursorTuningParams } from './cursor-tuning'
 import type { PresenceDebugEntry } from './presence-debug'
-import type { Tool } from './tool'
+import type { DrawingBrushType, Tool } from './tool'
 
-export type { Tool, ToolKind, ToolDuration } from './tool'
+export type { DrawingBrushType, Tool, ToolKind, ToolDuration } from './tool'
 
 // --- IPC Channel Types ---
 
@@ -1938,8 +1938,6 @@ export interface AnnotationDrawingPoint {
   x: number
   y: number
 }
-
-export type DrawingBrushType = 'pen' | 'highlight'
 
 export interface AnnotationDrawingStroke {
   id: string


### PR DESCRIPTION
## Summary

- New highlighter brush alongside the existing pen in the drawing tool. Toolbar exposes it as a separate button (Highlighter icon).
- Highlight strokes render as a perfect-freehand outline filled with a directional gradient (denser at start/end, lighter in the middle) plus a subtle SVG turbulence-grain filter for paper texture.
- Brush type is persisted on each stroke (`brushType: 'pen' | 'highlight'`).
- Centralised the draw/highlight discriminator in `activeDrawBrush(tool)` and reused the existing `withAlpha` helper from `canvas-colors`.

## Test plan

- [ ] Toggle the Highlight tool from the toolbar; confirm the icon shows active and the cursor enters draw mode
- [ ] Draw a horizontal highlight stroke at default zoom — no flag-shaped end caps, no clipping
- [ ] Draw a slow stroke (lots of points) and a quick swipe — both stay smooth
- [ ] Cross two highlight strokes; both remain visible (no opaque overpaint)
- [ ] Switch back to the Pen tool; pen strokes still render with the existing red fill
- [ ] Save & reload a canvas containing both pen and highlight strokes; both round-trip correctly
- [ ] Undo/redo works for highlight strokes