### PR TITLE
Plan + ADRs: keyboard binding registry

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -136,6 +136,20 @@ Discriminated by `anchor.type: 'element' | 'canvas' | 'region'`. The legacy `Ann
 
 **Pending composer** — single component that mounts after the gesture and before the comment is committed. Placement is a thin function over the anchor: above-right of the element bbox, adjacent to the click point, or above-right of the region rect. Esc cancels; click outside commits (if non-empty) or discards (if empty); only one pending composer exists at a time.
 
+## Keyboard bindings
+
+A **Binding** is one entry in the keyboard registry: `{ id, defaultKey, scope, target, when?, firesWhileTyping?, firesFromPageFocus?, label }`. The registry is the single source of truth — the dispatcher reads it, the app menu reads it, future tooltips and Bindings settings read it. See [ADR 0010](./docs/adr/0010-main-as-sole-shortcut-dispatch-site.md) and [`docs/plans/keyboard-binding-registry.md`](./docs/plans/keyboard-binding-registry.md).
+
+- **BindingId** — string-literal union of every shortcut's canonical name (e.g. `'tool-comment'`, `'undo'`, `'select-all'`). Lives in `src/shared/bindings.ts`.
+- **NormalizedKey** — `{ key, cmd, alt, shift }` where `key` is lowercased and `cmd` collapses `Cmd`/`Ctrl` per platform. The cross-process key representation; both Electron `Input` events and DOM `KeyboardEvent`s normalise to this.
+- **Binding dispatcher** — pure function `dispatchKey(table, key, ctx) → BindingId | null` in `src/shared/bindings.ts`. The only dispatch happens in main's `before-input-event` listener, attached to every WebContentsView (see ADR 0010).
+- **Keyboard source view** — which WebContentsView produced a keystroke (`'aboveView' | 'canvasBg' | 'toolbar' | 'leftSidebar' | 'rightDetailsPanel' | 'devtoolsHeader' | 'devtoolsResizeHandle' | 'page'`). Each binding declares the source views it can fire from via `scope: KeyboardSourceView[]`. Distinct from **page focus** (ADR 0001): page focus says "which page receives native input"; keyboard source view says "which view produced this keystroke."
+- **Binding target** — `'main' | KeyboardSourceView`. Where the handler runs. Most bindings run in main; a few (annotation overlay) run in a renderer because their state is renderer-local React `useState`.
+- **`firesWhileTyping`** — opt-in flag for a binding to fire when `isTextEditing` is true. Default `false`. Only `undo`, `redo`, `reset-viewport`, and `escape-tool` opt in.
+- **`firesFromPageFocus`** — opt-in flag for a binding to fire when a page has keyboard focus (per [ADR 0011](./docs/adr/0011-page-focus-respects-native-shortcuts.md)). Default `false`. Only `escape-page-focus` and `reset-viewport` opt in.
+
+**Keyboard shortcuts and tools.** Every `Tool['kind']` has a default key, enforced by TypeScript exhaustiveness. Variant keys (e.g. Shift+R for diamond, Shift+M for highlight) activate the tool *and* write the variant to **tool defaults** per ADR 0009. Pressing a tool's key while that tool is already active is a no-op (FigJam reference); Escape is the only keyboard path back to `select`.
+
 ## UI copy voice
 
 - **Sentence case** — capitalize the first word only. Default for menus, buttons, dialog text, chrome labels: "Reveal codebase in finder", "Delete project…", "Rename".

--- a/docs/adr/0010-main-as-sole-shortcut-dispatch-site.md
+++ b/docs/adr/0010-main-as-sole-shortcut-dispatch-site.md
@@ -1,0 +1,96 @@
+# ADR 0010 — Main is the sole shortcut dispatch site
+
+**Status:** Proposed
+**Date:** 2026-05-12
+**Refines:** [ADR 0005 — Unified `Tool` concept](./0005-unified-tool-concept.md). ADR 0005 §"Decision" identified keyboard shortcuts as the follow-up enabled by unifying `Tool` but left out of that ADR. This is that follow-up.
+**Companion to:** [ADR 0011 — Page focus respects native shortcuts](./0011-page-focus-respects-native-shortcuts.md). See [`docs/plans/keyboard-binding-registry.md`](../plans/keyboard-binding-registry.md) for the implementation plan.
+
+## Context
+
+Keyboard shortcut handling today is split across three locations:
+
+1. **Main process** — `src/main/runtime/keyboard-shortcuts.ts` registers a `before-input-event` listener on every WebContentsView. 285 lines of inline `if (input.type === 'keyDown' && input.meta && ...)` blocks.
+2. **Renderer process** — three hooks (`useAnnotateToggleShortcut`, `useAnnotationOverlayShortcuts`, the v/c/d branches of `useCanvasGlobalShortcuts`) install `keydown` listeners. They exist to make v/c/d fire when focus is in views where main passes `handleShortcuts: false`.
+3. **App menu** — `src/main/runtime/app-menu.ts` declares `accelerator: 'CmdOrCtrl+W'` strings, decoupled from the other two.
+
+The split exists because no single WebContents reliably sees every keystroke. The toolbar, right-details-panel, and pages each have `handleShortcuts: false` in main's listener, and the renderer hooks compensate for some of those gaps. Effects:
+
+- "Where is the `v` shortcut defined?" has three answers depending on which WebContents has focus.
+- The shortcut→action mapping is duplicated across files. v/c/d live in `keyboard-shortcuts.ts` *and* in `useAnnotateToggleShortcut.ts`.
+- The text-editing suppression predicate is asked in three places: `isTypingTarget(event.target)` inline in each renderer hook, plus `isTextEditingActive()` in main, plus the ref-counted IPC flag that synchronizes them.
+- Adding a new shortcut is a 4-file diff and has to consider which views need to fire it.
+- No unit tests exist. The interface forces tests to simulate Electron's `Input` events; nobody has paid that cost.
+- The late-bound `wireKeyboardShortcuts(...)` setter pattern works around an import cycle, adding a configuration step that's easy to forget.
+
+This is the same accidental-complexity shape ADR 0005 fixed for `Tool`: one user concept, three implementations.
+
+## Decision
+
+Main is the sole dispatch site for keyboard shortcuts. Renderer `keydown` listeners are an anti-pattern for *shortcut handling*.
+
+Concretely:
+
+1. A single binding registry lives in `src/shared/bindings.ts` as pure data: `readonly Binding[]`.
+2. A single dispatch function `dispatchKey(table, key, ctx) → BindingId | null` is pure and unit-testable.
+3. Main's `before-input-event` is the *only* place that calls `dispatchKey`. Every WebContentsView (overlays, pages, sidebars) has this listener attached via `attachBindingDispatcher(wc, sourceView)`.
+4. Each binding declares a `scope: KeyboardSourceView[]` listing which source views can fire it. This replaces the `handleShortcuts: false` per-view flag.
+5. Each binding declares a `target: 'main' | KeyboardSourceView`. Most run in main; the few that touch renderer-local React state (`annotation-close-thread`, `annotation-clear-draft`) declare a renderer target. Main dispatches, sends `binding-fire` IPC, and the target renderer runs the handler.
+6. The app menu reads from the same table: `accelerator: acceleratorFor('close-tab')`. The menu and dispatcher cannot drift.
+
+DOM `ClipboardEvent` handling (Cmd+C / Cmd+V / Cmd+X for the canvas) stays in a renderer hook, because `event.clipboardData` and `window.getSelection()` exist only renderer-side. Clipboard events are not keystrokes; they're a separate browser event family and stay outside the registry.
+
+## Alternatives considered
+
+**A. Status quo (split dispatch).** Reject. Causes the duplication and drift documented in Context. The Bindings UI mentioned in the recent settings-window work has nothing to bind against; future contributors keep adding renderer hooks.
+
+**B. Renderer-side dispatch as primary, main-side as fallback.** Renderers run dispatch on their own keydown listeners; uncaught keys forward to main. Reject. Distributes the table across processes (it'd live in `src/shared/` but be evaluated independently in each), keeps the typing-target check duplicated, and re-introduces the v/c/d-in-multiple-views problem for any future contributor adding shortcuts in a renderer.
+
+**C. Per-renderer registries.** Each view declares its own bindings. Reject. The Bindings pane (future) can't show a single table; the menu accelerators can't be derived; users debugging a shortcut have to know which view owns it.
+
+**D. Single registry, dispatch in any process.** The table is shared but the dispatcher runs in whichever process has focus. Reject. Re-introduces "where is dispatch happening for this keystroke" as a question, and the keystrokes a renderer sees are a subset of what main sees (some keys arrive at main's `before-input-event` before any renderer keydown listener fires). Main is the only process that sees every keystroke reliably.
+
+**E. Promote all renderer-local state to main so every handler can live in main.** Specifically, promote `pendingAnnotation` and `openThreadId` (the two renderer-state cases) to main runtime variables broadcast via layout. Reject as part of this work — it's a separate refactor and not load-bearing. The `target: 'main' | KeyboardSourceView` field is a clean expression of where each handler lives without forcing the state migration.
+
+## Consequences
+
+**Replaces:**
+- `src/main/runtime/keyboard-shortcuts.ts` — replaced by `binding-dispatcher.ts` + `binding-handlers.ts`.
+- `useAnnotateToggleShortcut.ts`, `useAnnotationOverlayShortcuts.ts` — deleted.
+- v/c/d/escape/delete keyboard branches of `useCanvasGlobalShortcuts.ts` — deleted (clipboard extracted into `useCanvasClipboard.ts`).
+- `wireKeyboardShortcuts(...)` late-bound setter — deleted.
+- `watchModifierKeys(wc, { handleShortcuts: boolean })` — replaced by `attachBindingDispatcher(wc, sourceView: KeyboardSourceView)`.
+- `handleShortcuts: false` per-view flag — replaced by per-binding `scope`.
+
+**Enables:**
+- Pure-function test surface: every binding is a one-line unit test.
+- Bindings settings pane (future) reads one table.
+- Toolbar tooltips (future) read one table.
+- New shortcuts are a one-row diff, not a four-file diff.
+- Menu accelerators cannot drift from dispatch.
+- New tools are forced to have a default key (TypeScript exhaustiveness over `Tool['kind']`).
+
+**Costs:**
+- Two renderer-targeted bindings (`annotation-close-thread`, `annotation-clear-draft`) cost one IPC roundtrip per keystroke. Imperceptible in practice; flagged for future profiling.
+- Behavior changes — see Migration.
+
+## Migration
+
+The plan in `docs/plans/keyboard-binding-registry.md` steps through this in four PRs: registry-only addition, port main, port renderers, port menu. Each step ends in a working app.
+
+The behavior changes that land alongside:
+
+- Tool keys no longer toggle on second keypress (FigJam reference).
+- Duplicate no longer auto-groups (separate but adjacent cleanup).
+- `Cmd+A` is now a real canvas binding (`select-all` for entities) outside text editing.
+- Page focus no longer captures `Cmd+Z` and friends (see [ADR 0011](./0011-page-focus-respects-native-shortcuts.md)).
+
+Changelog entries required for each.
+
+## Tests
+
+- **Unit:** the binding table is well-formed (every `Tool['kind']` has a default key; no two bindings share `(key, scope, modifiers)`).
+- **Unit:** `dispatchKey` returns the right `BindingId` for every binding × source-view × context combination.
+- **Unit:** `acceleratorString` round-trips every modifier combination.
+- **Smoke:** every shortcut fires the right action end-to-end (canvas-region and page focus).
+- **Smoke:** renderer-targeted bindings (annotation overlay) fire correctly via the IPC path.
+- **Smoke:** menu accelerators derived from the table show the same key string as the binding's `defaultKey`.

--- a/docs/adr/0011-page-focus-respects-native-shortcuts.md
+++ b/docs/adr/0011-page-focus-respects-native-shortcuts.md
@@ -1,0 +1,71 @@
+# ADR 0011 — Page focus respects native shortcuts
+
+**Status:** Proposed
+**Date:** 2026-05-12
+**Refines:** [ADR 0001 — Click to enter frame focus](./0001-click-to-enter-frame-focus.md). ADR 0001 established the page-focus mode where the focused page receives native pointer input; this ADR extends the same trust to keyboard input.
+**Companion to:** [ADR 0010 — Main is the sole shortcut dispatch site](./0010-main-as-sole-shortcut-dispatch-site.md). See [`docs/plans/keyboard-binding-registry.md`](../plans/keyboard-binding-registry.md) for the implementation plan.
+
+## Context
+
+When a page is keyboard-focused (per ADR 0001's `pageFocus` runtime state), main's `before-input-event` listener intercepts the keystroke first via `watchModifierKeys` attached at `page-factory.ts:262`. Today the handler runs *all* registered shortcuts before the page sees the keystroke:
+
+- `Cmd+Z` fires our Yjs undo even if the user is editing a GitHub comment box, a Notion page, or any other web app that has its own undo stack.
+- `Cmd+G`, `Cmd+W`, arrow keys, and other shortcuts likewise pre-empt the page.
+- Only single-letter tool keys (v, c, d) are excluded via the `handleShortcuts: false` flag.
+
+This is surprising. The whole premise of ADR 0001's page focus is that the user has *chosen* to interact with the page natively — pointer events go to the page, native scrolling works, form inputs accept text. The same trust should extend to keyboard shortcuts. A user editing a Notion page expects Cmd+Z to undo the last character they typed, not to undo a canvas action they made several minutes earlier.
+
+The current behavior is also dangerous because it's invisible: nothing on screen tells the user that their keystroke is going to Specular instead of the page. They press Cmd+Z to fix a typo and silently lose canvas state instead.
+
+Three policies considered:
+
+- **P1 — status quo.** Specular's shortcuts win while page-focused. Page apps lose Cmd+Z, Cmd+F, Cmd+S, etc.
+- **P2 — page wins broadly; Specular reserves hand-of-god keys.** Anything the page might bind, the page gets. Specular keeps only escape-page-focus (back to canvas) and reset-viewport (rescue from a weird zoom).
+- **P3 — page wins everything.** Even Escape is hijackable by the page. Users lose the keyboard-only path to exit page focus; a hostile or buggy page can trap them.
+
+## Decision
+
+Policy **P2**. When `pageFocus` is non-null:
+
+1. The only bindings that fire are those with `firesFromPageFocus: true`.
+2. Exactly two bindings opt in:
+   - `escape-page-focus` — Escape returns the user to canvas mode (deselects the page, runs the focus reconciler).
+   - `reset-viewport` — Cmd+1 resets zoom/pan. Doesn't mutate the document; safe to interrupt anything.
+3. Every other binding (Cmd+Z, Cmd+G, Cmd+W, arrows, single-letter tool keys, etc.) falls through to the page natively — the dispatcher returns `null` and does not call `event.preventDefault()`.
+
+A user who wants Specular's undo while a page is focused presses Escape first, then Cmd+Z.
+
+## Alternatives considered
+
+**A. P1 (status quo).** Reject. Documented above. Steals expected behavior from page apps; surprising; invisible.
+
+**B. P3 (page wins everything).** Reject. Removes the reliable rescue path. A page that captures Escape (or that crashes its renderer in a way that swallows input) can trap the user; they have no keyboard-only exit. P2 keeps Escape sacred for safety. Cmd+1 is the same kind of guarantee for the viewport.
+
+**C. Heuristic detection (page wins only if a known editable element inside the page has focus).** Tempting but unreliable. Detecting "is an editable element focused inside the page" requires polling DOM state across process boundaries; it's racy, slow, and wrong for non-standard editors (Notion, Google Docs, CodeMirror) which don't always use native focusable elements. P2 picks a coarser but predictable rule.
+
+**D. User-configurable policy.** Per-user setting "give Cmd+Z to pages vs Specular." Reject for v1 — adds settings surface for a question that should have a single defensible answer. Revisit if users push back.
+
+## Consequences
+
+**Replaces:**
+- The implicit "main always intercepts modifier keys" behavior in `keyboard-shortcuts.ts`.
+
+**Enables:**
+- Page web apps work as users expect — Cmd+Z in a comment box undoes the character, Cmd+F opens find-in-page, Cmd+S triggers the app's save handler.
+- The page-focus trust model from ADR 0001 extends cleanly to keyboard input. Same intuition: "I clicked in, I'm using this thing natively."
+
+**Costs:**
+- Behavior change. Users who learned to press Cmd+Z while page-focused expecting canvas undo will need to learn the new flow (Escape, then Cmd+Z). Changelog entry required.
+- The Escape-out path becomes load-bearing in a way it wasn't before. Bugs that break Escape from page focus are now blocking (no other way out).
+
+**Out of scope:**
+- A visible "you are in page focus" affordance. ADR 0001's pointer-focus already implies the user knows; if we add a chrome cue for keyboard focus too, that's a separate UX question.
+- Allowing pages to opt out (a page that wants Specular to keep handling shortcuts). Hypothetical and unmotivated.
+
+## Tests
+
+- **Smoke:** with a page focused, Cmd+Z does not invoke Specular's undo (the keystroke reaches the page).
+- **Smoke:** with a page focused, Escape exits page focus and returns to canvas mode.
+- **Smoke:** with a page focused, Cmd+1 resets the viewport.
+- **Smoke:** with a page focused on a known editable page (a local fixture page with a textarea), typing Cmd+Z in the textarea undoes the most recent character there, and the canvas undo stack is unchanged.
+- **Smoke:** Escape-then-Cmd+Z performs the canvas undo as expected.

--- a/docs/plans/keyboard-binding-registry.md
+++ b/docs/plans/keyboard-binding-registry.md
@@ -1,0 +1,481 @@
+# Keyboard Binding Registry
+
+Branch: `claude/explore-keyboard-system-N5fjt`. Plan for collapsing Specular's
+keyboard system into a single binding registry. The registry is the source of
+truth for every shortcut; main is the sole dispatch site; renderer keydown
+listeners go away. See [ADR 0010](../adr/0010-main-as-sole-shortcut-dispatch-site.md)
+and [ADR 0011](../adr/0011-page-focus-respects-native-shortcuts.md).
+
+## Status
+
+| Step | Status |
+|---|---|
+| A — registry + dispatch + tests, no callers | ⬜ not started |
+| B — port main's `keyboard-shortcuts.ts` to the registry | ⬜ not started |
+| C — delete renderer keydown hooks; port to registry | ⬜ not started |
+| D — `app-menu.ts` accelerators read from the registry | ⬜ not started |
+| E — adjacent: `Cmd+A` select-all, Cmd+D no-grouping, paste-smart, P2 page focus | ⬜ not started |
+
+Each step ends in a working app. Each ships as one PR.
+
+## Context
+
+Keyboard shortcuts today are scattered across:
+
+- `src/main/runtime/keyboard-shortcuts.ts` — 285 lines of `if (input.type === 'keyDown' && input.meta && …)` blocks.
+- Three renderer hooks (`useCanvasGlobalShortcuts`, `useAnnotateToggleShortcut`, `useAnnotationOverlayShortcuts`) that re-handle the same v/c/d keys when focus is in non-canvas views.
+- `src/main/runtime/app-menu.ts` accelerator strings, totally disconnected from the rest.
+- Per-WebContents `handleShortcuts: false` flag, which is the implicit "this view doesn't fire tool shortcuts" filter.
+
+Effects:
+
+- "Where is the `v` shortcut defined?" has three answers depending on which WebContents has focus.
+- No tests exist on any of the keyboard code.
+- The wiring uses a late-bound setter pattern (`wireKeyboardShortcuts(...)`) to dodge an import cycle.
+- ADR 0005 explicitly flagged keyboard shortcuts as the natural follow-up to the unified `Tool` concept. ADR 0009 §93 flagged variant-key bindings (R/E/D, etc.) as a follow-up to tool-defaults.
+
+This plan finishes that follow-up.
+
+## Goals
+
+1. **One source of truth for every shortcut.** The Bindings UI and the menu accelerators and the dispatcher all read the same table.
+2. **One dispatch site.** Main's `before-input-event`. No renderer `keydown` listeners for shortcuts. ([ADR 0010](../adr/0010-main-as-sole-shortcut-dispatch-site.md))
+3. **Coverage parity.** Every `Tool['kind']` has a default key (TypeScript exhaustiveness enforces it). Adding a new tool without a key is a build error.
+4. **Predictable suppression.** Plain letters never fire while typing. Modifier shortcuts opt in to firing while typing. Same shape applies to page focus. ([ADR 0011](../adr/0011-page-focus-respects-native-shortcuts.md))
+5. **Pure-function test surface.** Dispatch is unit-testable without spawning Electron.
+
+## Non-goals (v1)
+
+- Bindings settings pane.
+- User overrides (no `userData/bindings.json`).
+- `?` cheatsheet overlay.
+- Toolbar tooltips. (Tooltips land in a later PR and become the source of truth for discoverability.)
+
+## Architecture
+
+### Modules
+
+```
+src/shared/bindings.ts            // pure data + types + dispatchKey()
+src/main/runtime/binding-handlers.ts   // Record<BindingId, (ctx) => void>
+src/main/runtime/binding-dispatcher.ts // watchModifierKeys replacement; per-WebContents adapter
+src/renderer/{view}/binding-handlers.ts // small per-renderer handler maps (only for renderer-targeted bindings)
+src/renderer/{view}/useRendererBindingHandlers.ts // tiny hook that listens for 'binding-fire' IPC
+```
+
+Deleted:
+- `keyboard-shortcuts.ts` (replaced by `binding-dispatcher.ts` + `binding-handlers.ts`)
+- `useAnnotateToggleShortcut.ts`
+- `useAnnotationOverlayShortcuts.ts`
+- v/c/d/escape/delete branches of `useCanvasGlobalShortcuts.ts` (clipboard remains, split into `useCanvasClipboard.ts`)
+- `wireKeyboardShortcuts(...)` late-bound setter pattern
+- `handleShortcuts: false` per-view flag
+
+### Types
+
+```ts
+// src/shared/bindings.ts
+
+export type KeyboardSourceView =
+  | 'aboveView' | 'canvasBg'
+  | 'toolbar' | 'leftSidebar' | 'rightDetailsPanel'
+  | 'devtoolsHeader' | 'devtoolsResizeHandle'
+  | 'page'
+
+export type NormalizedKey = {
+  key: string      // lowercased, e.g. 'v', 'escape', 'arrowleft'
+  cmd: boolean     // CmdOrCtrl
+  alt: boolean
+  shift: boolean
+}
+
+export type BindingId =
+  | 'tool-select' | 'tool-add-page' | 'tool-add-text-plain' | 'tool-add-text-sticky'
+  | 'tool-add-shape-rectangle' | 'tool-add-shape-ellipse' | 'tool-add-shape-diamond'
+  | 'tool-comment' | 'tool-draw-pen' | 'tool-draw-highlight' | 'tool-inspect'
+  | 'undo' | 'redo' | 'reset-viewport' | 'group' | 'ungroup'
+  | 'select-all' | 'duplicate' | 'delete-selection'
+  | 'nav-left' | 'nav-right' | 'nav-up' | 'nav-down'
+  | 'escape-tool' | 'escape-page-focus'
+  | 'close-tab'
+  | 'annotation-close-thread' | 'annotation-clear-draft'
+
+export type BindingTarget = 'main' | KeyboardSourceView
+
+export type BindingContext = {
+  activeTool: Tool
+  isTextEditing: boolean
+  arrowNavigationLocked: boolean
+  hasKeyboardTargetPage: boolean
+  pageFocusActive: boolean
+  canUndo: boolean
+  canRedo: boolean
+  selectionEmpty: boolean
+  sourceView: KeyboardSourceView
+  viewMode: 'canvas' | 'browser'
+}
+
+export type Binding = {
+  id: BindingId
+  defaultKey: NormalizedKey
+  scope: KeyboardSourceView[]        // which source views can fire this binding
+  target: BindingTarget              // where the handler runs
+  firesWhileTyping?: boolean         // default false
+  firesFromPageFocus?: boolean       // default false
+  when?: (ctx: BindingContext) => boolean
+  label: string                      // for future Bindings pane + tooltips
+}
+```
+
+### Dispatch
+
+```ts
+// src/shared/bindings.ts
+
+export function dispatchKey(
+  table: readonly Binding[],
+  key: NormalizedKey,
+  ctx: BindingContext,
+): BindingId | null
+```
+
+Pure function. Returns the first binding whose `defaultKey` matches the input
+key and whose `scope`/`when`/`firesWhileTyping`/`firesFromPageFocus` predicates
+all hold.
+
+Match order: table order. No conflict detection needed because each binding's
+scope is explicit; if two bindings have the same key + scope + modifiers, that's
+a typo, caught by a unit test that asserts uniqueness.
+
+### Main adapter
+
+```ts
+// src/main/runtime/binding-dispatcher.ts
+
+export function attachBindingDispatcher(
+  webContents: WebContents,
+  sourceView: KeyboardSourceView,
+): void
+```
+
+Registers a `before-input-event` listener. On keydown:
+
+1. Normalize the Electron `Input` → `NormalizedKey`.
+2. Build `BindingContext` from runtime state (active tool, text-editing flag, …).
+3. Call `dispatchKey(BINDINGS, key, { ...ctx, sourceView })`.
+4. If a `BindingId` came back:
+   - `event.preventDefault()`.
+   - If `binding.target === 'main'`: invoke `mainHandlers[id](ctx)`.
+   - Else: `viewFor(binding.target).webContents.send('binding-fire', id)`.
+
+This replaces `watchModifierKeys`. The `sourceView` argument replaces the
+`handleShortcuts: false` flag.
+
+### Main handler map
+
+```ts
+// src/main/runtime/binding-handlers.ts
+
+export const mainHandlers: Record<MainBindingId, (ctx: BindingContext) => void>
+```
+
+Imports concrete runtime functions directly. No late-bound setters. The cycle
+that motivated `wireKeyboardShortcuts(...)` is broken by placing this file at
+a layer that runs *after* `runtime-core` is initialized.
+
+### Renderer handler maps
+
+```ts
+// src/renderer/above-view/binding-handlers.ts
+
+export const aboveViewBindingHandlers: Record<AboveViewBindingId, () => void>
+```
+
+Registered via a small hook on mount:
+
+```ts
+useRendererBindingHandlers(aboveViewBindingHandlers)
+```
+
+The hook listens for the `binding-fire` IPC and invokes the matching handler.
+Two bindings use this path today: `annotation-close-thread` and
+`annotation-clear-draft`, because their state (`openThreadId`,
+`pendingAnnotation`) is renderer-local React `useState`.
+
+### Menu accelerators
+
+```ts
+// src/main/runtime/app-menu.ts
+
+import { acceleratorFor } from './binding-accelerator'
+
+{ label: 'Close Tab', accelerator: acceleratorFor('close-tab'), click: () => mainHandlers['close-tab']({}) }
+```
+
+`acceleratorFor(id)` returns the `CmdOrCtrl+W`-style string derived from
+`bindingById(id).defaultKey`. The menu and the dispatcher cannot drift.
+
+Menu items without a binding (About dialog, Setup) keep their inline `click:`
+— they're not bindable anyway.
+
+## The binding table
+
+| Id | Default key | Scope | Target | While typing? | From page focus? |
+|---|---|---|---|---|---|
+| `tool-select` | `v` | canvas-region¹ | main | — | — |
+| `tool-add-page` | `p` | canvas-region | main | — | — |
+| `tool-add-text-plain` | `t` | canvas-region | main | — | — |
+| `tool-add-text-sticky` | `s` | canvas-region | main | — | — |
+| `tool-add-shape-rectangle` | `r` | canvas-region | main | — | — |
+| `tool-add-shape-ellipse` | `o` | canvas-region | main | — | — |
+| `tool-add-shape-diamond` | `Shift+R` | canvas-region | main | — | — |
+| `tool-comment` | `c` | canvas-region | main | — | — |
+| `tool-draw-pen` | `m` | canvas-region | main | — | — |
+| `tool-draw-highlight` | `Shift+M` | canvas-region | main | — | — |
+| `tool-inspect` | `i` | canvas-region | main | — | — |
+| `escape-tool` | `Escape` | all | main | yes (commits text edit instead) | yes |
+| `escape-page-focus` | `Escape` | `page` | main | — | yes |
+| `undo` | `Cmd+Z` | all | main | **yes** | — |
+| `redo` | `Cmd+Shift+Z` | all | main | **yes** | — |
+| `reset-viewport` | `Cmd+1` | all | main | **yes** | **yes** |
+| `group` | `Cmd+G` | canvas-region | main | — | — |
+| `ungroup` | `Cmd+Shift+G` | canvas-region | main | — | — |
+| `select-all` | `Cmd+A` | canvas-region | main | — | — |
+| `duplicate` | `Cmd+D` | canvas-region | main | — | — |
+| `delete-selection` | `Delete` / `Backspace` | canvas-region | main | — | — |
+| `nav-left` | `ArrowLeft` | canvas-region | main | — | — |
+| `nav-right` | `ArrowRight` | canvas-region | main | — | — |
+| `nav-up` | `ArrowUp` | canvas-region | main | — | — |
+| `nav-down` | `ArrowDown` | canvas-region | main | — | — |
+| `close-tab` | `Cmd+W` | all | main | yes | — |
+| `annotation-close-thread` | `Escape` | `aboveView` | `aboveView` | — | — |
+| `annotation-clear-draft` | `Escape` | `aboveView` | `aboveView` | — | — |
+
+¹ `canvas-region` is a convenience for `['aboveView', 'canvasBg', 'toolbar', 'rightDetailsPanel']` — the four views where canvas-style shortcuts should fire. Constant defined in `src/shared/bindings.ts`.
+
+### `add-document` intentionally unbound
+
+Has no default key. Users add documents via the toolbar's "Add text ▾"
+dropdown. Bindable later via the (future) Bindings pane.
+
+### `Escape` resolution order
+
+Three bindings share `Escape`. Match order is:
+
+1. `annotation-close-thread` / `annotation-clear-draft` (scope: `aboveView`, only when active state predicate holds — the `when` checks for `openThreadId` / `pendingAnnotation`).
+2. `escape-page-focus` (scope: `page` only, only when page focus is active).
+3. `escape-tool` (all scopes, fires whenever `activeTool.kind !== 'select'`).
+
+Each binding's `when` predicate ensures only one fires per keystroke; if none of
+them match, Escape falls through to native handling.
+
+### Variant key handlers
+
+Per [ADR 0009](../adr/0009-tool-variants-in-popup-state.md), shape and brush
+variants live in tool defaults. The keyboard handler does **both**:
+
+```ts
+'tool-add-shape-rectangle': () => {
+  setActiveTool({ kind: 'add-shape' })
+  setToolDefault('add-shape.shapeKind', 'rectangle')
+}
+'tool-draw-highlight': () => {
+  setActiveTool({ kind: 'draw' })
+  setToolDefault('draw.brushType', 'highlight')
+}
+```
+
+No compound-action framework needed — it's just a multi-statement handler body.
+
+## Behavior rules
+
+### No tool-toggle on second keypress
+
+FigJam reference: pressing the same tool key twice does nothing (the tool stays
+active). Escape is the only way back to `select`. This removes the existing
+toggle behavior in `useAnnotateToggleShortcut.ts`.
+
+### Suppression while typing
+
+Default: bindings do not fire while `isTextEditing` is true. Opt-in via
+`firesWhileTyping: true`. Four bindings opt in:
+
+- `undo`, `redo` — global Yjs undo spans text + canvas edits.
+- `reset-viewport` — hand-of-god. Viewport reset doesn't mutate the document.
+- `escape-tool` — Escape in a text input commits the edit; the text-edit
+  context check inside the handler prevents double-firing as a tool reset.
+
+`Cmd+A` is contextual: when `isTextEditing`, the native "select all text" wins
+because the binding's `firesWhileTyping` is `false`. When not typing, our
+`select-all` handler invokes `selectAllEntities()`.
+
+### Page focus (P2 policy)
+
+Per [ADR 0011](../adr/0011-page-focus-respects-native-shortcuts.md), when a
+page has keyboard focus, the page wins almost all keystrokes. Specular reserves
+only:
+
+- `escape-page-focus` — exit page focus back to canvas.
+- `reset-viewport` — hand-of-god.
+
+Cmd+Z, Cmd+G, Cmd+W, arrows, and tool keys all fall through to the page
+natively. To use canvas undo while page-focused, the user presses Escape first.
+
+This is a behavior change from today. Changelog entry required.
+
+## Clipboard split
+
+Clipboard handling is **not** in the registry. `Cmd+C` / `Cmd+V` / `Cmd+X` arrive
+as DOM `ClipboardEvent`s, not as keystrokes — and `event.clipboardData` /
+`window.getSelection()` only exist renderer-side.
+
+The new `src/renderer/canvas-bg/useCanvasClipboard.ts` (extracted from
+`useCanvasGlobalShortcuts.ts`) owns this. The hijack rule:
+
+- If `event.target` is a typing target, native wins.
+- If `window.getSelection().toString()` is non-empty, native wins.
+- Else, the canvas hijacks.
+
+On hijack:
+
+- **Copy** with entity selection → entity JSON to clipboard.
+- **Cut** with entity selection → copy + delete.
+- **Paste** smart-resolution order (`pasteFromClipboard()` in main):
+  1. Our entity-shaped JSON → paste entities.
+  2. Text that `looksLikeUrl()` matches → create a page (reuses existing URL paster).
+  3. Image data → create a file entity.
+  4. Plain text → create a sticky note.
+  5. Otherwise → no-op.
+
+Active page intercepts nothing — when page focus is held, the page receives
+clipboard events natively. The renderer hook installs no listeners on the page.
+
+## Duplicate cleanup
+
+`Cmd+D` reuses `duplicatePageFromSource` / `duplicateEntity`. Side cleanup:
+
+- Default `skipGrouping: true` across all three call sites in
+  `register-canvas-entity-ipc.ts` and `register-right-details-panel-ipc.ts`.
+- Remove the `mode: 'duplicate'` grouping codepath through `addPageFromSource`.
+
+This is a behavior change for the existing context-menu and right-details-panel
+duplicate buttons — they no longer auto-create row groups. Changelog entry
+required.
+
+## Build order
+
+### Step A — registry + dispatch + tests (no callers)
+
+Files added:
+- `src/shared/bindings.ts` — types, the table, `dispatchKey()`, `normalizeElectronInput()`, `acceleratorString()`.
+- `tests/unit/bindings.test.ts` — table uniqueness, dispatch for every binding × source view × modifier combination, scope and predicate filtering.
+
+Files unchanged. App behavior unchanged. Pure addition. Zero risk.
+
+### Step B — port main
+
+Files added/changed:
+- `src/main/runtime/binding-handlers.ts` — main-side handler map.
+- `src/main/runtime/binding-dispatcher.ts` — `attachBindingDispatcher(wc, sourceView)`.
+- `src/main/runtime/window-init.ts` — replace `watchModifierKeys(...)` calls with `attachBindingDispatcher(...)`.
+- `src/main/runtime/page-factory.ts` — same swap.
+- `src/main/ipc/register-canvas-ipc.ts` — `setTextEditingActive` import path stays.
+
+Files deleted:
+- `src/main/runtime/keyboard-shortcuts.ts`.
+
+The `wireKeyboardShortcuts(...)` injection in `window-init.ts:132` is deleted;
+`binding-handlers.ts` imports its dependencies directly.
+
+Adjacent IPC additions:
+- `selectAllEntities` — new IPC handler that selects every entity in the active tab. Used by `Cmd+A` when not typing.
+
+Existing smoke tests should pass unchanged. Add:
+- `tests/smoke/keyboard-shortcuts.test.ts` — happy path for every binding.
+
+### Step C — delete renderer hooks
+
+Files deleted:
+- `src/renderer/shared/hooks/useAnnotateToggleShortcut.ts`.
+- `src/renderer/shared/hooks/useAnnotationOverlayShortcuts.ts`.
+- v/c/d/escape/delete branches removed from `useCanvasGlobalShortcuts.ts` (it becomes empty for keyboard; remove the hook).
+
+Files added/changed:
+- `src/renderer/canvas-bg/useCanvasClipboard.ts` — clipboard events only.
+- `src/renderer/above-view/binding-handlers.ts` — `annotation-close-thread`, `annotation-clear-draft`.
+- `src/renderer/shared/hooks/useRendererBindingHandlers.ts` — generic IPC listener.
+
+Renderer App.tsx files updated to use the new hooks.
+
+### Step D — port menu accelerators
+
+Files changed:
+- `src/main/runtime/app-menu.ts` — `accelerator: acceleratorFor('close-tab')` etc.
+- `src/main/runtime/binding-accelerator.ts` — `acceleratorFor(id)` helper.
+
+The menu cannot drift from the dispatcher; they read the same table.
+
+### Step E — adjacent behavior changes
+
+Lands as part of Step B/C or split into its own PR. Each is small but
+user-visible:
+
+- `select-all` action + Cmd+A wiring.
+- `duplicate` action: reuse helpers, drop auto-grouping in all paths.
+- Smart-paste resolution.
+- P2 page-focus enforcement.
+
+Each gets a changelog entry. Alt-drag-to-duplicate (pointer-router work) is
+**adjacent** to this plan and should ship in the same release for narrative
+coherence, but is tracked separately because it touches the router not the
+keyboard.
+
+## Tests
+
+### Unit
+
+- `bindings.test.ts` — the table is well-formed (every `Tool['kind']` has a binding; no two bindings share `(key, scope, modifiers)`).
+- `bindings.test.ts` — `dispatchKey` returns the right id for every binding × source-view × context combination.
+- `bindings.test.ts` — `acceleratorString` round-trips for every modifier combination.
+- `bindings.test.ts` — `firesWhileTyping` and `firesFromPageFocus` defaults are respected.
+
+### Smoke
+
+- `keyboard-shortcuts.test.ts` — Cmd+Z, Cmd+G, v, c, m, paste-URL-creates-page, paste-text-creates-sticky, Cmd+A select-all, Cmd+D duplicate-no-grouping, Escape exits page focus, Escape exits tool, Cmd+1 from page focus resets viewport.
+
+### Regression
+
+- Existing tests for tool switching, undo/redo, grouping, paste — should all pass unchanged after the port. Only the wiring changed, not the actions.
+
+## Out of scope
+
+- Bindings settings pane (UI).
+- User-override storage.
+- Toolbar tooltips (separate PR; reads from the same registry).
+- `?` cheatsheet overlay (later).
+- Empty-canvas onboarding hints.
+- Alt-drag-to-duplicate (pointer-router work; adjacent).
+- Promoting `pendingAnnotation` / `openThreadId` to main runtime state (would
+  let those bindings be `target: 'main'`; not worth the scope creep here).
+
+## Migration notes
+
+- `wireKeyboardShortcuts(...)` deleted — search for it; one call site in `window-init.ts`.
+- `watchModifierKeys(...)` deleted — every call site swaps to `attachBindingDispatcher(wc, sourceView)`.
+- `handleShortcuts: false` flag deleted — replaced by per-binding `scope`.
+- `setTextEditingActive(...)` stays — it's the same flag, same IPC, same logic.
+- `useAnnotateToggleShortcut` / `useAnnotationOverlayShortcuts` deleted; consumers updated.
+- Tool-toggle behavior removed: pressing `c` while in comment tool no longer goes back to select. Changelog.
+- Duplicate no longer auto-groups. Changelog.
+- Page focus no longer captures Cmd+Z and friends. Changelog.
+
+## Future work
+
+- **Bindings pane in Settings.** Reads `listBindings()`. β1 (read-only) for v1
+  of the pane; β2 (rebinding + `userData/bindings.json`) later.
+- **Toolbar tooltips.** Reads `binding.label` + `acceleratorString(binding.key)`
+  for each toolbar button. Will be the source of truth for discoverability.
+- **`?` overlay.** Modal cheatsheet listing all bindings. One-day add once the
+  registry exists.
+- **Per-binding context labels.** "Group entities (when entities selected)" —
+  the `when` predicate gets a human-readable explanation for the Bindings pane.


### PR DESCRIPTION
Planning artifacts only — no implementation.

Collapses the keyboard system into a single binding registry: one source of truth, main as the sole dispatch site, renderer keydown hooks deleted, menu accelerators derived from the same table.

- `docs/plans/keyboard-binding-registry.md` — design + binding table + 5-step build order (A registry → B port main → C port renderers → D menu accelerators → E adjacent behavior changes).
- `docs/adr/0010` — main is the sole shortcut dispatch site.
- `docs/adr/0011` — page focus respects native shortcuts (P2). Behavior change: Cmd+Z while page-focused goes to the page, not to Specular.
- `CONTEXT.md` — adds Binding, BindingId, NormalizedKey, Binding dispatcher, Keyboard source view, Binding target.

Adjacent behavior changes that land with the refactor (each gets a changelog entry):
- No tool toggle on second keypress (FigJam reference).
- Duplicate stops auto-grouping.
- Cmd+A becomes a real canvas binding.
- Smart paste: URL → page, image → file, text → sticky.

Issue breakdown via `/to-issues` after this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_0159AK6HfGvc7K1TAEMoUxvY)_