### PR TITLE
Run smoke-test Electron in accessory mode

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -83,6 +83,10 @@ app.commandLine.appendSwitch('remote-debugging-port', remoteDebuggingPort)
 app.commandLine.appendSwitch('remote-debugging-address', '127.0.0.1')
 app.commandLine.appendSwitch('enable-unsafe-webgpu')
 
+if (process.platform === 'darwin' && process.env.SPECULAR_BACKGROUND === '1') {
+  app.setActivationPolicy('accessory')
+}
+
 // Allow smoke tests to isolate workspace data in a temp directory
 const userDataDirArg = process.argv.find((a) => a.startsWith('--user-data-dir='))
 if (userDataDirArg) {

--- a/src/main/runtime/window-init.ts
+++ b/src/main/runtime/window-init.ts
@@ -147,6 +147,7 @@ export function initWindow(): void {
     height: 1000,
     title: 'Specular',
     titleBarStyle: 'hidden',
+    show: process.env.SPECULAR_BACKGROUND !== '1',
     ...(process.platform === 'darwin'
       ? { trafficLightPosition: { x: 14, y: 13 } }
       : {}),

--- a/tests/smoke/global-setup.ts
+++ b/tests/smoke/global-setup.ts
@@ -51,6 +51,7 @@ export async function setup() {
       SPECULAR_PORT: String(SMOKE_PORT),
       SPECULAR_REMOTE_DEBUGGING_PORT: String(SMOKE_CDP_PORT),
       SPECULAR_SKIP_ONBOARDING: '1',
+      SPECULAR_BACKGROUND: '1',
     },
   })
 


### PR DESCRIPTION
## Summary
- Smoke tests previously launched Electron as a normal GUI app, which on macOS auto-activates and steals focus from whatever the user was working in.
- Adds a `SPECULAR_BACKGROUND=1` env var that, on macOS, switches the app activation policy to `accessory` — the process still runs, serves the HTTP API, and can render windows, but doesn't grab focus or show up in the Dock / cmd-tab.
- The smoke harness (`tests/smoke/global-setup.ts`) sets the flag so `pnpm test:smoke` runs unobtrusively in the background.

## Test plan
- [ ] `pnpm test:smoke` passes
- [ ] Running smoke tests doesn't pull focus away from the foreground app
- [ ] Spot-check `focus.test.ts` and `keyboard-shortcuts.test.ts` (anything depending on key-window focus) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)