### PR TITLE
Document alignment guides as visual-only; grid-snap remains sole magnet

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,6 +59,15 @@ Conventions:
 - **Body sub-rect** — the part of the entity rect that holds the entity's content (the live document for a page, the image for a file, etc.). Resize handles and edge anchors attach here.
 - **Chrome slot** — the part of the entity rect reserved for canvas-anchored overlay UI. Per-kind, runtime-derived, **not persisted** in the `.canvas` schema.
 
+## Drag affordances
+
+Modifiers and visual feedback that ride on top of entity drag (and resize) gestures. The single magnetic pull on the canvas is grid-snap (`snapToGrid`, 20 px); everything below either projects the delta before the snap (axis lock) or renders informationally after it (alignment / distribution guides). See [ADR 0012](./docs/adr/0012-alignment-guides-are-visual-only.md).
+
+- **Axis lock** — holding `Shift` during an entity drag (with or without `Alt`/`Option` for copy) constrains movement to a single axis. Live: the dominant axis is recomputed every frame from cursor offset to drag origin, so the lock can flip H↔V mid-drag without releasing the mouse. Projection happens in main: `aboveView` adds a `shiftKey` flag to each `canvas-drag-entity` IPC update, and `applyDragDelta` zeros the smaller-magnitude axis. The locked axis bypasses grid-snap (entity holds its exact origin coordinate); the free axis still grid-snaps. Multi-select drag applies the same constrained delta to all entities.
+- **Snap candidate** — an entity that contributes alignment edges during a drag or resize. Snapshot is taken once at gesture begin from the current viewport-visible entity set (rect intersects the available canvas viewport rect), excluding entities in the active selection. Pages and groups (snap to bbox) are included; group children inside an included group don't double-contribute. Pan is locked during drag, so the snapshot is stable.
+- **Alignment guide** — a 1 px solid line in the canvas accent color, rendered in `aboveView`'s drag overlay layer, that confirms the dragged (or resized) entity's edge or center coincides with a snap candidate's edge or center within 0.5 px. Each candidate contributes 6 edges: top, bottom, left, right, horizontal-center, vertical-center; the dragged entity contributes its own 6 reference points (only the moving edge for resize). Guides are detected after grid-snap runs — they confirm an alignment, never create one — so they appear honestly and never lie. The line spans from min to max of the candidate and dragged rects on the snapping axis.
+- **Distribution guide** — `==` measure marks rendered alongside alignment guides when the dragged entity sits at equal distance from two or more snap candidates along an axis (post-grid-snap). Same visual-only contract: detection only, no pull.
+
 ## Input authority
 
 - **Page focus** — runtime state `{ id, since } | null` in main. When set, the focused page receives native pointer input; aboveView's gate is closed. When null, aboveView is the sole input authority. See [ADR 0001](./docs/adr/0001-click-to-enter-frame-focus.md). (ADR 0001 was authored under the old "frame" name; the runtime variable is currently `frameFocus` and renames to `pageFocus` in the migration.)

--- a/docs/adr/0012-alignment-guides-are-visual-only.md
+++ b/docs/adr/0012-alignment-guides-are-visual-only.md
@@ -1,0 +1,24 @@
+# Alignment guides are visual-only; grid-snap remains the sole magnet
+
+## Context
+
+Specular's drag flow has always pulled entities to a 20 px grid via `snapToGrid` inside `applyDragDelta` (`src/main/runtime/document-commands.ts`). Adding FigJam-style alignment guides — top / bottom / left / right / horizontal-center / vertical-center lines that appear when the dragged entity aligns with neighbors — raises the question of whether those guides should be magnetic (pull the entity onto them) or purely visual (render only when alignment already happens to be true).
+
+## Decision
+
+**Guides are visual-only. Grid-snap is the only magnetic pull during drag.** A guide renders iff the dragged entity's edge or center is within 0.5 px of a snap candidate's edge or center *after* `snapToGrid` has run. The guide list is broadcast from main to `aboveView` for paint; no second projection runs in main.
+
+Distribution guides (`==` marks for equal spacing) follow the same contract — detection only, never pull.
+
+## Considered options
+
+- **Magnetic guides (FigJam parity).** Guides override grid-snap on engaged axes; grid is the per-axis fallback. Better feel, but introduces a second magnetic system that fights the grid on disengaged axes and changes the meaning of every coordinate `applyDragDelta` produces.
+- **Drop grid-snap entirely.** Cleanest, matches FigJam exactly. Rejected because the 20 px grid is part of Specular's current placement feel and dropping it is a much larger product change than adding guides.
+- **Magnetic with a shift-to-suppress modifier.** Conflicts with the axis-lock claim on `Shift` (see CONTEXT → Drag affordances → Axis lock); would need a different modifier and a parallel concept of "snap mode."
+
+## Consequences
+
+- Center alignment will rarely engage. An entity's center sits at `x + width/2`; unless `width` is a multiple of 40, the center is off-grid, so the post-grid-snap position will almost never satisfy the 0.5 px equality with another center. Edge alignment (top / left between two grid-placed entities) will engage often.
+- The guide is honest by construction: if the line is on screen, the entity is actually aligned. There is no flicker-and-bounce from the grid pulling the entity off a guide it briefly hit.
+- The implementation stays inside `applyDragDelta`'s existing seam: snap to grid → compute 6 reference points → diff against the drag-begin snapshot of viewport-visible candidates → broadcast guide list. No new interaction mode, no second projection site, no reconciler.
+- Pivot path: if center alignment turns out to be the feature users actually want, the cheapest move is to drop grid-snap (or reduce it to 1 px) rather than introduce magnetic guides on top of the grid.


### PR DESCRIPTION
## Summary

Adds ADR 0012 documenting the decision to implement alignment guides as visual-only feedback rather than magnetic pulls during entity drag. Updates CONTEXT.md to formalize drag affordances terminology and link to the ADR.

## Changes

- **docs/adr/0012-alignment-guides-are-visual-only.md** (new)
  - Documents the decision to keep guides purely visual; grid-snap (20 px) remains the only magnetic pull
  - Guides render when dragged entity's edge or center is within 0.5 px of a snap candidate's edge/center *after* grid-snap runs
  - Explains rationale: preserves existing grid-based placement feel, avoids fighting two magnetic systems, keeps implementation inside `applyDragDelta`'s existing seam
  - Lists considered alternatives (magnetic guides, drop grid entirely, shift-to-suppress modifier) and consequences
  - Notes that distribution guides (`==` marks) follow the same visual-only contract

- **CONTEXT.md** (modified)
  - Adds new "Drag affordances" section formalizing terminology and interaction model
  - Defines **axis lock** (Shift modifier for single-axis constraint), **snap candidate** (entities contributing alignment edges), **alignment guide** (1 px confirmation lines), and **distribution guide** (equal spacing marks)
  - Links to ADR 0012 as the authoritative source for the design decision
  - Clarifies that guides are detected post-grid-snap and never create alignment, only confirm it

## Implementation notes

- No code changes to runtime behavior; this documents existing and intended design
- Guides are broadcast from main to `aboveView` for paint; no second projection runs in main
- The 0.5 px tolerance allows for floating-point precision without requiring exact equality
- Center alignment will rarely engage due to grid offset; edge alignment between grid-placed entities will be the common case

https://claude.ai/code/session_01US83Hzb5MQ6d34yYVC295u