### PR TITLE
chore(orchestrator): journal entry 2026-05-10 (first real run)

### DIFF
--- a/docs/orchestrator/journal.md
+++ b/docs/orchestrator/journal.md
@@ -24,3 +24,10 @@ Hint for next run: <one sentence for tomorrow-you>
 Surveyed: nothing yet — first run, system being set up.
 Notes: scope clarified — orchestrator watches the *automation system*, not the product. Output is proposals to improve the system (skills, prompts, labels, habits), not actions inside the system. Operating skills already in place: `/triage`, `/to-issues`, `/to-prd`, `/grill-with-docs`, `/improve-codebase-architecture`.
 Hint for next run: on first real run, baseline the system. Count merged PRs in the last week, what fraction came via the AFK pipeline, current `needs-triage` and `ready-for-agent` queue depths, and when the skills directory was last touched. That snapshot is what future runs compare against to spot leaks.
+
+## 2026-05-10 (first real run)
+Surveyed: Last 30 merged PRs, Lyle's commits since May 3, issue queues (`needs-triage`, `ready-for-agent`, `orchestrator-proposal`), CI workflows, and `.claude/skills` history.
+Acted:
+- #63 — Proposed basic PR CI workflow (`typecheck` + `test:unit` + SKILL.md diff). Two observed instances of manual "typecheck + test:unit pass" documentation in structural rename commits: `telescope → specular` (#36) and `frame → page` (#50). Absorbs open proposal #61 as a step in the same workflow — no separate workflow file needed.
+Noticed (no action): AFK pipeline dormant — `ready-for-agent` queue = 0, all 30 recent PRs authored by lklyne (Claude co-authors via sessions but doesn't open PRs independently). The two `[codex]`-prefixed PRs (#25, #26) from April 23 are the only prior AFK-style artifacts visible. Not a leak; looks like an intentional HITL workflow. Baseline to track: if `ready-for-agent` stays at 0 for 3+ weeks while `needs-triage` grows, that's signal the triage-to-agent routing isn't working.
+Hint for next run: Watch whether #63 and #61 land or stall. If neither is acted on within ~2 weeks, stop proposing new CI and write a "why aren't proposals converting?" reflection instead.


### PR DESCRIPTION
Appends the first real orchestrator run entry to `docs/orchestrator/journal.md`.

**What ran:** Baselined the last 30 merged PRs, Lyle's commits since May 3, issue queue depths (`needs-triage` = 1, `ready-for-agent` = 0, `orchestrator-proposal` = 1 open), CI state, and `.claude/skills` history.

**Proposal filed:** #63 — Add basic PR CI (`typecheck` + `test:unit` + SKILL.md diff), absorbing open proposal #61.

**Key baseline numbers for future comparison:**
- Merged PRs/week: ~9 (all HITL, Claude co-authors)
- `ready-for-agent` queue: 0
- `needs-triage` queue: 1
- Open orchestrator proposals: 2 (#61, #63)
- CI workflows: `release.yml` only (no PR gate)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPCEzmoSpk1BfxQfbS8RHb)_