### PR TITLE
Plain-text placement: 'Add text' ghost + auto-enter edit

### DIFF
--- a/src/main/ipc/register-canvas-entity-ipc.ts
+++ b/src/main/ipc/register-canvas-entity-ipc.ts
@@ -162,12 +162,14 @@ export function registerCanvasEntityIpc(): void {
           tool.style === 'sticky'
             ? getStickyDefaultColor()
             : getPlainTextDefaultColor() ?? undefined
-        createTextEntity({
+        const created = createTextEntity({
           canvasX,
           canvasY,
           textStyle: tool.style,
           color: defaultColor,
         })
+        selectEntity(created.id, 'text')
+        beginEditingEntity(created.id)
       } else if (tool.kind === 'add-document') {
         try {
           const filePath = createNoteFile()

--- a/src/main/runtime/canvas-layout-data.ts
+++ b/src/main/runtime/canvas-layout-data.ts
@@ -294,6 +294,7 @@ function buildPlacementPreview(tool: ReturnType<typeof uiActiveTool>): PendingPl
   const isFile = entityKind === 'file'
   const isShape = entityKind === 'shape'
   const presetIndex = tool.kind === 'add-page' ? tool.presetIndex : undefined
+  const textStyle = tool.kind === 'add-text' ? tool.style : undefined
   const customSize = tool.kind === 'add-page' ? tool.customSize === true : false
   const sourcePageId = tool.kind === 'add-page' ? tool.sourcePageId : undefined
   // shapeKind moved to tool defaults per ADR 0009 — preview reads the persisted
@@ -310,6 +311,7 @@ function buildPlacementPreview(tool: ReturnType<typeof uiActiveTool>): PendingPl
     entityKind,
     presetIndex,
     shapeKind,
+    textStyle,
     width: isText
       ? DEFAULT_TEXT_WIDTH
       : isFile

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -186,6 +186,12 @@ export default function App({
     layoutData.interaction.kind === 'editing-entity'
       ? layoutData.interaction.entityId
       : null
+  const textPopupReady =
+    interactionIdle ||
+    Boolean(
+      editingEntityId &&
+        selectedTextEntities.some((entity) => entity.id === editingEntityId),
+    )
 
   const marqueePreviewIds = useMemo(() => {
     if (
@@ -1130,7 +1136,7 @@ export default function App({
                     isDark={isDark}
                     layout={layoutData}
                     selectedTextEntities={selectedTextEntities}
-                    interactionIdle={interactionIdle}
+                    popupReady={textPopupReady}
                   />
                   <GroupPopup
                     api={api}

--- a/src/renderer/above-view/StickyBodyLayer.tsx
+++ b/src/renderer/above-view/StickyBodyLayer.tsx
@@ -17,11 +17,11 @@
 
 import { memo, useEffect, useRef, useState } from 'react'
 import Markdown from 'react-markdown'
+import { PLAIN_TEXT_PLACEHOLDER } from '../../shared/constants'
 import type { CanvasSceneTextEntity, TextEntityStyle } from '../../shared/types'
 import { resolveCanvasColor } from '../../shared/canvas-colors'
 import { MarkdownEditor } from '../shared/MarkdownEditor'
 
-const PLAIN_TEXT_PLACEHOLDER = 'Add text'
 const PLAIN_MIN_WIDTH = 64
 const PLAIN_MIN_HEIGHT = 18
 

--- a/src/renderer/above-view/StickyBodyLayer.tsx
+++ b/src/renderer/above-view/StickyBodyLayer.tsx
@@ -21,7 +21,8 @@ import type { CanvasSceneTextEntity, TextEntityStyle } from '../../shared/types'
 import { resolveCanvasColor } from '../../shared/canvas-colors'
 import { MarkdownEditor } from '../shared/MarkdownEditor'
 
-const PLAIN_MIN_WIDTH = 40
+const PLAIN_TEXT_PLACEHOLDER = 'Add text'
+const PLAIN_MIN_WIDTH = 64
 const PLAIN_MIN_HEIGHT = 18
 
 /**
@@ -218,7 +219,7 @@ function StickyCard({
   // CodeMirror renders dark text matching the view-mode color below.
   const editorIsDark = isPlain ? isDark : false
   const textColor = isPlain ? (isDark ? '#e7e5e4' : '#1c1917') : '#1c1917'
-  const placeholder = isPlain ? 'Type some text...' : 'Type a note...'
+  const placeholder = isPlain ? PLAIN_TEXT_PLACEHOLDER : 'Type a note...'
 
   const innerColumnStyle: React.CSSProperties = isPlain
     ? { display: 'flex', flexDirection: 'column' }

--- a/src/renderer/above-view/StickyNotePopover.tsx
+++ b/src/renderer/above-view/StickyNotePopover.tsx
@@ -16,7 +16,7 @@ export function StickyNotePopover({
   isDark,
   layout,
   selectedTextEntities,
-  interactionIdle,
+  popupReady,
 }: {
   api: Pick<
     CanvasBgElectronAPI,
@@ -25,11 +25,11 @@ export function StickyNotePopover({
   isDark: boolean
   layout: LayoutUpdateData
   selectedTextEntities: CanvasSceneTextEntity[]
-  interactionIdle: boolean
+  popupReady: boolean
 }) {
   const count = selectedTextEntities.length
   const ids = selectedTextEntities.map((e) => e.id).join('|')
-  const open = usePopupDelayedKey(ids, interactionIdle && count > 0)
+  const open = usePopupDelayedKey(ids, popupReady && count > 0)
   if (count === 0) return null
 
   const sharedColor = sharedValue(

--- a/src/renderer/canvas-bg/CanvasGridSurface.tsx
+++ b/src/renderer/canvas-bg/CanvasGridSurface.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { PLAIN_TEXT_PLACEHOLDER } from '../../shared/constants'
 import type { TextEntityStyle } from '../../shared/types'
 import { buildCanvasGridStyle } from './canvasGridStyle'
 
@@ -109,7 +110,7 @@ export function PlacementPreviewLayer({
           fontFamily: 'system-ui, sans-serif',
         }}
       >
-        Add text
+        {PLAIN_TEXT_PLACEHOLDER}
       </div>
     )
   }

--- a/src/renderer/canvas-bg/CanvasGridSurface.tsx
+++ b/src/renderer/canvas-bg/CanvasGridSurface.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import type { TextEntityStyle } from '../../shared/types'
 import { buildCanvasGridStyle } from './canvasGridStyle'
 
 function previewBoxStyle(
@@ -83,12 +84,35 @@ export function PlacementPreviewLayer({
   preview,
 }: {
   isDark: boolean
-  preview: { entityKind?: string; shapeKind?: string; left: number; top: number; width: number; height: number } | null
+  preview: {
+    entityKind?: string
+    shapeKind?: string
+    textStyle?: TextEntityStyle
+    left: number
+    top: number
+    width: number
+    height: number
+  } | null
 }) {
   if (!preview) return null
   const isTextEntity = preview.entityKind === 'text'
   const isFileEntity = preview.entityKind === 'file'
   const isShape = preview.entityKind === 'shape'
+  if (isTextEntity && preview.textStyle === 'plain') {
+    return (
+      <div
+        className="pointer-events-none absolute select-none text-[12px] leading-[18px] font-normal"
+        style={{
+          left: preview.left,
+          top: preview.top,
+          color: isDark ? 'rgba(231, 229, 228, 0.58)' : 'rgba(28, 25, 23, 0.48)',
+          fontFamily: 'system-ui, sans-serif',
+        }}
+      >
+        Add text
+      </div>
+    )
+  }
   if (isShape) {
     const baseStyle = previewBoxStyle(isDark, preview)
     const stroke = isDark ? 'rgba(168, 162, 158, 0.6)' : 'rgba(120, 113, 108, 0.6)'
@@ -169,4 +193,3 @@ export function DragCopyPreviewLayer({
     </>
   )
 }
-

--- a/src/renderer/canvas-bg/canvasBgSelectors.ts
+++ b/src/renderer/canvas-bg/canvasBgSelectors.ts
@@ -28,6 +28,7 @@ export function buildPendingPlacementPreview(
   return {
     entityKind: layoutData.pendingPlacement.entityKind,
     shapeKind: layoutData.pendingPlacement.shapeKind,
+    textStyle: layoutData.pendingPlacement.textStyle,
     left: layoutData.canvasOrigin.x + layoutData.pan.x + snappedX * layoutData.zoom,
     top: layoutData.canvasOrigin.y + layoutData.pan.y + snappedY * layoutData.zoom,
     width: layoutData.pendingPlacement.width * layoutData.zoom,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -3,6 +3,8 @@ import type { PageConfig } from './types'
 // Device dimensions are defined in device-catalog.ts (single source of truth).
 export { VIEWPORT_PRESETS, LAPTOP_PRESET_INDEX, DESKTOP_PRESET_INDEX } from './device-catalog'
 
+export const PLAIN_TEXT_PLACEHOLDER = 'Add text'
+
 export const TOOLBAR_HEIGHT = 44
 export const GRID_SIZE = 20
 export const USER_GROUP_PADDING = 24

--- a/tests/unit/canvas-placement-preview.test.ts
+++ b/tests/unit/canvas-placement-preview.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { buildPendingPlacementPreview } from '../../src/renderer/canvas-bg/canvasBgSelectors'
 import { PlacementPreviewLayer } from '../../src/renderer/canvas-bg/CanvasGridSurface'
 import { EMPTY_LAYOUT } from '../../src/renderer/canvas-bg/canvasBgConstants'
+import { PLAIN_TEXT_PLACEHOLDER } from '../../src/shared/constants'
 
 describe('placement preview', () => {
   it('preserves text style while snapping the pending text preview', () => {
@@ -44,7 +45,7 @@ describe('placement preview', () => {
       },
     }) as { props: { className: string; children: string; style: Record<string, unknown> } }
 
-    expect(element.props.children).toBe('Add text')
+    expect(element.props.children).toBe(PLAIN_TEXT_PLACEHOLDER)
     expect(element.props.className).not.toContain('border')
     expect(element.props.style).toMatchObject({ left: 20, top: 30 })
     expect(element.props.style).not.toHaveProperty('background')

--- a/tests/unit/canvas-placement-preview.test.ts
+++ b/tests/unit/canvas-placement-preview.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { buildPendingPlacementPreview } from '../../src/renderer/canvas-bg/canvasBgSelectors'
+import { PlacementPreviewLayer } from '../../src/renderer/canvas-bg/CanvasGridSurface'
+import { EMPTY_LAYOUT } from '../../src/renderer/canvas-bg/canvasBgConstants'
+
+describe('placement preview', () => {
+  it('preserves text style while snapping the pending text preview', () => {
+    const preview = buildPendingPlacementPreview(
+      {
+        ...EMPTY_LAYOUT,
+        zoom: 2,
+        canvasOrigin: { x: 10, y: 44 },
+        pan: { x: 3, y: 5 },
+        pendingPlacement: {
+          entityKind: 'text',
+          textStyle: 'plain',
+          width: 200,
+          height: 200,
+        },
+      },
+      { clientX: 54, clientY: 97 },
+    )
+
+    expect(preview).toMatchObject({
+      entityKind: 'text',
+      textStyle: 'plain',
+      left: 53,
+      top: 89,
+      width: 400,
+      height: 400,
+    })
+  })
+
+  it('renders plain text placement as an Add text placeholder, not a sticky box', () => {
+    const element = PlacementPreviewLayer({
+      isDark: false,
+      preview: {
+        entityKind: 'text',
+        textStyle: 'plain',
+        left: 20,
+        top: 30,
+        width: 200,
+        height: 200,
+      },
+    }) as { props: { className: string; children: string; style: Record<string, unknown> } }
+
+    expect(element.props.children).toBe('Add text')
+    expect(element.props.className).not.toContain('border')
+    expect(element.props.style).toMatchObject({ left: 20, top: 30 })
+    expect(element.props.style).not.toHaveProperty('background')
+  })
+})


### PR DESCRIPTION
## Summary
- Plain-text placement preview now renders an "Add text" hint at the click position instead of the sticky-style box, matching the inline placeholder shown once the entity exists.
- Creating a text entity selects it and immediately enters inline edit, so the cursor lands where the user clicked.
- `PLAIN_TEXT_PLACEHOLDER` lives in `src/shared/constants` so preview ghost and inline placeholder stay in lockstep.
- Plain-text `PLAIN_MIN_WIDTH` bumped 40 → 64 to better fit short typed lines.

## Test plan
- [ ] Plain-text tool: click on empty canvas — "Add text" ghost follows the cursor, no sticky box.
- [ ] Click to place — entity is created, selected, and editor is focused at the click position.
- [ ] Type immediately — text appears without an extra click.
- [ ] Sticky tool still previews/places the sticky note as before.
- [ ] `pnpm typecheck && pnpm test:unit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)