### PR TITLE
Add HTML file rendering support to canvas

### DIFF
--- a/.claude/skills/specular/SKILL.md
+++ b/.claude/skills/specular/SKILL.md
@@ -52,7 +52,7 @@ Annotations are a single concept (a comment thread) discriminated by **anchor ty
 |---|---|---|
 | page | `specular create page <url>` | Live web page rendered in a webview |
 | text | `specular create note <text>` | Short text note (sticky-note style) |
-| file | `specular upsert --json` | File entity — markdown (`.md`) or wireframe (`.wireframe.json`) |
+| file | `specular upsert --json` | File entity — markdown (`.md`), wireframe (`.wireframe.json`), or HTML (`.html`) |
 
 ### Upsert tips
 
@@ -155,6 +155,10 @@ EOF
 ```
 
 See [references/wireframes.md](references/wireframes.md) for the full node schema, layout patterns, and examples.
+
+### HTML pages
+
+Drop a `.html` file onto the canvas to render it inline (charts, mockups, generated visualizations). Write the file to disk, then upsert with `{ "kind": "file", "file": "/abs/path/viz.html" }`. Rendered display-only; edit the file to update.
 
 ## Passing URLs
 

--- a/resources/skills/specular/SKILL.md
+++ b/resources/skills/specular/SKILL.md
@@ -52,7 +52,7 @@ Annotations are a single concept (a comment thread) discriminated by **anchor ty
 |---|---|---|
 | page | `specular create page <url>` | Live web page rendered in a webview |
 | text | `specular create note <text>` | Short text note (sticky-note style) |
-| file | `specular upsert --json` | File entity — markdown (`.md`) or wireframe (`.wireframe.json`) |
+| file | `specular upsert --json` | File entity — markdown (`.md`), wireframe (`.wireframe.json`), or HTML (`.html`) |
 
 ### Upsert tips
 
@@ -155,6 +155,10 @@ EOF
 ```
 
 See [references/wireframes.md](references/wireframes.md) for the full node schema, layout patterns, and examples.
+
+### HTML pages
+
+Drop a `.html` file onto the canvas to render it inline (charts, mockups, generated visualizations). Write the file to disk, then upsert with `{ "kind": "file", "file": "/abs/path/viz.html" }`. Rendered display-only; edit the file to update.
 
 ## Passing URLs
 

--- a/src/main/ipc/register-canvas-ipc.ts
+++ b/src/main/ipc/register-canvas-ipc.ts
@@ -16,6 +16,8 @@ import {
 } from '../runtime/surface-layout'
 import { saveImageBuffer } from '../runtime/image-assets'
 import { imageSizeFromBuffer } from '../runtime/image-sizing'
+import { HTML_EXTENSIONS } from '../../shared/file-extensions'
+import { deviceForPresetIndex, DESKTOP_PRESET_INDEX } from '../../shared/device-catalog'
 import {
   focusSelectedPage,
   getSelectedEntityIds,
@@ -78,6 +80,17 @@ import {
 import { consumeDragId } from '../runtime/drop-owner'
 import { registerCanvasDragIpc } from './register-canvas-drag-ipc'
 import { registerCanvasEntityIpc } from './register-canvas-entity-ipc'
+
+// HTML files don't carry intrinsic pixel dimensions like images do, so the
+// generic file fallback lands them as a small tile. Use the Desktop preset
+// (landscape) instead — sensible for charts, mockups, and generated viz.
+function defaultDropSizeForExt(ext: string, buffer: Buffer): { width: number; height: number } {
+  if (HTML_EXTENSIONS.test(`.${ext}`)) {
+    const desktop = deviceForPresetIndex(DESKTOP_PRESET_INDEX)
+    if (desktop) return { width: desktop.viewport.width, height: desktop.viewport.height }
+  }
+  return imageSizeFromBuffer(buffer)
+}
 
 export function registerCanvasIpc(): void {
   registerCanvasDragIpc()
@@ -465,7 +478,7 @@ export function registerCanvasIpc(): void {
       }
 
       const file = saveImageBuffer(buffer, ext)
-      const { width, height } = imageSizeFromBuffer(buffer)
+      const { width, height } = defaultDropSizeForExt(ext, buffer)
       createFileEntity({ canvasX, canvasY, file, width, height })
     },
   )

--- a/src/main/ipc/register-canvas-ipc.ts
+++ b/src/main/ipc/register-canvas-ipc.ts
@@ -15,9 +15,7 @@ import {
   zoom,
 } from '../runtime/surface-layout'
 import { saveImageBuffer } from '../runtime/image-assets'
-import { imageSizeFromBuffer } from '../runtime/image-sizing'
-import { HTML_EXTENSIONS } from '../../shared/file-extensions'
-import { deviceForPresetIndex, DESKTOP_PRESET_INDEX } from '../../shared/device-catalog'
+import { htmlDefaultSize, imageSizeFromBuffer } from '../runtime/image-sizing'
 import {
   focusSelectedPage,
   getSelectedEntityIds,
@@ -80,17 +78,6 @@ import {
 import { consumeDragId } from '../runtime/drop-owner'
 import { registerCanvasDragIpc } from './register-canvas-drag-ipc'
 import { registerCanvasEntityIpc } from './register-canvas-entity-ipc'
-
-// HTML files don't carry intrinsic pixel dimensions like images do, so the
-// generic file fallback lands them as a small tile. Use the Desktop preset
-// (landscape) instead — sensible for charts, mockups, and generated viz.
-function defaultDropSizeForExt(ext: string, buffer: Buffer): { width: number; height: number } {
-  if (HTML_EXTENSIONS.test(`.${ext}`)) {
-    const desktop = deviceForPresetIndex(DESKTOP_PRESET_INDEX)
-    if (desktop) return { width: desktop.viewport.width, height: desktop.viewport.height }
-  }
-  return imageSizeFromBuffer(buffer)
-}
 
 export function registerCanvasIpc(): void {
   registerCanvasDragIpc()
@@ -478,7 +465,7 @@ export function registerCanvasIpc(): void {
       }
 
       const file = saveImageBuffer(buffer, ext)
-      const { width, height } = defaultDropSizeForExt(ext, buffer)
+      const { width, height } = htmlDefaultSize(`.${ext}`) ?? imageSizeFromBuffer(buffer)
       createFileEntity({ canvasX, canvasY, file, width, height })
     },
   )

--- a/src/main/plugins/builtin/html-render.ts
+++ b/src/main/plugins/builtin/html-render.ts
@@ -1,0 +1,10 @@
+import { HTML_EXTENSIONS } from '../../../shared/file-extensions'
+import type { InlineRendererClaim } from '../registry'
+
+export const htmlRenderPlugin: InlineRendererClaim = {
+  id: 'specular.html',
+  kind: 'inline',
+  rendererTag: 'html',
+  editable: false,
+  claims: (entity) => HTML_EXTENSIONS.test(entity.file),
+}

--- a/src/main/plugins/index.ts
+++ b/src/main/plugins/index.ts
@@ -7,6 +7,7 @@
 
 import { registerEntityRenderer, unregisterEntityRenderer } from './registry'
 import { componentRenderPlugin } from './builtin/component-render'
+import { htmlRenderPlugin } from './builtin/html-render'
 import { imageRenderPlugin } from './builtin/image-render'
 import { markdownRenderPlugin } from './builtin/markdown-render'
 import { videoRenderPlugin } from './builtin/video-render'
@@ -14,6 +15,7 @@ import { wireframeRenderPlugin } from './builtin/wireframe-render'
 
 const builtIns = [
   componentRenderPlugin,
+  htmlRenderPlugin,
   imageRenderPlugin,
   markdownRenderPlugin,
   videoRenderPlugin,

--- a/src/main/plugins/registry.ts
+++ b/src/main/plugins/registry.ts
@@ -21,6 +21,7 @@ export type EntityRendererTag =
   | 'image'
   | 'video'
   | 'component'
+  | 'html'
 
 interface BaseRendererClaim {
   /** Stable id used for telemetry, debugging, and unregister. */

--- a/src/main/routes/entities.ts
+++ b/src/main/routes/entities.ts
@@ -15,6 +15,8 @@ import { createPages } from '../workspace-pages'
 import { deletePages } from '../workspace-entities'
 import { findPageById } from '../runtime/runtime-context'
 import { imageSizeFromPath, videoSizeFromPath } from '../runtime/image-sizing'
+import { HTML_EXTENSIONS } from '../../shared/file-extensions'
+import { deviceForPresetIndex, DESKTOP_PRESET_INDEX } from '../../shared/device-catalog'
 import {
   animateCursorScan,
   allEntityPositions,
@@ -161,7 +163,12 @@ export const entityRoutes: Route[] = [
       const resolveFileDimensions = (item: { file: string; width?: number; height?: number }) => {
         if (item.width != null && item.height != null) return { width: item.width, height: item.height }
         const fromImage = imageSizeFromPath(item.file) ?? videoSizeFromPath(item.file)
-        return fromImage ?? { width: item.width, height: item.height }
+        if (fromImage) return fromImage
+        if (HTML_EXTENSIONS.test(item.file)) {
+          const desktop = deviceForPresetIndex(DESKTOP_PRESET_INDEX)
+          if (desktop) return { width: desktop.viewport.width, height: desktop.viewport.height }
+        }
+        return { width: item.width, height: item.height }
       }
       const items = payload.items ?? [payload]
       if (items.length <= 1) {

--- a/src/main/routes/entities.ts
+++ b/src/main/routes/entities.ts
@@ -14,9 +14,7 @@ import { createNoteFile } from '../runtime/note-assets'
 import { createPages } from '../workspace-pages'
 import { deletePages } from '../workspace-entities'
 import { findPageById } from '../runtime/runtime-context'
-import { imageSizeFromPath, videoSizeFromPath } from '../runtime/image-sizing'
-import { HTML_EXTENSIONS } from '../../shared/file-extensions'
-import { deviceForPresetIndex, DESKTOP_PRESET_INDEX } from '../../shared/device-catalog'
+import { htmlDefaultSize, imageSizeFromPath, videoSizeFromPath } from '../runtime/image-sizing'
 import {
   animateCursorScan,
   allEntityPositions,
@@ -162,13 +160,8 @@ export const entityRoutes: Route[] = [
       }
       const resolveFileDimensions = (item: { file: string; width?: number; height?: number }) => {
         if (item.width != null && item.height != null) return { width: item.width, height: item.height }
-        const fromImage = imageSizeFromPath(item.file) ?? videoSizeFromPath(item.file)
-        if (fromImage) return fromImage
-        if (HTML_EXTENSIONS.test(item.file)) {
-          const desktop = deviceForPresetIndex(DESKTOP_PRESET_INDEX)
-          if (desktop) return { width: desktop.viewport.width, height: desktop.viewport.height }
-        }
-        return { width: item.width, height: item.height }
+        const detected = imageSizeFromPath(item.file) ?? videoSizeFromPath(item.file) ?? htmlDefaultSize(item.file)
+        return detected ?? { width: item.width, height: item.height }
       }
       const items = payload.items ?? [payload]
       if (items.length <= 1) {

--- a/src/main/runtime/image-sizing.ts
+++ b/src/main/runtime/image-sizing.ts
@@ -1,6 +1,7 @@
 import { nativeImage } from 'electron'
 import { execFileSync } from 'child_process'
-import { VIDEO_EXTENSIONS } from '../../shared/file-extensions'
+import { HTML_EXTENSIONS, VIDEO_EXTENSIONS } from '../../shared/file-extensions'
+import { DESKTOP_PRESET_INDEX, deviceForPresetIndex } from '../../shared/device-catalog'
 import { DEFAULT_FILE_WIDTH, DEFAULT_FILE_HEIGHT } from './file-entity-state'
 
 const DEFAULT_FALLBACK = { width: DEFAULT_FILE_WIDTH, height: DEFAULT_FILE_HEIGHT }
@@ -15,6 +16,15 @@ export function imageSizeFromPath(filePath: string): { width: number; height: nu
   const img = nativeImage.createFromPath(filePath)
   if (img.isEmpty()) return null
   return img.getSize()
+}
+
+// HTML files have no intrinsic pixel dimensions. Default to the Desktop
+// viewport preset so charts, mockups, and generated viz land readably.
+export function htmlDefaultSize(filePath: string): { width: number; height: number } | null {
+  if (!HTML_EXTENSIONS.test(filePath)) return null
+  const desktop = deviceForPresetIndex(DESKTOP_PRESET_INDEX)
+  if (!desktop) return null
+  return { width: desktop.viewport.width, height: desktop.viewport.height }
 }
 
 export function videoSizeFromPath(filePath: string): { width: number; height: number } | null {

--- a/src/renderer/above-view/FileBodyLayer.tsx
+++ b/src/renderer/above-view/FileBodyLayer.tsx
@@ -148,6 +148,7 @@ function FileBodyCard({
             entity={entity}
             canEdit={canEdit}
             isDark={isDark}
+            isSelected={isSelected}
             wireframeJsonMode={wireframeJsonMode}
             onTextEditingChange={onTextEditingChange}
           />

--- a/src/renderer/above-view/FilePopup.tsx
+++ b/src/renderer/above-view/FilePopup.tsx
@@ -63,12 +63,13 @@ export function FilePopup({
       layout={layout}
       open={open}
       placement="above"
+      align={isSingle ? 'stretch' : 'center'}
       offset={POPUP_OFFSET_Y}
     >
       <CanvasItemPopup.Frame isDark={isDark}>
         {single ? (
-          <CanvasItemPopup.Section>
-            <span className="flex items-center gap-1.5">
+          <CanvasItemPopup.Section grow>
+            <span className="flex min-w-0 flex-1 items-center gap-1.5">
               {(() => {
                 const FileIcon = iconForFilePath(single.file)
                 return <FileIcon size={13} className="shrink-0 text-zinc-400" />
@@ -84,7 +85,7 @@ export function FilePopup({
                 onCancel={() => setIsRenaming(false)}
                 variant="canvas-chrome"
                 isDark={isDark}
-                titleClassName="min-w-0 truncate text-xs font-medium"
+                titleClassName="min-w-0 flex-1 truncate text-xs font-medium"
                 onTitleClick={() => setIsRenaming(true)}
               />
             </span>

--- a/src/renderer/canvas-bg/entity-renderers/HtmlInlineRenderer.tsx
+++ b/src/renderer/canvas-bg/entity-renderers/HtmlInlineRenderer.tsx
@@ -1,0 +1,19 @@
+import type { CanvasSceneFileEntity } from '../../../shared/types'
+import { filePathToSrc } from './filePathToSrc'
+
+export function HtmlInlineRenderer({ entity }: { entity: CanvasSceneFileEntity }) {
+  const fileName = entity.file.split('/').pop() ?? entity.file
+  return (
+    <iframe
+      src={filePathToSrc(entity.file)}
+      title={fileName}
+      style={{
+        width: '100%',
+        height: '100%',
+        border: 'none',
+        pointerEvents: 'none',
+        background: 'white',
+      }}
+    />
+  )
+}

--- a/src/renderer/canvas-bg/entity-renderers/HtmlInlineRenderer.tsx
+++ b/src/renderer/canvas-bg/entity-renderers/HtmlInlineRenderer.tsx
@@ -1,7 +1,13 @@
 import type { CanvasSceneFileEntity } from '../../../shared/types'
 import { filePathToSrc } from './filePathToSrc'
 
-export function HtmlInlineRenderer({ entity }: { entity: CanvasSceneFileEntity }) {
+export function HtmlInlineRenderer({
+  entity,
+  isSelected,
+}: {
+  entity: CanvasSceneFileEntity
+  isSelected: boolean
+}) {
   const fileName = entity.file.split('/').pop() ?? entity.file
   return (
     <iframe
@@ -11,7 +17,7 @@ export function HtmlInlineRenderer({ entity }: { entity: CanvasSceneFileEntity }
         width: '100%',
         height: '100%',
         border: 'none',
-        pointerEvents: 'none',
+        pointerEvents: isSelected ? 'auto' : 'none',
         background: 'white',
       }}
     />

--- a/src/renderer/canvas-bg/entity-renderers/RendererSwitch.tsx
+++ b/src/renderer/canvas-bg/entity-renderers/RendererSwitch.tsx
@@ -1,5 +1,6 @@
 import type { CanvasSceneFileEntity } from '../../../shared/types'
 import {
+  HTML_EXTENSIONS,
   IMAGE_EXTENSIONS,
   MARKDOWN_EXTENSIONS,
   VIDEO_EXTENSIONS,
@@ -7,6 +8,7 @@ import {
 } from '../entityConstants'
 import { ComponentPlaceholderRenderer } from './ComponentPlaceholderRenderer'
 import { FileFallbackRenderer } from './FileFallbackRenderer'
+import { HtmlInlineRenderer } from './HtmlInlineRenderer'
 import { ImageInlineRenderer } from './ImageInlineRenderer'
 import { MarkdownInlineRenderer } from './MarkdownInlineRenderer'
 import { VideoInlineRenderer } from './VideoInlineRenderer'
@@ -24,6 +26,7 @@ function resolveTag(entity: CanvasSceneFileEntity): CanvasSceneFileEntity['rende
   if (VIDEO_EXTENSIONS.test(entity.file)) return 'video'
   if (WIREFRAME_EXTENSIONS.test(entity.file)) return 'wireframe'
   if (MARKDOWN_EXTENSIONS.test(entity.file)) return 'markdown'
+  if (HTML_EXTENSIONS.test(entity.file)) return 'html'
   return undefined
 }
 
@@ -66,6 +69,8 @@ export function RendererSwitch({
       )
     case 'component':
       return <ComponentPlaceholderRenderer entity={entity} isDark={isDark} />
+    case 'html':
+      return <HtmlInlineRenderer entity={entity} />
     default:
       return <FileFallbackRenderer entity={entity} isDark={isDark} />
   }

--- a/src/renderer/canvas-bg/entity-renderers/RendererSwitch.tsx
+++ b/src/renderer/canvas-bg/entity-renderers/RendererSwitch.tsx
@@ -34,12 +34,14 @@ export function RendererSwitch({
   entity,
   canEdit,
   isDark,
+  isSelected,
   wireframeJsonMode,
   onTextEditingChange,
 }: {
   entity: CanvasSceneFileEntity
   canEdit: boolean
   isDark: boolean
+  isSelected: boolean
   wireframeJsonMode: boolean
   onTextEditingChange: (active: boolean) => void
 }) {
@@ -70,7 +72,7 @@ export function RendererSwitch({
     case 'component':
       return <ComponentPlaceholderRenderer entity={entity} isDark={isDark} />
     case 'html':
-      return <HtmlInlineRenderer entity={entity} />
+      return <HtmlInlineRenderer entity={entity} isSelected={isSelected} />
     default:
       return <FileFallbackRenderer entity={entity} isDark={isDark} />
   }

--- a/src/renderer/canvas-bg/entityConstants.ts
+++ b/src/renderer/canvas-bg/entityConstants.ts
@@ -20,6 +20,7 @@ export {
   VIDEO_EXTENSIONS,
   MARKDOWN_EXTENSIONS,
   WIREFRAME_EXTENSIONS,
+  HTML_EXTENSIONS,
 } from '../../shared/file-extensions'
 import { IMAGE_EXTENSIONS, VIDEO_EXTENSIONS } from '../../shared/file-extensions'
 import { RESIZE_HANDLE_VISUAL_PX } from '../../shared/canvas-hit-geometry'

--- a/src/renderer/shared/fileIcon.ts
+++ b/src/renderer/shared/fileIcon.ts
@@ -1,5 +1,6 @@
-import { File, FileText, Image, PenLine, Video, type LucideIcon } from 'lucide-react'
+import { Code, File, FileText, Image, PenLine, Video, type LucideIcon } from 'lucide-react'
 import {
+  HTML_EXTENSIONS,
   IMAGE_EXTENSIONS,
   MARKDOWN_EXTENSIONS,
   VIDEO_EXTENSIONS,
@@ -14,5 +15,6 @@ export function iconForFilePath(filePath: string): LucideIcon {
   if (IMAGE_EXTENSIONS.test(filePath)) return Image
   if (VIDEO_EXTENSIONS.test(filePath)) return Video
   if (WIREFRAME_EXTENSIONS.test(filePath)) return PenLine
+  if (HTML_EXTENSIONS.test(filePath)) return Code
   return File
 }

--- a/src/shared/file-extensions.ts
+++ b/src/shared/file-extensions.ts
@@ -2,3 +2,4 @@ export const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|svg|webp|bmp|ico)$/i
 export const VIDEO_EXTENSIONS = /\.(webm|mp4|mov|ogg)$/i
 export const MARKDOWN_EXTENSIONS = /\.md$/i
 export const WIREFRAME_EXTENSIONS = /\.wireframe\.json$/i
+export const HTML_EXTENSIONS = /\.html?$/i

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -174,7 +174,7 @@ export interface CanvasSceneFileEntity {
   parentGroupId?: string
   objectFit?: FileObjectFit
   /** Renderer-side dispatch tag chosen by the entity-renderer registry. */
-  rendererTag?: 'image' | 'video' | 'markdown' | 'wireframe' | 'component'
+  rendererTag?: 'image' | 'video' | 'markdown' | 'wireframe' | 'component' | 'html'
   /**
    * Static contribution tags declared by the picked renderer plugin (ADR 0008
    * §7). The `FilePopup` reads these to compose plugin-specific controls
@@ -791,7 +791,14 @@ export interface PanelTextEntityDetail {
   height: number
 }
 
-export type PanelFileType = 'image' | 'video' | 'markdown' | 'wireframe' | 'component' | 'other'
+export type PanelFileType =
+  | 'image'
+  | 'video'
+  | 'markdown'
+  | 'wireframe'
+  | 'component'
+  | 'html'
+  | 'other'
 
 export interface PanelFileEntityDetail {
   id: string


### PR DESCRIPTION
## Summary

Adds `.html` as a first-class file entity on the canvas, rendered inline via iframe. Files land at the Desktop viewport preset by default; scroll is enabled when selected; the file popup stretches to width when only one file is selected.

## Changes

- New `HtmlInlineRenderer` mounted via the entity-renderer registry (`htmlRenderPlugin`, `rendererTag: 'html'`, `editable: false`)
- `HTML_EXTENSIONS` (`/\.html?$/i`) added to `src/shared/file-extensions.ts`; wired through `RendererSwitch`, `EntityRendererTag`, `PanelFileType`, and `fileIcon` (Lucide `Code`)
- `htmlDefaultSize(filePath)` helper in `runtime/image-sizing.ts` returns the Desktop viewport when the path looks like HTML; used by both the drop IPC and the entities HTTP route, so dimension resolution stays uniform across drag-drop and upsert
- `FileBodyLayer` threads `isSelected` into `RendererSwitch`; the iframe enables `pointerEvents` only while selected so the rest of the canvas stays clickable but users can scroll a selected page
- `FilePopup` uses `align="stretch"` and a flex layout when a single file is selected, so the popup matches the file's width
- Skill doc (`.claude/skills/specular/SKILL.md` + `resources/skills/specular/SKILL.md`) describes the HTML drop / upsert flow

## Test plan

- [ ] Drop a `.html` file on the canvas — lands at Desktop viewport size, renders inline
- [ ] Upsert a file entity with `{ "kind": "file", "file": "/abs/path.html" }` via the HTTP API — same default size
- [ ] Select an HTML entity and scroll inside it — scroll works only on the selected one
- [ ] Deselect — pointer events fall through to the canvas
- [ ] Select a single file entity — popup stretches to the entity's width
- [ ] Multi-select files — popup falls back to centered, fixed width
- [ ] `pnpm typecheck` + `pnpm test:unit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)