### PR TITLE
Scoped text-editing flag + Cmd+D fixes for multi-selection and groups

### DIFF
--- a/src/main/ipc/register-canvas-entity-ipc.ts
+++ b/src/main/ipc/register-canvas-entity-ipc.ts
@@ -79,9 +79,7 @@ import {
 import { createAnnotation, moveAnnotation } from '../workspace-annotations'
 import {
   deletePages,
-  groupBoundsForEntityIds,
 } from '../workspace-entities'
-import { findDuplicatePlacement } from '../workspace-placement'
 import {
   createPageAtPosition,
   duplicateEntity,
@@ -89,13 +87,11 @@ import {
   tidySelectedPages,
 } from '../workspace-pages'
 import { deleteGroups, duplicateGroup, ungroupUserGroup } from '../workspace-groups'
-import {
-  copyableSelectionPayload,
-  pasteEntitiesFromClipboard,
-} from '../workspace-clipboard'
+import { copyableSelectionPayload } from '../workspace-clipboard'
 import { workspaceGroups } from '../runtime/workspace-model'
 import { selectGroup } from '../runtime/selection-controller'
 import { deleteSelection } from '../runtime/delete-selection'
+import { duplicateSelection } from '../runtime/duplicate-selection'
 
 export function registerCanvasEntityIpc(): void {
   ipcMain.on(
@@ -397,23 +393,7 @@ export function registerCanvasEntityIpc(): void {
   })
 
   ipcMain.on('canvas-duplicate-selection', () => {
-    const entityIds = getSelectedEntityIds()
-    if (!entityIds.length) return
-    // For single selection, duplicate the entity (page or text entity)
-    if (entityIds.length === 1) {
-      duplicateEntity({ entityId: entityIds[0], focus: true })
-      return
-    }
-    const payload = copyableSelectionPayload()
-    if (!payload) return
-    const bounds = groupBoundsForEntityIds(entityIds)
-    if (!bounds) return
-    const placement = findDuplicatePlacement(bounds)
-    pasteEntitiesFromClipboard({
-      payload,
-      canvasX: placement.canvasX,
-      canvasY: placement.canvasY,
-    })
+    duplicateSelection()
   })
 
   ipcMain.on('canvas-copy-selection', () => {

--- a/src/main/runtime/binding-dispatcher.ts
+++ b/src/main/runtime/binding-dispatcher.ts
@@ -12,10 +12,11 @@ import { workspaceViewMode } from '../ui-state'
 import { aboveView } from './view-refs'
 import { mainHandlers } from './binding-handlers'
 
-// Track text-editing state per webContents so renderers don't clobber each
-// other's flag. Any one source being active is enough to suppress shortcuts.
+// Track text-editing state per webContents. A keystroke can only land in the
+// webContents that has focus, so dispatch consults that source's flag — not
+// a global aggregate. Aggregating let unrelated webContents (e.g. a page
+// with an autofocused input) suppress canvas-region shortcuts.
 const textEditingByWebContents = new WeakMap<WebContents, boolean>()
-let textEditingActiveCount = 0
 
 // Annotation state surfaced from above-view's renderer-local React state so
 // Escape resolution (annotation-close-thread / annotation-clear-draft) works.
@@ -31,21 +32,20 @@ export function setTextEditingActive(webContents: WebContents, active: boolean):
   const prev = textEditingByWebContents.get(webContents) ?? false
   if (prev === active) return
   textEditingByWebContents.set(webContents, active)
-  textEditingActiveCount += active ? 1 : -1
-  if (textEditingActiveCount < 0) textEditingActiveCount = 0
 }
 
-export function isTextEditingActive(): boolean {
-  return textEditingActiveCount > 0
+export function isTextEditingFor(webContents: WebContents): boolean {
+  return textEditingByWebContents.get(webContents) ?? false
 }
 
 export function buildBindingContext(
   sourceView: KeyboardSourceView,
   pageFocusActive: boolean,
+  isTextEditing = false,
 ): BindingContext {
   return {
     activeTool: activeTool(),
-    isTextEditing: isTextEditingActive(),
+    isTextEditing,
     pageFocusActive,
     sourceView,
     viewMode: workspaceViewMode(),
@@ -64,9 +64,6 @@ export function attachBindingDispatcher(
   attachedWebContents.add(webContents)
 
   webContents.on('destroyed', () => {
-    if (textEditingByWebContents.get(webContents)) {
-      textEditingActiveCount = Math.max(0, textEditingActiveCount - 1)
-    }
     textEditingByWebContents.delete(webContents)
   })
 
@@ -81,7 +78,11 @@ export function attachBindingDispatcher(
     if (!normalizedKey) return
 
     const pageFocusActive = sourceView === 'page'
-    const ctx = buildBindingContext(sourceView, pageFocusActive)
+    const ctx = buildBindingContext(
+      sourceView,
+      pageFocusActive,
+      isTextEditingFor(webContents),
+    )
 
     const bindingId = dispatchKey(BINDINGS, normalizedKey, ctx)
     if (!bindingId) return

--- a/src/main/runtime/binding-handlers.ts
+++ b/src/main/runtime/binding-handlers.ts
@@ -11,15 +11,14 @@ import { selectEntities, selectNone } from './selection-controller'
 import { markDirty } from './layout-dirty'
 import { requestLayout } from './surface-layout'
 import { arrowNavigationLocked, setArrowNavigationLocked, pages, selectedPageId } from './runtime-context'
-import { selectedCanvasTargets as uiSelectedCanvasTargets } from '../ui-state'
 import { deletePages } from '../workspace-entities'
 import { textEntities } from './text-entity-state'
 import { fileEntities } from './file-entity-state'
 import { drawingEntities } from './drawing-entity-state'
 import { shapeEntities } from './shape-entity-state'
-import { duplicatePageFromSource, duplicateEntity } from '../workspace-pages'
 import { selectBrowserTab } from './runtime-core'
 import { deleteSelection } from './delete-selection'
+import { duplicateSelection } from './duplicate-selection'
 
 type MainBindingId = Exclude<BindingId, 'annotation-close-thread' | 'annotation-clear-draft'>
 
@@ -156,14 +155,3 @@ export function selectAllEntities(): void {
   selectEntities(entityIds)
 }
 
-function duplicateSelection(): void {
-  const targets = uiSelectedCanvasTargets()
-  if (!targets.length) return
-  const target = targets[0]
-  if (!target) return
-  if (target.kind === 'page') {
-    duplicatePageFromSource({ sourcePageId: target.id, focus: true })
-  } else {
-    duplicateEntity({ entityId: target.id, focus: true })
-  }
-}

--- a/src/main/runtime/duplicate-selection.ts
+++ b/src/main/runtime/duplicate-selection.ts
@@ -1,0 +1,45 @@
+import {
+  entityKindById,
+  groupBoundsForEntityIds,
+} from '../workspace-entities'
+import { duplicateGroup } from '../workspace-groups'
+import { findDuplicatePlacement } from '../workspace-placement'
+import { duplicateEntity, duplicatePageFromSource } from '../workspace-pages'
+import {
+  copyableSelectionPayload,
+  pasteEntitiesFromClipboard,
+} from '../workspace-clipboard'
+import { getSelectedEntityIds } from './runtime-core'
+
+export function duplicateSelection(): void {
+  const entityIds = getSelectedEntityIds()
+  if (!entityIds.length) return
+
+  if (entityIds.length === 1) {
+    const id = entityIds[0]
+    const kind = entityKindById(id)
+    if (kind === 'group') {
+      duplicateGroup({ groupId: id, focus: true })
+      return
+    }
+    if (kind === 'page') {
+      duplicatePageFromSource({ sourcePageId: id, focus: true })
+      return
+    }
+    duplicateEntity({ entityId: id, focus: true })
+    return
+  }
+
+  // Multi-selection: reuse copy/paste machinery so duplicates retain
+  // their relative layout and every selected item is included.
+  const payload = copyableSelectionPayload()
+  if (!payload) return
+  const bounds = groupBoundsForEntityIds(entityIds)
+  if (!bounds) return
+  const placement = findDuplicatePlacement(bounds)
+  pasteEntitiesFromClipboard({
+    payload,
+    canvasX: placement.canvasX,
+    canvasY: placement.canvasY,
+  })
+}


### PR DESCRIPTION
## Summary

Two keyboard-shortcut fixes on this branch:

- **`fix(keyboard): scope text-editing flag per webContents`** — text-editing state now keyed by the editing webContents so other surfaces stay responsive.
- **`fix(duplicate): handle multi-selection and groups in Cmd+D`** — the duplicate handler only operated on the first selected target. Multi-selection of mixed items duplicated just one entity (diverging from copy/paste, which preserves the whole selection). Cmd+D on a single workspace group also threw from `duplicateEntity`.

Extracted a shared `duplicateSelection()` (`src/main/runtime/duplicate-selection.ts`) and routed both the keyboard binding and `canvas-duplicate-selection` IPC through it:

- Single selection → dispatches by kind (`duplicateGroup` / `duplicatePageFromSource` / `duplicateEntity`).
- Multi-selection → reuses `copyableSelectionPayload` + `pasteEntitiesFromClipboard`, so duplicates preserve relative layout just like copy/paste.

## Test plan

- [ ] Cmd+D on a single page → duplicates the page next to it
- [ ] Cmd+D on a single text/shape/file/drawing → duplicates that entity
- [ ] Cmd+D on a single workspace group → duplicates the whole group tree (no throw)
- [ ] Cmd+D on a multi-selection of mixed items → all items duplicated, relative layout preserved
- [ ] Cmd+D via menu / IPC path matches the keyboard path
- [ ] Delete key still works in webview text inputs without nuking canvas selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)