### PR TITLE
AFK: add afk-local skill, codex worker option, loop bugfixes

### DIFF
--- a/.claude/skills/afk-local/SKILL.md
+++ b/.claude/skills/afk-local/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: afk-local
+description: Kick off an AFK multi-PR feature build locally using scripts/afk-loop.sh. Accepts either a planning doc under docs/plans/ OR a GitHub issue (number or URL). Sets up the feature branch + dex epic + subtasks, then drops into the local loop. Use when the user wants to "run this AFK locally", "loop on this issue", or "AFK from issue #N". Sibling of /afk-feature (which sets up the cloud routine instead).
+---
+
+# AFK local
+
+One-shot kickoff for a multi-PR feature built by the **local** worker loop (`scripts/afk-loop.sh`).
+
+Input: a path to a planning doc under `docs/plans/` **or** a GitHub issue reference (`#81`, `81`, or full URL).
+
+Output: a `claude/feat-<slug>` branch with the plan committed, a dex epic with one subtask per worker-codeable step, and a running `afk-loop.sh` session.
+
+## Architectural notes
+
+- The local loop has no cron floor — fires back-to-back as soon as each `claude -p` returns.
+- Subtasks come from `## Phase N` (or `## <heading>`) sections in the plan. The user picks which ones are worker-codeable before any dex tasks are created — "Decisions before starting" / "Goals" / "Non-goals" / "Success criteria" style sections usually shouldn't be tasks.
+- The script reads dex state from the working tree on each fire, so `.dex/` must be committed to the feature branch.
+- The script enforces `claude/feat-*` branch naming — it will exit if the branch doesn't match.
+
+## Kickoff sequence
+
+### 1. Resolve the input
+
+If the user passed:
+- A path ending in `.md` (or matching `docs/plans/*`): treat as a **plan file**. Read it; you'll derive the slug from its filename.
+- A bare number, `#N`, or a URL containing `/issues/N`: treat as an **issue ref**. Fetch with `gh issue view <N> --json title,body,url`.
+- Nothing: stop and ask the user to provide one.
+
+### 2. Derive the slug
+
+- **Plan file:** slug = filename without `.md`. (e.g. `docs/plans/keyboard-binding-registry.md` → `keyboard-binding-registry`.)
+- **Issue:** propose a tidy slug from the first comma/colon-delimited segment of the title, kebab-cased, capped at ~30 chars. Show the user and let them override.
+
+Feature branch: `claude/feat-<slug>`. Plan path (issue mode only): `docs/plans/<slug>.md`.
+
+### 3. Identify worker-codeable steps
+
+Parse the plan/issue body. Find `## ` headings. Show the user a numbered list of every `## ` section and your proposed **worker-codeable** subset (typically the `## Phase N` rows, minus any "decisions / goals / non-goals / success criteria / risks" sections).
+
+Ask the user to confirm or edit which sections become dex subtasks.
+
+### 4. Confirm the plan before writing anything
+
+Show the user:
+
+```
+Slug:     <slug>
+Branch:   claude/feat-<slug>
+Plan:     docs/plans/<slug>.md   (created)   OR   <existing path>
+Subtasks: (N)
+  - <section name>
+  - <section name>
+  ...
+```
+
+Wait for explicit confirmation. Don't proceed silently.
+
+### 5. Create the feature branch
+
+```
+git fetch origin main
+git switch -c claude/feat-<slug> origin/main
+```
+
+If the branch already exists locally or on origin, switch to it instead of recreating.
+
+### 6. Write the plan file (issue mode only)
+
+If the plan file does not exist, write the issue body to `docs/plans/<slug>.md` with a header containing the title and source URL. Commit:
+
+```
+git add docs/plans/<slug>.md
+git commit -m "chore(afk): ingest issue #<N> plan"
+```
+
+### 7. Ingest the plan into dex
+
+```
+dex plan docs/plans/<slug>.md
+```
+
+Capture the new root task ID — the simplest way is to snapshot `dex list --json` filtered to root tasks (`parent_id is None`) before and after the call, and take the new ID from the diff.
+
+### 8. Create subtasks
+
+For each confirmed section from step 3, in order:
+
+```
+dex create "<section heading>" --parent <epic-id> --description "<section body>"
+```
+
+(If a child task with that name already exists under the epic, skip — keeps the skill idempotent if the user re-runs it.)
+
+### 9. Commit `.dex/` and push
+
+```
+git add .dex/
+git commit -m "chore(afk): seed dex subtasks for <slug>"
+git push -u origin claude/feat-<slug>
+```
+
+### 10. Hand off to the loop
+
+Tell the user the kickoff is complete, print the epic ID and the subtask IDs, then ask which worker should run each fire:
+
+- `claude` (default) — Opus via the Claude CLI
+- `codex` — OpenAI Codex via `codex exec`
+
+Pick the command based on the answer:
+
+```
+./scripts/afk-loop.sh <epic-id>                       # claude (default)
+AFK_WORKER=codex ./scripts/afk-loop.sh <epic-id>      # codex
+```
+
+Don't run it for the user without confirmation — it'll consume tokens and write code. Once they say go, run it in the foreground (so they see fire output) or background via `run_in_background: true` per their preference.
+
+## Re-runnability
+
+Every step above is idempotent:
+- Existing branch → switch, don't recreate.
+- Existing plan file → don't overwrite.
+- Existing epic for this plan (match by root task name) → reuse.
+- Existing subtask name under the epic → skip.
+
+If the user re-runs this skill after a partial bootstrap, it picks up where the previous run left off.
+
+## What this skill does NOT do
+
+- It doesn't create a cloud routine. For that, use `/afk-feature` (which writes to a separate worker.md instruction file and uses `RemoteTrigger`).
+- It doesn't modify the script. Anything the loop needs (claude/feat-* branch, dex epic in working tree) must be set up before handoff.
+- It doesn't decide whether the work is a good idea. If the user picked a bad plan, the loop will faithfully execute a bad plan.

--- a/scripts/afk-loop.sh
+++ b/scripts/afk-loop.sh
@@ -93,19 +93,38 @@ for i in $(seq 1 "$MAX_FIRES"); do
 
   echo ""
 
-  # Check if epic is now complete
-  EPIC_DONE="$(dex show "$EPIC_ID" --json 2>/dev/null | python3 -c '
+  # Check if epic is now complete. Two exit paths:
+  #   1. dex marks the epic completed (only happens after integration PR merges)
+  #   2. Every child task is completed AND an integration PR is open against main
+  #      (the worker can't merge the integration PR itself — that's the human's job —
+  #      so once it's open, every further fire is a no-op and we should stop early)
+  EPIC_STATE="$(dex show "$EPIC_ID" --json 2>/dev/null | python3 -c '
 import sys, json
 try:
     t = json.load(sys.stdin)
-    print("yes" if t.get("completed") else "no")
+    if t.get("completed"):
+        print("done")
+    else:
+        children = t.get("subtasks", {}).get("children", []) or t.get("children", [])
+        if children and all(c.get("completed") for c in children):
+            print("children-done")
+        else:
+            print("in-progress")
 except Exception:
-    print("no")
+    print("in-progress")
 ')"
 
-  if [[ "$EPIC_DONE" == "yes" ]]; then
+  if [[ "$EPIC_STATE" == "done" ]]; then
     echo "✓ Epic $EPIC_ID complete. Loop done."
     exit 0
+  fi
+
+  if [[ "$EPIC_STATE" == "children-done" ]]; then
+    INTEGRATION_PR="$(gh pr list --head "$FEATURE_BRANCH" --base main --state open --json number -q '.[0].number' 2>/dev/null || true)"
+    if [[ -n "$INTEGRATION_PR" ]]; then
+      echo "✓ All child tasks complete; integration PR #$INTEGRATION_PR is open against main. Loop done."
+      exit 0
+    fi
   fi
 
   echo "Sleeping ${SLEEP_SECONDS}s before next fire..."

--- a/scripts/afk-loop.sh
+++ b/scripts/afk-loop.sh
@@ -9,6 +9,7 @@
 # Env knobs:
 #   MAX_FIRES        max iterations before stopping (default 20)
 #   SLEEP_SECONDS    seconds to sleep between fires (default 5)
+#   AFK_WORKER       which CLI runs each fire: "claude" (default) or "codex"
 #
 # Stop with Ctrl+C. Each fire is a fresh context — no compaction, predictable cost.
 # This is the local equivalent of the cloud worker routine, without the 1h cron floor.
@@ -46,11 +47,26 @@ fi
 OWNER_REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
 MAX_FIRES="${MAX_FIRES:-20}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-5}"
+AFK_WORKER="${AFK_WORKER:-claude}"
+
+case "$AFK_WORKER" in
+  claude|codex) ;;
+  *)
+    echo "Error: AFK_WORKER must be 'claude' or 'codex' (got: $AFK_WORKER)" >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v "$AFK_WORKER" >/dev/null 2>&1; then
+  echo "Error: '$AFK_WORKER' CLI is not on PATH." >&2
+  exit 1
+fi
 
 echo "=== AFK loop ==="
 echo "Repo:           $OWNER_REPO"
 echo "Feature branch: $FEATURE_BRANCH"
 echo "Epic:           $EPIC_ID"
+echo "Worker:         $AFK_WORKER"
 echo "Max fires:      $MAX_FIRES"
 echo "Sleep between:  ${SLEEP_SECONDS}s"
 echo ""
@@ -84,12 +100,22 @@ for i in $(seq 1 "$MAX_FIRES"); do
   git fetch origin "$FEATURE_BRANCH" >/dev/null 2>&1 || true
   git reset --hard "origin/$FEATURE_BRANCH" >/dev/null 2>&1 || true
 
-  if ! claude -p "$PROMPT" \
-      --allowedTools "Bash,Read,Write,Edit,Glob,Grep" \
-      --dangerously-skip-permissions; then
-    echo "claude -p exited non-zero, stopping" >&2
-    exit 1
-  fi
+  case "$AFK_WORKER" in
+    claude)
+      if ! claude -p "$PROMPT" \
+          --allowedTools "Bash,Read,Write,Edit,Glob,Grep" \
+          --dangerously-skip-permissions; then
+        echo "claude -p exited non-zero, stopping" >&2
+        exit 1
+      fi
+      ;;
+    codex)
+      if ! codex exec --full-auto "$PROMPT"; then
+        echo "codex exec exited non-zero, stopping" >&2
+        exit 1
+      fi
+      ;;
+  esac
 
   echo ""
 

--- a/scripts/afk-loop.sh
+++ b/scripts/afk-loop.sh
@@ -70,9 +70,9 @@ Do this and only this:
 4. Follow its decision tree exactly ONCE, with the variables above substituted.
    - Skip every "RemoteTrigger run <SELF_ROUTINE_ID>" and "RemoteTrigger update" instruction in worker.md — we are running in a local shell loop, not a routine.
 
-Exit when you have done one unit of work (opened/merged one PR, advanced one task's state, or determined there is nothing to do).
+Exit when you have done one unit of work (opened/merged one PR, advanced one tasks state, or determined there is nothing to do).
 
-Do not invent extra work. Do not refactor outside the current step's scope. One PR per fire, max.
+Do not invent extra work. Do not refactor outside the current steps scope. One PR per fire, max.
 EOF
 )
 


### PR DESCRIPTION
## Summary

Round of improvements to the local AFK feature-build workflow.

- **New `/afk-local` skill** (`.claude/skills/afk-local/SKILL.md`). Sibling of `/afk-feature` (which spawns a cloud routine). Takes a planning doc under `docs/plans/` or a GitHub issue reference, sets up the `claude/feat-<slug>` branch + dex epic + subtasks, and hands off to `scripts/afk-loop.sh`. Prompts the user to pick worker-codeable phases from plan headings before creating dex tasks, so non-codeable sections (`Decisions before starting`, `Goals`, `Non-goals`, etc.) don't become subtasks the worker burns fires blocking on.

- **`AFK_WORKER` env var to pick the CLI per fire.** `AFK_WORKER=claude` (default) or `AFK_WORKER=codex` — the loop now invokes either CLI with the right flags. Validates the value, confirms the CLI is on `PATH`, and prints the selected worker in the startup banner.

- **Stop early once the integration PR is open.** Previous exit condition only checked dex's `completed` flag, which doesn't flip until the integration PR merges into main. With a 20-fire cap, ~14 fires were no-ops after the worker finished. New logic: if every child task is `completed` AND an integration PR exists from the feature branch into main, exit — the worker can't merge that PR itself, so further fires have no useful work.

- **Fix a bash syntax error that prevented the script from loading.** Two apostrophes (`task's`, `step's`) inside `PROMPT=\$(cat <<EOF ... EOF)` made bash treat the heredoc as an unterminated single-quoted string, failing with `unexpected EOF while looking for matching \`)'`. Replaced with `tasks`, `steps`. Caught while running issue #81 AFK locally — script wouldn't run at all until this was fixed.

## Test plan

- [x] `bash -n scripts/afk-loop.sh` passes after every commit
- [x] End-to-end on issue #81 with the new exit condition: 5 fires opened/merged 4 step PRs (#84, #85, #86, #87) plus the integration PR (#88), then the loop would have exited via the new `children-done` path instead of burning ~14 no-op fires
- [ ] Smoke test `AFK_WORKER=codex` on a throwaway plan (manual)