### PR TITLE
Page bounds: anchor canvasY at snap-rect top (Path A)

### DIFF
--- a/docs/explorations/page-bounds-snap-alignment.md
+++ b/docs/explorations/page-bounds-snap-alignment.md
@@ -1,0 +1,330 @@
+# Page bounds and snap/alignment alignment
+
+**Status:** Exploration — no code changes yet.
+**Trigger:** PR #97 (c2ec984) added alignment guides that exposed inconsistent snapping between page entities and other canvas items.
+**Question:** What should be the authoritative rect for snap, grid alignment, and alignment guides — the page body, body+device-frame, or body+chrome+device-frame?
+
+---
+
+## 1. Current system map
+
+### 1a. Stored page data
+
+`page.canvasX` / `page.canvasY` = the **top-left corner of the chrome band**, not the page body.
+
+`page.chromeHeight` is initialised to `CHROME_HEADER_HEIGHT` (44 px in `src/main/runtime/runtime-constants.ts:8`) at creation time (`src/main/runtime/page-factory.ts:113`). It is a mutable field on the `Page` interface (`src/main/runtime/runtime-entities.ts:22`) but nothing currently changes it after creation — it is effectively a constant.
+
+`page.canvasX/Y` and the content `width/height` are serialised verbatim into `.canvas` files as `x/y/width/height` on the JSON Canvas `link` node (`src/main/runtime/json-canvas-serializer.ts:120-123`). The chrome height is **not** stored in `.canvas` — it is re-derived from the constant at load time.
+
+### 1b. Canvas rect helpers (no chrome)
+
+`pageCanvasBounds(page)` → `{ x: page.canvasX, y: page.canvasY, width, height }` where width/height is content-only (`src/main/runtime/runtime-geometry.ts:68-77`).
+
+`pageOuterCanvasBounds(page)` → expands `pageCanvasBounds` outward by shell insets if a device frame is on (`src/main/runtime/runtime-geometry.ts:91-104`). When no shell is active, inner = outer = `pageCanvasBounds`.
+
+Neither function subtracts chrome; `canvasY` is already above the page body.
+
+### 1c. Screen bounds (with chrome)
+
+`computeScreenBoundsForPage` returns four sub-rects (`src/main/runtime/runtime-geometry.ts:195-284`):
+
+| Sub-rect | What it covers |
+|---|---|
+| `chrome` | The favicon/title row (y = `page.canvasY * zoom + pan.y + toolbarHeight`) |
+| `page` | The webview (y = chrome.y + chromeH + gap) |
+| `frame` | The webview + 1px card border |
+| `shell` | The device bezel outer bounds (body + shell insets) |
+
+The `page` sub-rect's Y is: `canvasY * zoom + pan + toolbarHeight + chromeH + gap`.
+
+`backgroundPageOverlays()` broadcasts screen coords to canvas-bg:
+- When shell is on: `screenX/Y/Width/Height` = `bounds.shell.*`
+- When shell is off: `screenX/Y/Width/Height` = `bounds.page.*`
+- `contentScreenX/Y/Width/Height` = always `bounds.page.*`
+
+(`src/main/runtime/canvas-layout-data.ts:67-87`)
+
+### 1d. Chrome rendering (floating above body)
+
+`EntityChrome.Root` uses `transform: translateY(-100%)` to position itself above the entity's top edge (`src/renderer/shared/EntityChrome.tsx:74-78`).
+
+`CanvasItemChrome.Root` (`src/renderer/above-view/CanvasItemChrome.tsx`) feeds `screenY = headerRect.y + headerRect.height` as the pseudo-bottom-edge to `EntityChrome.Root`, so the chrome paints at the top of the entity rect and translates upward. The net visual result: chrome floats above the body.
+
+`useAnchoredPosition` (`src/renderer/above-view/useAnchoredPosition.ts`) receives `screenX/Y/Width/Height` from the layout broadcast — which today encodes the **page-body rect** (see §1c above). To reconstruct the chrome slot it synthetically extends upward by `CHROME_HEADER_HEIGHT` (36 px, from `src/shared/entity-chrome-slots.ts:20`):
+
+```
+entityRectFor() at line 107-120:
+  headerExtension = hasHeader ? CHROME_HEADER_HEIGHT : 0
+  return { x: screenX, y: screenY - headerExtension, width: screenWidth, height: screenHeight + headerExtension }
+```
+
+`entityChromeSlots()` then carves the top `CHROME_HEADER_HEIGHT` pixels of that synthetic rect as the `header` slot.
+
+### 1e. Snap / alignment rect (the bug site)
+
+`currentSnapSnapshotEntities()` builds the rect the snap engine sees for each entity:
+
+```typescript
+// src/main/runtime/document-commands.ts:188-200
+pages.map((page) => {
+  const bounds = pageOuterCanvasBounds(page)   // ← body + shell insets, NO chrome
+  return {
+    canvasX: bounds.x,
+    canvasY: bounds.y,    // same as page.canvasY (chrome-top edge)
+    width: bounds.width,
+    height: bounds.height, // content height only
+  }
+})
+```
+
+`pageOuterCanvasBounds` returns `{ x: page.canvasX, y: page.canvasY, width, height }` — where `page.canvasY` is the **chrome top edge**, and `height` is the **content height only** (no chrome).
+
+So the snap rect for a page is: `top = chrome top edge`, `bottom = body bottom edge`.
+
+This is incoherent. The top of the snap rect is the chrome band's top, but the bottom is the page body's bottom. Guides fire against the chrome-top for top-edge alignment and against the body-bottom for bottom-edge alignment.
+
+Grid snap (`snapToGrid` applied to `entity.canvasX/canvasY` in `applyDragDelta`, `src/main/runtime/document-commands.ts:356-357`) also operates on `canvasY`, which is the chrome-top. So grid-snapping works but snaps the chrome top, not the body top.
+
+### 1f. Selectable bounds (chrome included in height)
+
+`pageSelectableBounds()` expands `pageOuterCanvasBounds` height by `page.chromeHeight` (`src/main/workspace-entities.ts:56-64`). This is used for hit-testing (marquee select, region select, `entityBoundsById`), placement collision, and group-bounds computation via `groupBoundsForEntityIds` (which calls `entityBoundsById` which calls `pageSelectableBounds`).
+
+So group bounds DO include chrome in their height when a page is a member.
+
+### 1g. Placement collision
+
+`occupiedRegions()` (`src/main/workspace-placement.ts:48-78`) takes `pageOuterCanvasBounds` (chrome-top, content-height) then calls `extendUpwardForChrome(bounds, page.chromeHeight)` to claim the chrome band above. The net occupied rect for a page is: top = chrome-top − chromeHeight (redundant since canvasY is already the chrome top), bottom = body-bottom. There's actually a double-shift here: `pageOuterCanvasBounds` starts at `canvasY` (chrome top), and `extendUpwardForChrome` subtracts `chromeHeight` again, producing a rect that starts 44 px above the chrome top. This was likely intended as a guard against new items landing under another item's chrome.
+
+### 1h. Device frame (shell)
+
+Shell insets are computed by `pageShellInsets()` (`src/main/runtime/runtime-geometry.ts:80-89`) from the device catalog. `pageOuterCanvasBounds` grows the rect by these insets, so the snap rect already includes the shell. However, the shell's screen-space rect (passed to `PageBorderLayer` and `DeviceShellLayer`) is derived from `bounds.shell.*` returned by `computeScreenBoundsForPage`, which pads around the page body — it does not start at the chrome top.
+
+Consequence: the device frame straddles two coordinate systems. Its top edge in screen space aligns with the page body top (not the chrome top), but in snap-candidate space it's part of `pageOuterCanvasBounds`, whose `y` is the chrome top. Alignment guides against the frame's visual top will fire at the wrong position.
+
+### 1i. CHROME_HEADER_HEIGHT constant mismatch
+
+There are two separate constants with the same name and different values:
+
+| File | Value | Used by |
+|---|---|---|
+| `src/main/runtime/runtime-constants.ts:8` | **44 px** | `page-factory.ts`, `workspace-placement.ts`, `register-canvas-entity-ipc.ts` |
+| `src/shared/entity-chrome-slots.ts:20` | **36 px** | `useAnchoredPosition.ts` (renderer chrome position) |
+
+The renderer chrome strip is rendered at 36 px; the snap candidate assumes 44 px. The two systems are already slightly misaligned by 8 px even when ignoring the body-vs-chrome origin question.
+
+---
+
+## 2. What the snap engine actually sees today (the smoking gun)
+
+When you drag a page, `currentSnapSnapshotEntities()` produces:
+
+```
+{ canvasX: page.canvasX,  canvasY: page.canvasY,
+  width: contentWidth,    height: contentHeight }
+```
+
+Where:
+- `canvasY` = chrome top (e.g. y=100)
+- `height` = body height only (e.g. 812 for iPhone)
+- So `bottom` in snap space = 100 + 812 = 912
+
+The visual body sits at `canvasY + chromeHeight` = 100 + 44 = 144.
+The visual body bottom = 144 + 812 = 956.
+
+If another entity sits at y=144 (body top), the alignment guide fires at `top = 100` — the chrome top — but the guide line is drawn at the chrome top in canvas space, which is 44 px above the visual body top. The guide line appears to float above the page.
+
+If you're aligning bottom edges: the snap candidate bottom (912) is 44 px above the visual body bottom (956). A guide matching at 912 fires before the bodies are actually bottom-aligned.
+
+For a page without a device frame, the snap rect is:
+- `top = chrome top` (above the visible content)
+- `bottom = body bottom` (matches visual)
+- `left/right = body left/right` (matches visual)
+
+The top edge is wrong; the rest are correct.
+
+For a page with a device frame, the shell expands `pageOuterCanvasBounds` outward from the body. But since `canvasY` starts at the chrome top (above the body), `pageOuterCanvasBounds.y` for a framed page is actually `canvasY - shellInsets.top` — which places the snap top even further above the visual chrome. The shell's visual top aligns with the body top, but the snap candidate top is at `chrome_top - shell.inset.top`.
+
+---
+
+## 3. Paths forward
+
+### Path A: Body-origin page — `canvasY` becomes the page body top
+
+**Overview:** Change the semantic of `page.canvasX/Y` to point at the body/viewport origin (currently `canvasY + chromeHeight`). Chrome renders above as a true overlay at `y - chromeHeight` in canvas space. Snap, grid, group bounds, and collision all operate on body coordinates.
+
+**What changes:**
+
+| Concern | Change |
+|---|---|
+| `Page.canvasY` | Shift by `+chromeHeight` at migration time (existing .canvas files) |
+| `pageCanvasBounds` | Returns body origin as-is — no change to the function signature |
+| `pageOuterCanvasBounds` | Grows from body outward with shell insets — aligns with visual |
+| Snap candidates | `canvasY` = body top; snap rect top is now correct |
+| `computeScreenBoundsForPage` | `chrome.y = page.canvasY * zoom + pan - chromeH`; `page.y = canvasY * zoom + pan`; geometry becomes simpler |
+| `pageSelectableBounds` | Can include chrome by extending upward: `{ y: outer.y - chromeH, height: outer.height + chromeH }` |
+| Placement (`occupiedRegions`) | `extendUpwardForChrome` still needed but now starts from body top, not chrome top |
+| `register-canvas-entity-ipc.ts:158` | `canvasY - CHROME_HEADER_HEIGHT` adjustment is removed (IPC now receives body Y) |
+| `region-capture.ts:139` | `contentCanvasY = pageBounds.y` (no adjustment needed) |
+| `presence-manager.ts:169` | Remove `+ page.chromeHeight` offset |
+| `canvas-layout-data.ts:424` | Remove `+ chromeHeight` offset in cursor placement |
+| `useAnchoredPosition.entityRectFor` | Extend upward by `CHROME_HEADER_HEIGHT` still needed (renderer receives body-only `screenY`) |
+| `.canvas` file migration | All existing `link` nodes must have their `y` shifted by `+44` |
+
+**Device frame with Path A:** `pageOuterCanvasBounds` starts at the body origin, so `outer.y = body.y - shellInsets.top`. Shell occupies body + insets in all directions. This cleanly aligns: the snap rect top for a framed page is the shell's visual top edge, not the chrome top.
+
+**Pros:**
+- Snap, grid, and alignment guides all operate on the visual body, which is what users expect.
+- Device shell visual top = snap top. No more floating guide lines.
+- `pageCanvasBounds` and `pageOuterCanvasBounds` return rects whose `y` matches the visible content origin — no mental shift needed when reading coordinates.
+- `computeScreenBoundsForPage` simplifies: chrome.y is derived downward from `canvasY - chromeH`, rather than `canvasY` being the chrome origin.
+- Region capture, presence, cursor placement all drop ad-hoc `+ chromeHeight` offsets.
+- The `page.chromeHeight` field could eventually be retired (chrome height is a constant).
+- Aligns with the ADR 0002 §1 intent: "entity rect = body + chrome stacked" where chrome extends above rather than body extending below.
+
+**Cons:**
+- Requires a `.canvas` file migration: all `link` nodes must shift `y` by `+CHROME_HEADER_HEIGHT` (44 px). Existing files opened without migration will render pages 44 px lower than they were placed.
+- Every site that reads `page.canvasY` as the chrome-top (currently documented in several comments) needs to be audited and updated — approximately 8–10 callsites.
+- The IPC that delivers `canvasY` from the renderer (drag start, click-to-place) assumes the renderer knows the chrome height. The renderer computes body position from `entity.screenY`; if IPC sends body coords that is already the right thing.
+- Existing tests that assert specific `canvasY` values will need updating.
+
+**Best for:** New builds or builds willing to accept a one-time migration. Highest long-term clarity.
+
+**Blast radius:** Medium-high. Mostly additive changes (shift values, remove offsets), no architectural additions. The migration itself is the largest risk.
+
+---
+
+### Path B: Keep `canvasY` as chrome-top; expose `pageBodyCanvasBounds()` for snap
+
+**Overview:** Do not change the stored coordinate meaning. Add a `pageBodyCanvasBounds()` helper that returns `{ y: page.canvasY + page.chromeHeight, height: contentHeight }`. Feed this (not `pageOuterCanvasBounds`) into `currentSnapSnapshotEntities()` for page entries. Alignment guides and grid snap operate on body bounds; view positioning continues using the existing chrome-aware paths.
+
+**What changes:**
+
+| Concern | Change |
+|---|---|
+| New function | `pageBodyCanvasBounds(page)` → `{ x: canvasX, y: canvasY + chromeHeight, width, height }` |
+| `currentSnapSnapshotEntities` | Pages use `pageBodyCanvasBounds`; width/height unchanged |
+| `currentSnapCandidateForEntity` | Same — use body bounds for pages |
+| `pageOuterCanvasBounds` | Extend from body origin, not chrome origin — same fix as Path A for the shell |
+| `pageSelectableBounds` | No change; hit-testing still uses chrome-inclusive bounds |
+| Everything else | Unchanged |
+| `.canvas` file migration | None |
+
+**Device frame with Path B:** `pageOuterCanvasBounds` needs the same fix as Path A — it currently starts from `page.canvasY` (chrome top) and expands with shell insets. It should start from `page.canvasY + page.chromeHeight` (body top) before applying insets. Otherwise the snap rect for a framed page still has a wrong top edge.
+
+**Pros:**
+- Zero migration. Existing `.canvas` files work unchanged.
+- Lower blast radius. Only 2–3 functions change in main.
+- Two coordinate systems coexist cleanly: chrome-top for rendering/view-positioning, body-top for snap/align.
+- Reversible. If the user changes their mind the function can be swapped back.
+
+**Cons:**
+- Two meanings of "page position" in the codebase. Any new code author must learn which `pageXxxCanvasBounds` to call.
+- `page.canvasY` (and thus the `.canvas` file) continues to encode chrome-top, which is visually misleading — the stored coordinate does not point at any visible content corner.
+- `pageOuterCanvasBounds` still needs fixing (see above), so there are changes in both Path A and B — Path B just avoids the migration.
+- Group bounds still computed via `entityBoundsById` → `pageSelectableBounds` → `pageOuterCanvasBounds`. If `pageOuterCanvasBounds` is fixed to start at the body, group bounds change slightly (they shrink by `chromeHeight` at the top). This is a behaviour change even if small.
+- The constant mismatch (44 vs 36 px) is not fixed.
+
+**Best for:** Fast fixes with a preference for minimal risk. Good as a stepping-stone toward Path A.
+
+**Blast radius:** Low. Mostly isolated to snap infrastructure.
+
+---
+
+### Path C: Separate snap bounds from selectable bounds via `getSnappableBounds(entity)`
+
+**Overview:** Introduce a single dispatch function `getSnappableBounds(entityId)` that returns the rect the snap engine should use, independent of `pageOuterCanvasBounds` or `pageSelectableBounds`. For pages it returns body-only (or body+shell). Other entity kinds return their `{canvasX, canvasY, width, height}` unchanged. Feed this exclusively into `currentSnapSnapshotEntities`, `currentSnapCandidateForEntity`, and the resize guide session.
+
+This is a generalisation of Path B: instead of a page-specific helper, the snap engine has a per-entity dispatch point that any future entity kind can override.
+
+**What changes:**
+
+| Concern | Change |
+|---|---|
+| New function in `workspace-entities.ts` | `getSnappableBounds(entityId): WorkspaceBounds \| null` |
+| `currentSnapSnapshotEntities` | Call `getSnappableBounds` for each entity |
+| `currentSnapCandidateForEntity` | Same |
+| Page implementation | Returns `pageBodyCanvasBounds` (body + shell, no chrome) |
+| `pageOuterCanvasBounds` | Fix shell to start from body origin (same as Path B) |
+| `.canvas` migration | None |
+
+**Pros:**
+- Cleanest abstraction for a multi-kind canvas: snap semantics are owned per entity type at a single dispatch point, not scattered across the snap loop.
+- Future entity types (e.g. sticky note with a tab, drawing with a label header) can opt into body-only snap without touching the snap engine.
+- No migration.
+
+**Cons:**
+- More indirection than Path B for the same immediate fix. The distinction between `getSnappableBounds` and `entityBoundsById` (which is already a dispatch function) needs careful documentation to avoid confusion.
+- Still leaves `page.canvasY` meaning chrome-top, which is the root semantic confusion. Path C cleans up snap but leaves the stored data ambiguous.
+- The constant mismatch is still not fixed.
+
+**Best for:** Teams expecting more entity kinds to need custom snap semantics. Good architecture for extensibility.
+
+**Blast radius:** Low-medium. Touch snap infrastructure + add one dispatch function.
+
+---
+
+### Path D: Make chrome a sibling entity (separate node)
+
+**Overview:** Chrome becomes its own persisted entity (or a "decoration" entity) parented to the page. The page's `canvasX/Y/width/height` stores only the body. Chrome is positioned by the parent-child relationship.
+
+**What changes:** Essentially everything. New entity kind, parent-child references, serialization, undo, group semantics, IPC. The page entity type becomes clean but the implementation cost is very high.
+
+**Pros:**
+- Absolute clarity: a page entity is the body, period.
+- Chrome can have its own z-ordering and styling.
+
+**Cons:**
+- Enormous blast radius. Every system that touches entities (snap, align, group, duplicate, delete, undo, serialization, IPC, CLI, agent tools) must handle chrome decorations.
+- `.canvas` format changes significantly.
+- Drag and hit-testing for chrome become coordination between two entities.
+- Undo of a move must move both nodes atomically.
+
+**Verdict:** Overkill for this problem. The chrome is not independently addressable — it is always owned by and moves with its page. A separate entity adds complexity without user-visible value.
+
+---
+
+## 4. Recommended path
+
+**Start with Path B, then migrate to Path A.**
+
+### Phase 1 — Path B (no migration, fixes snap immediately)
+
+1. Add `pageBodyCanvasBounds(page)` returning `{ x: page.canvasX, y: page.canvasY + page.chromeHeight, width: contentWidth, height: contentHeight }`.
+
+2. Fix `pageOuterCanvasBounds` to start from body origin: `inner = pageBodyCanvasBounds(page)`, then add shell insets. (Currently it starts from `page.canvasY` which is the chrome top — this is the device-frame bug.)
+
+3. In `currentSnapSnapshotEntities` and `currentSnapCandidateForEntity`, use `pageBodyCanvasBounds` (not `pageOuterCanvasBounds`) for the base, then apply shell insets separately — or simply use the fixed `pageOuterCanvasBounds` (which now = body + shell).
+
+4. Reconcile the constant mismatch: pick one value (36 px, matching the renderer) and update `runtime-constants.ts`, `page-factory.ts`, and all callers.
+
+5. Update `pageSelectableBounds` to extend upward from the fixed outer bounds: `{ y: outer.y - chromeH, height: outer.height + chromeH }`.
+
+**Result:** Snap and alignment guides fire at the body's visual edges. Device shell top aligns with snap top. No `.canvas` migration.
+
+### Phase 2 — Path A (migration, cleans stored semantics)
+
+Once Phase 1 is stable, write a one-time migration in `workspace-restore.ts` (or the JSON canvas loader) that detects legacy files (where `y` = chrome top) and shifts `y += chromeHeight` on every `link` node. Flip `page.canvasY` to mean body origin. Remove all `+ chromeHeight` offsets from callsites.
+
+The migration can be detected reliably: when loading a file, if the stored page `y` equals `page.canvasY - 44` of what the chrome-top logic would produce, it's a pre-migration file. A simpler heuristic: add a `__formatVersion` field to the `.canvas` `appState` extension and bump it.
+
+### Why this order
+
+Path B is a targeted, reviewable fix with near-zero migration risk. It closes the snap bug and the device-frame misalignment in one small PR. Path A's migration introduces risk on every `.canvas` file a user has ever created — doing that after behaviour is validated in Path B is safer.
+
+---
+
+## 5. Open questions
+
+1. **Chrome height constant**: Which value is correct — 44 px (`runtime-constants.ts`) or 36 px (`entity-chrome-slots.ts`)? The renderer paints at 36 px (the actual pixel height of the chrome strip); the main process assumes 44 px everywhere. The 8 px gap means the view is positioned 8 px lower than the chrome bottom in screen space. Decide which is canonical before Phase 1.
+
+2. **Should the device frame be inside or outside the snap rect?** Path B as described puts the snap rect at body + shell insets (the full outer bezel). An alternative: snap rect = body only; frame is visual chrome. The user's words say the page body should be the source of truth, which suggests body-only snap with the device frame as visual decoration. But that would mean alignment guides fire at the body edges, not the outer bezel — two framed pages that look visually flush at their bezels would not produce a guide. Clarify the expected UX before implementing.
+
+3. **Group bounds and the chrome above pages**: `groupBoundsForEntityIds` calls `entityBoundsById` → `pageSelectableBounds` → `pageOuterCanvasBounds` (after the fix, body+shell), then adds `chromeH` on top. Group bounds therefore include the chrome band. When a page is grouped, should the group outline include chrome? If yes, the current logic is correct after the fix. If no, `pageSelectableBounds` should not extend upward for chrome.
+
+4. **Grid-snap anchor**: With Path B/A, `applyDragDelta` snaps `entity.canvasX/Y`. After Path A, `canvasY` is the body top, so grid lines align with body tops — the design intent. Before Path A (during Path B phase), `canvasY` is still chrome-top, so grid alignment is still broken for the stored coordinate even though snap guides show correctly. Is this acceptable interim state?
+
+5. **Undo/redo correctness**: The undo stack records `canvasX/Y` mutations via Y.Doc. After Path A's migration, any undo of a pre-migration drag that was recorded with chrome-top coordinates will replay correctly because the delta is relative. Cross-session undo (stored in the `.canvas` file) will work only if the migration runs before the undo stack replays. Confirm whether undo history is cleared on file open (it is, via `clearUndoHistory()` in `workspace-restore.ts`) — if so, no special handling is needed.
+
+6. **CLI and agent tools**: The HTTP API routes expose `canvasX/canvasY` directly (e.g. `update-page-bounds`, `list-pages`). After Path A these semantics change. Agent tools that position pages by explicit `canvasY` will need to account for the shift. Consider a deprecation notice in the API response or a migration guide for agents.
+
+7. **`pageSelectableBounds` height expansion**: The current `page.chromeHeight` (44 px) is used to expand selectable height. After fixing the constant to 36 px, selectable bounds shrink slightly at the top. Check whether this affects marquee selection feel — the drag target for the chrome strip would shrink from 44 to 36 px.

--- a/docs/plans/page-bounds-snap-alignment.md
+++ b/docs/plans/page-bounds-snap-alignment.md
@@ -1,0 +1,345 @@
+# Plan: Page bounds — Path A (snap-rect-top is `canvasY`)
+
+See `docs/explorations/page-bounds-snap-alignment.md` for the current-system map and rationale.
+
+## 1. Goal and locked-in decisions
+
+Re-anchor `page.canvasY` to the **top of the snap rect**, where the snap rect = body + device-frame insets. Chrome lives outside the snap rect and renders at `y - CHROME_HEADER_HEIGHT`.
+
+Locked-in decisions:
+
+1. **`page.canvasY` semantics change** to "top of the snap rect" (body top when unframed, device-bezel top when framed). Chrome paints above at `y - CHROME_HEADER_HEIGHT`.
+2. **Snap rect = body + device-frame insets.** Chrome is always outside.
+3. **Toggling a frame is anchored at `canvasY`.** With `canvasY` defined as the snap-rect top, turning a frame ON keeps the snap-rect-top anchored and *pushes the body down* by `insets.top` to make room for the bezel. Turning a frame OFF pulls the body back up to `canvasY`. This is the natural consequence of decision #1 — no extra logic needed.
+4. **No `.canvas` migration.** Pre-existing files will visually shift by `CHROME_HEADER_HEIGHT` (and by `insets.top` when a frame is on) on reopen. Accepted.
+5. **Reconcile `CHROME_HEADER_HEIGHT` to 36 px** — the renderer's visible value. Single source of truth lives in `src/shared/entity-chrome-slots.ts`; `runtime-constants.ts` re-exports. `page.chromeHeight` is removed from the `Page` interface (effectively constant).
+
+### Chrome-height decision (callout)
+
+- `src/main/runtime/runtime-constants.ts:8` defines `CHROME_HEADER_HEIGHT = 44`.
+- `src/shared/entity-chrome-slots.ts:20` defines `CHROME_HEADER_HEIGHT = 36`.
+- `src/shared/canvas-hit-geometry.ts:3` defines `PAGE_CHROME_HEIGHT_PX = 36` (used by hit-test).
+
+**Decision:** the 36 in `src/shared/entity-chrome-slots.ts` becomes the single source of truth. Main imports it from `shared`; `runtime-constants.ts` no longer declares the constant. `PAGE_CHROME_HEIGHT_PX` is collapsed into the same export. `page.chromeHeight` is removed from the `Page` interface (`src/main/runtime/runtime-entities.ts:22`) — callsites read the shared constant.
+
+Why 36 (not 44): 36 is what the user actually sees and what hit-test already uses. 44 is a phantom in main-only code paths; the 8 px excess only shows up as occluded space in placement, not as anything visible.
+
+---
+
+## 2. Implementation steps (in order)
+
+### Step 1 — Unify the chrome-height constant
+
+**Files:**
+- `src/main/runtime/runtime-constants.ts:8` — delete `export const CHROME_HEADER_HEIGHT = 44`. Replace with `export { CHROME_HEADER_HEIGHT } from '../../shared/entity-chrome-slots'`.
+- `src/shared/canvas-hit-geometry.ts:3` — delete `PAGE_CHROME_HEIGHT_PX = 36`, re-export `CHROME_HEADER_HEIGHT` from `entity-chrome-slots` (or rename callers).
+- `src/shared/hit-test.ts:20,344,346` — switch references from `PAGE_CHROME_HEIGHT_PX` to `CHROME_HEADER_HEIGHT`.
+- `src/main/runtime/runtime-entities.ts:22` — remove `chromeHeight: number` from the `Page` interface.
+- `src/main/runtime/page-factory.ts:113` — delete `chromeHeight: CHROME_HEADER_HEIGHT,` from the `Page` literal.
+- All sites that read `page.chromeHeight` read `CHROME_HEADER_HEIGHT` from shared.
+
+**Verifies:** typecheck passes; `pnpm dev` still launches. The 36/44 mismatch (main thought chrome was 44 while renderer painted 36) disappears.
+
+### Step 2 — Flip `page.canvasY` semantics (no rename of stored data)
+
+Update the doc comment over `Page.canvasY` in `src/main/runtime/runtime-entities.ts:21`:
+
+```typescript
+/** Top-left of the page's snap rect in canvas coords. With a device frame
+ *  this is the bezel top; without, it is the body top. Chrome renders
+ *  above at (canvasY - CHROME_HEADER_HEIGHT). */
+canvasY: number
+```
+
+**Verifies:** no compile errors.
+
+### Step 3 — Geometry helpers: redefine `pageOuterCanvasBounds` and add a chrome-inclusive helper
+
+`src/main/runtime/runtime-geometry.ts:68-103`:
+
+- **Rename** `pageCanvasBounds` → `pageBodyCanvasBounds` (the body, not the snap rect — old name misleads once `canvasY` is the snap-rect top).
+- **Rename** `pageOuterCanvasBounds` → `pageSnapBounds`. Body inside is at `(canvasY + insets.top, canvasX + insets.left)` when framed; unchanged when unframed.
+
+```typescript
+export function pageSnapBounds(page): WorkspaceBounds {
+  const size = pageContentSize(page)
+  const insets = pageShellInsets(page)
+  if (!insets) return { x: page.canvasX, y: page.canvasY, width: size.width, height: size.height }
+  return {
+    x: page.canvasX,
+    y: page.canvasY,
+    width: size.width + insets.left + insets.right,
+    height: size.height + insets.top + insets.bottom,
+  }
+}
+
+export function pageBodyCanvasBounds(page): WorkspaceBounds {
+  const size = pageContentSize(page)
+  const insets = pageShellInsets(page)
+  return {
+    x: page.canvasX + (insets?.left ?? 0),
+    y: page.canvasY + (insets?.top ?? 0),
+    width: size.width,
+    height: size.height,
+  }
+}
+
+export function pageVisualBounds(page): WorkspaceBounds {
+  const snap = pageSnapBounds(page)
+  return { x: snap.x, y: snap.y - CHROME_HEADER_HEIGHT, width: snap.width, height: snap.height + CHROME_HEADER_HEIGHT }
+}
+```
+
+Three rects now exist: **body**, **snap** (body + frame insets), **visual** (snap + chrome above).
+
+**Verifies:** typecheck. Every `pageOuterCanvasBounds` importer must update via single search-and-replace.
+
+### Step 4 — `computeScreenBoundsForPage`: rewire chrome to live above `canvasY`
+
+`src/main/runtime/runtime-geometry.ts:191-283`:
+
+```typescript
+// Before:
+const pageY = ... : Math.round(canvasY * zoom + pan.y) + toolbarHeight + chromeH + gap
+const chromeY = ... : Math.round(canvasY * zoom + pan.y) + toolbarHeight
+
+// After:
+const snapTopScreenY = Math.round(canvasY * zoom + pan.y) + toolbarHeight
+const insetTopScreen = Math.round((insets?.top ?? 0) * zoom)
+const pageY = ... : snapTopScreenY + insetTopScreen       // body top
+const chromeY = ... : snapTopScreenY - chromeH            // chrome above snap top
+const shellY = ... : snapTopScreenY                       // bezel top = canvasY in screen space
+```
+
+Shell rect: `shell.y = snapTopScreenY`, `shell.height = pageH + insets.top + insets.bottom`. Drop `CHROME_PAGE_GAP` if unused after.
+
+**Verifies:** `pnpm dev` — drag a page; chrome floats above body. With a frame, bezel hugs body and chrome floats above the bezel. Toggle a frame on/off; body shifts down/up by `insets.top`, snap-rect-top stays put.
+
+### Step 5 — Strip the `+ chromeHeight` offsets at call sites
+
+Each currently compensates for `canvasY` being chrome-top. After Path A they simplify:
+
+- `src/main/ipc/register-canvas-entity-ipc.ts:158` — drop the `- CHROME_HEADER_HEIGHT`.
+- `src/main/presence-manager.ts:165-169`:
+  ```typescript
+  // before: canvasY: page.canvasY + page.chromeHeight + clamp(point.y, 0, height),
+  // after:  canvasY: pageBodyCanvasBounds(page).y + clamp(point.y, 0, height),
+  ```
+- `src/main/runtime/canvas-layout-data.ts:421-424`:
+  ```typescript
+  // before: const chromeHeight = pageWcv?.chromeHeight ?? 0
+  //         canvasY: page.canvasY + chromeHeight + clampedY,
+  // after:  canvasY: pageBodyCanvasBounds(page).y + clampedY,
+  ```
+- `src/main/runtime/region-capture.ts:137-139`:
+  ```typescript
+  // before: const contentCanvasY = pageBounds.y + page.chromeHeight
+  // after:  const contentCanvasY = pageBodyCanvasBounds(page).y
+  ```
+- `src/main/workspace-entities.ts:56-66` `pageSelectableBounds`:
+  ```typescript
+  // before: { y: outer.y, height: outer.height + page.chromeHeight }
+  // after:  return pageVisualBounds(page)
+  ```
+  Old version stretched height *down*; under Path A chrome lives *above*.
+- `src/main/workspace-placement.ts:45-58` `extendUpwardForChrome` — behavior is now correct as-named, no math change.
+
+**Verifies:** typecheck; placement smoke yields same placement modulo the chromeHeight shift on stored pages.
+
+### Step 6 — Snap and alignment guides
+
+`src/main/runtime/document-commands.ts:188-200, 250-267`:
+
+```typescript
+// before: const bounds = pageOuterCanvasBounds(page)
+// after:  const bounds = pageSnapBounds(page)
+```
+
+`currentSnapCandidateForEntity` at `document-commands.ts:253` likewise: `pageSnapBounds(page)`.
+
+**Grid snap path:** `src/main/runtime/document-commands.ts:356-357` mutates `entity.canvasX/Y` directly via `snapToGrid`. Since `canvasY` now means snap-rect top, grid snap aligns the snap rect's top edge — design intent. No code change.
+
+**Alignment guides path (PR #97 / c2ec984):** detector at `src/main/runtime/alignment-guide-detector.ts:51` consumes `SnapCandidate` built via `snapCandidateFromRect(entity, rect)`. With the snap rect fed in, guides fire on visible edges.
+
+**Verifies:** drag two pages (one framed, one unframed) — guides fire flush with visible edges. Bezel-top of framed page snaps to body-top of unframed page (both are snap-rect tops).
+
+### Step 7 — Renderer chrome: render above the body
+
+`src/renderer/above-view/useAnchoredPosition.ts:113-122` `entityRectFor` — synthetically extends upward by `CHROME_HEADER_HEIGHT` for kinds with chrome. After Step 4, entity `screenY` is the snap-rect top (bezel top for framed, body top for unframed). The synthetic extension upward by `CHROME_HEADER_HEIGHT` puts the chrome slot above. ✓
+
+Update the doc comment at `useAnchoredPosition.ts:106-112` to reflect: "entity screenY is the snap-rect top of the page; chrome lives above".
+
+**Device frame visual sanity:** `bezel top = canvasY` in canvas space ⇒ `bezel top = snapTopScreenY` in screen space. `body top = bezel top + insets.top * zoom`. Matches locked-in #2.
+
+### Step 8 — Selection outline: recommendation
+
+`src/renderer/above-view/SelectionOutlineLayer.tsx:47-79` currently outlines the snap rect with `-6` padding. Chrome NOT included.
+
+**Recommendation: wrap the snap rect, not chrome.** Reasons:
+1. Today's outline already wraps the snap rect; chrome floats outside.
+2. Chrome is always shown on hover/active.
+3. The snap rect IS the alignment/grid rect — outlining it tells the user where guides fire from.
+
+No code change. Add doc comment confirming intent. Multi-selection bbox already uses union of snap rects via `entityBoundsById → pageSelectableBounds`; under Step 5 this becomes `pageVisualBounds` (chrome-inclusive). See Step 11 for the group decision — if groups use visual bounds, multi-select bbox does too.
+
+### Step 9 — Main process view positioning (verification — no offset to remove)
+
+`src/main/runtime/layout-engine.ts:384-385`:
+
+```typescript
+page.lastFrameBoundsKey = setBoundsIfChanged(page.frameView, bounds.frame, ...)
+page.lastPageBoundsKey  = setBoundsIfChanged(page.pageView,  bounds.page,  ...)
+```
+
+`bounds.page` from `computeScreenBoundsForPage` (Step 4) = body screen rect. No `+ CHROME_HEADER_HEIGHT` offset needed.
+
+**Verifies:** click-into-page focus shifts to WCV at body region; 36 px above body is the chrome strip (renderer-painted), not WCV.
+
+### Step 10 — Hit-test / drag-handle confirmation
+
+`src/shared/hit-test.ts:341-348`:
+
+```typescript
+function chromeRect(entity: CanvasSceneEntity): Rect {
+  return {
+    x: entity.screenX,
+    y: entity.screenY - CHROME_HEADER_HEIGHT,
+    width: entity.screenWidth,
+    height: CHROME_HEADER_HEIGHT,
+  }
+}
+```
+
+`entity.screenY` is the snap-rect top (Step 4). Chrome hit region is above the snap rect. Correct.
+
+**File responsible for chrome-as-drag-handle:** `src/main/ipc/register-canvas-drag-ipc.ts:204` (`canvas-drag-page-start`).
+
+**Verifies:** click on chrome strip and drag → page moves. With a framed page, clicking the bezel does NOT trigger drag — bezel is part of the snap rect, not chrome hit region. (Deliberate behavior change vs. ambiguous status quo; revisit if users complain.)
+
+### Step 11 — Groups
+
+`src/main/workspace-entities.ts:164-176` `groupBoundsForEntityIds` → `pageSelectableBounds`. After Step 5's rewrite, `pageSelectableBounds = pageVisualBounds = snap rect + chrome above`.
+
+**Deliberate change:** group bounds containing a page shift up by `CHROME_HEADER_HEIGHT` (chrome now claimed as visible-but-above), bottom moves up by the old `page.chromeHeight` (no longer extending downward).
+
+**Recommendation: groups use *visual* bounds (chrome-inclusive).** Reasons:
+1. Group outline is a visual frame; users expect it to wrap everything visible.
+2. Grouped pages need chrome handle reachable; cropping chrome would visually overflow.
+3. Matches today's behavior (height-extended bounds), just inverted in direction.
+
+No `groupBoundsForEntityIds` change needed; it inherits corrected `pageSelectableBounds`.
+
+### Step 12 — CLI + HTTP API
+
+`src/main/app-control-server.ts:451,573,594` returns `canvasX/canvasY`. Values change meaning: "chrome top" → "snap-rect top". Existing CLI scripts that pass explicit y values will render in slightly different spots:
+
+- Unframed: 36 px higher than before.
+- Framed: `36 + insets.top` px higher than before.
+
+**Document as known visible-but-accepted shift.** No code change to HTTP API surface — field name `canvasY` stays.
+
+---
+
+## 3. Known visible behavior changes
+
+1. **Existing `.canvas` files reopen with pages shifted** by `CHROME_HEADER_HEIGHT` (unframed) or `CHROME_HEADER_HEIGHT + insets.top` (framed). **Accepted.**
+2. **Toggling a frame** now pushes body down by `insets.top` (frame ON) or pulls body up by `insets.top` (frame OFF), keeping snap-rect-top anchored at `canvasY`. **Desired.**
+3. **Group bounds change shape** — extend `chromeHeight` *up* instead of *down*.
+4. **CLI `specular create page --x --y` semantics shift** — `y` now means snap-rect top.
+5. **Selection outline excludes chrome** (unchanged, now documented as intentional).
+6. **Bezel is no longer a drag handle** (unchanged from today's hit-test).
+7. **Constant collapse: 44 → 36.** Placement reserves 8 px less of chrome headroom.
+
+---
+
+## 4. Testing strategy
+
+### Existing tests to update
+
+Search for:
+- `canvasY` values asserted directly — flip semantics or query `pageBodyCanvasBounds`.
+- `CHROME_HEADER_HEIGHT === 44` — update to 36 or remove.
+- `pageOuterCanvasBounds` — rename to `pageSnapBounds`.
+- Placement collision tests asserting specific occupied-region rects — adjust by 8 px at the top.
+
+### Tests that should fail and signal a real bug
+
+- Any test asserting visual bottom of a framed page = `canvasY + insets.top + height + insets.bottom`. Under Path A this should be `canvasY + height + insets.top + insets.bottom`.
+- Any snap-engine test asserting a guide fires at chrome-top y. Under Path A guides fire at snap-rect top — **smoking gun fix**.
+
+### New tests worth adding
+
+`src/main/runtime/runtime-geometry.test.ts` (create if absent):
+
+```typescript
+describe('page snap bounds', () => {
+  it('unframed page: snap rect = body rect', () => {
+    const page = mkPage({ canvasX: 100, canvasY: 200, presetIndex: 0 })
+    expect(pageSnapBounds(page)).toEqual({ x: 100, y: 200, width: 393, height: 852 })
+    expect(pageBodyCanvasBounds(page)).toEqual({ x: 100, y: 200, width: 393, height: 852 })
+  })
+
+  it('framed page: snap rect = bezel rect, body inset by insets', () => {
+    const page = mkPage({ canvasX: 100, canvasY: 200, presetIndex: 0, metadata: { showDeviceFrame: true, deviceId: 'iphone-15' } })
+    const insets = pageShellInsets(page)!
+    expect(pageSnapBounds(page)).toEqual({
+      x: 100, y: 200,
+      width: 393 + insets.left + insets.right,
+      height: 852 + insets.top + insets.bottom,
+    })
+    expect(pageBodyCanvasBounds(page)).toEqual({
+      x: 100 + insets.left, y: 200 + insets.top,
+      width: 393, height: 852,
+    })
+  })
+
+  it('chrome lives above the snap rect', () => {
+    const page = mkPage({ canvasX: 100, canvasY: 200 })
+    expect(pageVisualBounds(page).y).toBe(200 - CHROME_HEADER_HEIGHT)
+  })
+
+  it('toggling frame on keeps canvasY stable and pushes body down', () => {
+    const unframed = mkPage({ canvasX: 100, canvasY: 200 })
+    const framed = { ...unframed, metadata: { showDeviceFrame: true, deviceId: 'iphone-15' } }
+    expect(pageSnapBounds(framed).y).toBe(pageSnapBounds(unframed).y)             // anchor stable
+    expect(pageBodyCanvasBounds(framed).y).toBeGreaterThan(pageBodyCanvasBounds(unframed).y) // body moves down
+  })
+})
+```
+
+`src/main/runtime/alignment-guide-detector.test.ts`:
+
+```typescript
+it('two unframed pages with the same body top produce a top-edge guide', () => { /* ... */ })
+it('framed + unframed at same bezel/body top produces a top-edge guide', () => { /* ... */ })
+```
+
+---
+
+## 5. Rollout / sanity-check checklist (manual smoke in `pnpm dev`)
+
+- [ ] **Open a fresh workspace:** create one unframed page. Chrome above body; body top = stored Y (via `specular list pages`).
+- [ ] **Add a framed page:** bezel hugs body; chrome floats above the *bezel*.
+- [ ] **Toggle frame on an existing page:** body shifts *down* by `insets.top`; bezel-top stays put at `canvasY`. Toggle off → body returns to `canvasY`.
+- [ ] **Drag-from-chrome:** chrome strip drags page. Click bezel of framed page → no drag.
+- [ ] **Alignment guides — top edge (unframed pair):** guide fires flush with visible top edges.
+- [ ] **Alignment guides — framed-vs-unframed:** guide fires when B's body top aligns with A's *bezel top*.
+- [ ] **Grid snap:** snap-rect top snaps to grid (visible top of page or bezel).
+- [ ] **Group:** group outline wraps chrome+frame+body.
+- [ ] **Open a pre-Path-A `.canvas` file:** pages reposition visually by `CHROME_HEADER_HEIGHT` (and `insets.top` if framed). Stored coordinates unchanged.
+- [ ] **CLI:** `specular create page --x 100 --y 100`. Snap-rect-top at (100, 100). Body top = (100, 100) unframed or `(100 + insets.left, 100 + insets.top)` framed.
+- [ ] **Region capture:** screenshot region overlapping a page lands content at correct vertical offset.
+- [ ] **Presence cursor:** remote cursor over page body lands on body, not 36 px below.
+- [ ] **Resize handles:** sit on snap-rect edges (bezel for framed, body for unframed). 6 px outward padding unchanged.
+
+---
+
+## Critical files
+
+- `src/main/runtime/runtime-geometry.ts`
+- `src/main/runtime/document-commands.ts`
+- `src/main/runtime/runtime-constants.ts`
+- `src/main/runtime/page-factory.ts`
+- `src/main/workspace-entities.ts`
+
+Supporting (one-line changes each): `src/main/runtime/runtime-entities.ts`, `src/main/runtime/region-capture.ts`, `src/main/runtime/canvas-layout-data.ts`, `src/main/workspace-placement.ts`, `src/main/presence-manager.ts`, `src/main/ipc/register-canvas-entity-ipc.ts`, `src/shared/entity-chrome-slots.ts`, `src/shared/canvas-hit-geometry.ts`, `src/shared/hit-test.ts`, `src/renderer/above-view/useAnchoredPosition.ts`.

--- a/src/main/ipc/register-annotation-inspection-ipc.ts
+++ b/src/main/ipc/register-annotation-inspection-ipc.ts
@@ -4,7 +4,7 @@ import {
   bgView,
   aboveView,
   layoutAllViews,
-  pageCanvasBounds,
+  pageBodyCanvasBounds,
 } from '../runtime/surface-layout'
 import {
   findPageById,
@@ -72,20 +72,21 @@ function annotationCanvasBounds(annotation: Annotation): WorkspaceBounds | null 
     case 'element': {
       const page = findPageById(anchor.pageId)
       if (!page) return null
+      const body = pageBodyCanvasBounds(page)
       if (anchor.boundingBox) {
         return {
-          x: page.canvasX + anchor.boundingBox.x,
-          y: page.canvasY + anchor.boundingBox.y,
+          x: body.x + anchor.boundingBox.x,
+          y: body.y + anchor.boundingBox.y,
           width: anchor.boundingBox.width,
           height: anchor.boundingBox.height,
         }
       }
-      return pageCanvasBounds(page)
+      return body
     }
     case 'page': {
       const page = findPageById(anchor.pageId)
       if (!page) return null
-      return pageCanvasBounds(page)
+      return pageBodyCanvasBounds(page)
     }
   }
 }

--- a/src/main/ipc/register-canvas-entity-ipc.ts
+++ b/src/main/ipc/register-canvas-entity-ipc.ts
@@ -66,7 +66,6 @@ import {
 } from '../runtime/surface-layout'
 import { markDirty } from '../runtime/layout-dirty'
 import { pageContentSize } from '../runtime/runtime-geometry'
-import { CHROME_HEADER_HEIGHT } from '../runtime/runtime-constants'
 import {
   scheduleWorkspaceAutosave,
 } from '../runtime/workspace-session'
@@ -155,7 +154,7 @@ export function registerCanvasEntityIpc(): void {
           presetIndex: tool.presetIndex ?? 0,
           customSize: tool.customSize ?? false,
           canvasX,
-          canvasY: canvasY - CHROME_HEADER_HEIGHT,
+          canvasY,
           mode: 'add_from_toolbar',
           focus: true,
         })

--- a/src/main/presence-manager.ts
+++ b/src/main/presence-manager.ts
@@ -24,7 +24,7 @@ import {
 import {
   findPageById,
 } from './runtime/runtime-context'
-import { pageContentSize } from './runtime/runtime-geometry'
+import { pageBodyCanvasBounds, pageContentSize } from './runtime/runtime-geometry'
 
 // --- Re-exports from presence-session ---
 export {
@@ -162,11 +162,12 @@ export function resolveCanvasPointForPage(
     fallbackX: width / 2,
     fallbackY: height / 2,
   })
-  // `page.canvasY` is the top of the page's chrome band; the DOM point lives
-  // in content coordinates, so shift down by chromeHeight to land on the page.
+  // DOM point lives in content coordinates; shift to the body origin so
+  // the cursor lands on the page body (inside any device-frame bezel).
+  const body = pageBodyCanvasBounds(page)
   return {
-    canvasX: page.canvasX + clamp(point.x, 0, width),
-    canvasY: page.canvasY + page.chromeHeight + clamp(point.y, 0, height),
+    canvasX: body.x + clamp(point.x, 0, width),
+    canvasY: body.y + clamp(point.y, 0, height),
   }
 }
 

--- a/src/main/runtime/canvas-layout-data.ts
+++ b/src/main/runtime/canvas-layout-data.ts
@@ -59,6 +59,7 @@ import {
 } from './runtime-constants'
 import { currentKeyboardTargetPageId } from './selection-controller'
 import {
+  pageBodyCanvasBounds,
   pageContentSize,
   boundEffectivePageContentSize as effectivePageContentSize,
   boundAvailableCanvasViewport as localAvailableCanvasViewport,
@@ -418,10 +419,10 @@ export function buildCanvasLayoutData(
             const clampedX = Math.max(0, Math.min(point.x, page.width))
             const clampedY = Math.max(0, Math.min(point.y, page.height))
             const pageWcv = findPageById(page.id)
-            const chromeHeight = pageWcv?.chromeHeight ?? 0
+            const body = pageWcv ? pageBodyCanvasBounds(pageWcv) : { x: page.canvasX, y: page.canvasY }
             return {
-              canvasX: page.canvasX + clampedX,
-              canvasY: page.canvasY + chromeHeight + clampedY,
+              canvasX: body.x + clampedX,
+              canvasY: body.y + clampedY,
             }
           }
         }

--- a/src/main/runtime/document-commands.ts
+++ b/src/main/runtime/document-commands.ts
@@ -102,7 +102,7 @@ import { scheduleWorkspaceAutosave } from './workspace-session'
 import { markUndoBoundary } from './workspace-undo'
 import {
   boundAvailableCanvasViewportRect,
-  pageOuterCanvasBounds,
+  pageSnapBounds,
 } from './runtime-geometry'
 import {
   snapCandidateFromRect,
@@ -188,7 +188,7 @@ function currentCanvasViewportRect(): SnapRect {
 function currentSnapSnapshotEntities(): SnapCandidateSnapshotEntity[] {
   return [
     ...pages.map((page) => {
-      const bounds = pageOuterCanvasBounds(page)
+      const bounds = pageSnapBounds(page)
       return {
         id: page.id,
         kind: 'page' as const,
@@ -252,7 +252,7 @@ function currentSnapCandidateForEntity(id: string): SnapCandidate | null {
   if (page) {
     return snapCandidateFromRect(
       { id: page.id, kind: 'page' },
-      pageOuterCanvasBounds(page),
+      pageSnapBounds(page),
     )
   }
 

--- a/src/main/runtime/page-factory.ts
+++ b/src/main/runtime/page-factory.ts
@@ -62,7 +62,6 @@ function isSelectedPage(page: Page): boolean {
 
 import {
   CARD_BORDER_RADIUS,
-  CHROME_HEADER_HEIGHT,
   selectionDebug,
 } from './runtime-constants'
 
@@ -110,7 +109,6 @@ export function createPage(config: PageConfig): Page {
     presetIndex,
     canvasX: config.canvasX,
     canvasY: config.canvasY,
-    chromeHeight: CHROME_HEADER_HEIGHT,
     linked: config.linked ?? false,
     source: config.source ?? 'manual',
     parentGroupId: config.parentGroupId ?? config.groupId,

--- a/src/main/runtime/region-capture.ts
+++ b/src/main/runtime/region-capture.ts
@@ -8,7 +8,7 @@
 import { nativeImage, screen as electronScreen } from 'electron'
 import type { WorkspaceBounds } from '../../shared/types'
 import { captureFrameComposited, captureViewRegion } from './frame-compositor'
-import { boundCanvasOrigin, boundsOverlap, pageCanvasBounds } from './runtime-geometry'
+import { boundCanvasOrigin, boundsOverlap, pageBodyCanvasBounds } from './runtime-geometry'
 import { aboveView, bgView } from './view-refs'
 
 function setRendererCaptureMode(active: boolean): void {
@@ -84,9 +84,9 @@ async function captureRegionInternal(
   dpr: number,
 ): Promise<RegionCaptureResult> {
 
-  // Find pages whose canvas bounds intersect the region.
+  // Find pages whose body bounds intersect the region.
   const intersectingPages = pages.filter((page) => {
-    const bounds = pageCanvasBounds(page)
+    const bounds = pageBodyCanvasBounds(page)
     return boundsOverlap(canvasRect, bounds)
   })
 
@@ -132,13 +132,10 @@ async function captureRegionInternal(
     const capture = await captureFrameComposited(page, { dpr })
     if (!capture) continue
 
-    const pageBounds = pageCanvasBounds(page)
+    const pageBounds = pageBodyCanvasBounds(page)
 
-    // `page.canvasY` is the top of the page's chrome band, not the page
-    // content; content sits `chromeHeight` below (computeScreenBoundsForPage).
-    const contentCanvasY = pageBounds.y + page.chromeHeight
     const offsetX = Math.round((pageBounds.x - canvasRect.x) * zoom * dpr)
-    const offsetY = Math.round((contentCanvasY - canvasRect.y) * zoom * dpr)
+    const offsetY = Math.round((pageBounds.y - canvasRect.y) * zoom * dpr)
 
     // Blit the page capture into the output buffer.
     const srcW = capture.width

--- a/src/main/runtime/region-select.ts
+++ b/src/main/runtime/region-select.ts
@@ -8,7 +8,7 @@ import { captureRegion } from './region-capture'
 import { extractRegionComponents } from './region-components'
 import { createAnnotation } from '../workspace-annotations'
 import { queryElementsInRect } from './page-queries'
-import { pageCanvasBounds } from './runtime-geometry'
+import { pageBodyCanvasBounds } from './runtime-geometry'
 import { pageDisplayLabel } from './runtime-serialization'
 
 /**
@@ -21,7 +21,7 @@ export async function executeRegionSelect(canvasRect: WorkspaceBounds, text?: st
   // Query DOM elements within the region for each intersecting page.
   const regionElements: RegionElementGroup[] = []
   for (const page of intersectingPages) {
-    const pageBounds = pageCanvasBounds(page)
+    const pageBounds = pageBodyCanvasBounds(page)
     // Convert canvas rect to page-local viewport coordinates.
     const viewportRect = {
       x: Math.max(0, canvasRect.x - pageBounds.x),

--- a/src/main/runtime/runtime-constants.ts
+++ b/src/main/runtime/runtime-constants.ts
@@ -5,7 +5,7 @@
 // --- Layout geometry ---
 export const CARD_BORDER_WIDTH = 1
 export const CARD_BORDER_RADIUS = 0
-export const CHROME_HEADER_HEIGHT = 44
+export { CHROME_HEADER_HEIGHT } from '../../shared/entity-chrome-slots'
 export const CHROME_PAGE_GAP = 0
 export { TOOLBAR_HEIGHT } from '../../shared/constants'
 export const TOOLBAR_BORDER_LIGHT = '#d4d4d8'

--- a/src/main/runtime/runtime-entities.ts
+++ b/src/main/runtime/runtime-entities.ts
@@ -18,8 +18,12 @@ export interface Page {
   devtoolsHostAttached?: boolean
   presetIndex: number
   canvasX: number
+  /**
+   * Top-left of the page's snap rect in canvas coords. With a device frame
+   * this is the bezel top; without, it is the body top. Chrome renders
+   * above at (canvasY - CHROME_HEADER_HEIGHT).
+   */
   canvasY: number
-  chromeHeight: number
   linked: boolean
   source: WorkspacePageSource
   parentGroupId?: string

--- a/src/main/runtime/runtime-geometry.ts
+++ b/src/main/runtime/runtime-geometry.ts
@@ -5,6 +5,7 @@ import type { Page } from './runtime-entities'
 import {
   BROWSER_HEADER_HEIGHT,
   CARD_BORDER_WIDTH,
+  CHROME_HEADER_HEIGHT,
   CHROME_PAGE_GAP,
   LEFT_SIDEBAR_WIDTH,
   devtoolsPanelDebug,
@@ -65,18 +66,6 @@ export function pageContentSize(page: Pick<Page, 'presetIndex' | 'peekWidth' | '
   return sizeForOrientation(baseW, baseH, deviceOrientationFromMetadata(page.metadata))
 }
 
-export function pageCanvasBounds(
-  page: Pick<Page, 'presetIndex' | 'canvasX' | 'canvasY' | 'peekWidth' | 'peekHeight' | 'metadata'>,
-): WorkspaceBounds {
-  const size = pageContentSize(page)
-  return {
-    x: page.canvasX,
-    y: page.canvasY,
-    width: size.width,
-    height: size.height,
-  }
-}
-
 export function pageShellInsets(
   page: Pick<Page, 'metadata'>,
 ): { top: number; right: number; bottom: number; left: number } | null {
@@ -88,17 +77,64 @@ export function pageShellInsets(
   return shellInsetsForDevice(deviceId, orientation)
 }
 
-export function pageOuterCanvasBounds(
+/**
+ * Snap rect = body + device-frame insets, anchored at `canvasY`.
+ *
+ *   unframed: { x: canvasX,             y: canvasY,             w: bodyW, h: bodyH }
+ *   framed:   { x: canvasX,             y: canvasY,             w: bodyW + lr, h: bodyH + tb }
+ *
+ * This is the rect that alignment guides and grid snap should use. Chrome
+ * lives above it (see `pageVisualBounds`); the body sits inside it (see
+ * `pageBodyCanvasBounds`) — offset by the bezel insets when framed.
+ */
+export function pageSnapBounds(
   page: Pick<Page, 'presetIndex' | 'canvasX' | 'canvasY' | 'peekWidth' | 'peekHeight' | 'metadata'>,
 ): WorkspaceBounds {
-  const inner = pageCanvasBounds(page)
+  const size = pageContentSize(page)
   const insets = pageShellInsets(page)
-  if (!insets) return inner
+  if (!insets) {
+    return { x: page.canvasX, y: page.canvasY, width: size.width, height: size.height }
+  }
   return {
-    x: inner.x - insets.left,
-    y: inner.y - insets.top,
-    width: inner.width + insets.left + insets.right,
-    height: inner.height + insets.top + insets.bottom,
+    x: page.canvasX,
+    y: page.canvasY,
+    width: size.width + insets.left + insets.right,
+    height: size.height + insets.top + insets.bottom,
+  }
+}
+
+/**
+ * Body bounds = the webview content area, inside the bezel when framed.
+ *
+ *   unframed: body == snap rect
+ *   framed:   body is offset right/down by (insets.left, insets.top)
+ */
+export function pageBodyCanvasBounds(
+  page: Pick<Page, 'presetIndex' | 'canvasX' | 'canvasY' | 'peekWidth' | 'peekHeight' | 'metadata'>,
+): WorkspaceBounds {
+  const size = pageContentSize(page)
+  const insets = pageShellInsets(page)
+  return {
+    x: page.canvasX + (insets?.left ?? 0),
+    y: page.canvasY + (insets?.top ?? 0),
+    width: size.width,
+    height: size.height,
+  }
+}
+
+/**
+ * Visual bounds = snap rect extended upward by the chrome strip. Used for
+ * selection outlines that should wrap chrome and for placement claims.
+ */
+export function pageVisualBounds(
+  page: Pick<Page, 'presetIndex' | 'canvasX' | 'canvasY' | 'peekWidth' | 'peekHeight' | 'metadata'>,
+): WorkspaceBounds {
+  const snap = pageSnapBounds(page)
+  return {
+    x: snap.x,
+    y: snap.y - CHROME_HEADER_HEIGHT,
+    width: snap.width,
+    height: snap.height + CHROME_HEADER_HEIGHT,
   }
 }
 
@@ -213,8 +249,7 @@ export function computeScreenBoundsForPage(input: {
     input.currentViewMode() === 'browser' && input.selectedPageId() === input.page.id
   const isFillBrowserActive = input.isFillBrowserPage(input.page)
   const displayZoom = isFillBrowserActive ? 1 : input.zoom
-  const chromeH = Math.round(input.page.chromeHeight * input.zoom)
-  const gap = Math.round(input.chromePageGap * input.zoom)
+  const chromeH = Math.round(CHROME_HEADER_HEIGHT * input.zoom)
   const contentW = Math.round(w * displayZoom)
   const fullPageH = Math.round(h * displayZoom)
   const viewport = input.availableCanvasViewportRect()
@@ -226,11 +261,24 @@ export function computeScreenBoundsForPage(input: {
     : isBrowserActive
       ? Math.min(fullPageH, maxBrowserPageH)
       : fullPageH
+  const insets = pageShellInsets(input.page)
+  const insetLeft = Math.round((insets?.left ?? 0) * displayZoom)
+  const insetTop = Math.round((insets?.top ?? 0) * displayZoom)
+  const insetRight = Math.round((insets?.right ?? 0) * displayZoom)
+  const insetBottom = Math.round((insets?.bottom ?? 0) * displayZoom)
+
+  // `snapTopScreenY` is the snap-rect top in screen space: the bezel top
+  // when framed, body top when not. Body lives at snapTopScreenY + insetTop,
+  // chrome floats above at snapTopScreenY - chromeH.
+  const snapTopScreenY =
+    Math.round(input.page.canvasY * input.zoom + input.pan.y) + input.toolbarHeight
+  const snapLeftScreenX = Math.round(input.page.canvasX * input.zoom + input.pan.x)
+
   const rawChromeX = isBrowserActive
     ? isFillBrowserActive
       ? viewport.x
       : Math.round(viewport.x + (viewport.width - w * input.zoom) / 2)
-    : Math.round(input.page.canvasX * input.zoom + input.pan.x)
+    : snapLeftScreenX + insetLeft
   const browserMinPageY = browserViewportTop
   const centeredBrowserPageY = Math.round(
     browserViewportTop + (browserViewportHeight - pageH) / 2,
@@ -239,18 +287,16 @@ export function computeScreenBoundsForPage(input: {
     ? fullPageH >= maxBrowserPageH
       ? browserMinPageY
       : Math.max(browserMinPageY, centeredBrowserPageY)
-    : Math.round(input.page.canvasY * input.zoom + input.pan.y) + input.toolbarHeight + chromeH + gap
-  const chromeY = isBrowserActive
-    ? browserViewportTop
-    : Math.round(input.page.canvasY * input.zoom + input.pan.y) + input.toolbarHeight
-  // Compute shell rect (device page bezel) — skip in fill-browser mode
-  const insets = pageShellInsets(input.page)
+    : snapTopScreenY + insetTop
+  const chromeY = isBrowserActive ? browserViewportTop : snapTopScreenY - chromeH
+  // Shell rect (device page bezel) anchored at the snap-rect top — skip in
+  // fill-browser mode.
   const shellRect = insets && !isFillBrowserActive
     ? {
-        x: rawChromeX - Math.round(insets.left * displayZoom),
-        y: pageY - Math.round(insets.top * displayZoom),
-        width: contentW + Math.round((insets.left + insets.right) * displayZoom),
-        height: pageH + Math.round((insets.top + insets.bottom) * displayZoom),
+        x: snapLeftScreenX,
+        y: snapTopScreenY,
+        width: contentW + insetLeft + insetRight,
+        height: pageH + insetTop + insetBottom,
       }
     : {
         x: rawChromeX - bw,

--- a/src/main/runtime/surface-layout.ts
+++ b/src/main/runtime/surface-layout.ts
@@ -25,8 +25,9 @@ export {
 export {
   boundCanvasOrigin as canvasOrigin,
   boundScreenBoundsForPage as screenBoundsForPage,
-  pageCanvasBounds,
-  pageOuterCanvasBounds,
+  pageBodyCanvasBounds,
+  pageSnapBounds,
+  pageVisualBounds,
   pageContentSize,
 } from './runtime-geometry'
 

--- a/src/main/runtime/video-recorder.ts
+++ b/src/main/runtime/video-recorder.ts
@@ -11,7 +11,7 @@ import { captureFrameComposited } from './frame-compositor'
 import { getZoom, pan } from './runtime-context'
 import { focusCanvasBounds, requestLayout, setPan, setZoom } from './viewport-control'
 import { layoutAllViews } from './layout-engine'
-import { pageCanvasBounds } from './runtime-geometry'
+import { pageBodyCanvasBounds } from './runtime-geometry'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -100,7 +100,7 @@ class VideoRecorderInstance {
     this.savedCamera = { zoom: getZoom(), panX: pan.x, panY: pan.y }
     try {
       if (getZoom() !== 1) setZoom(1)
-      focusCanvasBounds(pageCanvasBounds(this.page))
+      focusCanvasBounds(pageBodyCanvasBounds(this.page))
       layoutAllViews()
       // Chromium re-rasters on the next frame after enableDeviceEmulation.
       // Give it room so the first captured frames aren't mid-transition.

--- a/src/main/workspace-entities.ts
+++ b/src/main/workspace-entities.ts
@@ -31,13 +31,14 @@ import { fileEntities } from './runtime/file-entity-state'
 import { drawingEntities } from './runtime/drawing-entity-state'
 import { shapeEntities } from './runtime/shape-entity-state'
 import {
-  pageOuterCanvasBounds,
   pageContentSize,
+  pageSnapBounds,
+  pageVisualBounds,
   pan,
   requestLayout,
   zoom,
 } from './runtime/surface-layout'
-import { pageShellInsets } from './runtime/runtime-geometry'
+import { CHROME_HEADER_HEIGHT } from '../shared/entity-chrome-slots'
 import { workspaceEdges, workspaceGroups } from './runtime/workspace-model'
 import { scheduleWorkspaceAutosave } from './runtime/workspace-session'
 import { boundsOverlap } from './runtime/runtime-geometry'
@@ -50,19 +51,17 @@ import { cancelEditingEntityIfMatches } from './runtime/editing-entity-runtime'
 
 export function pageBoundsById(pageId: string): WorkspaceBounds | null {
   const page = findPageById(pageId)
-  return page ? pageOuterCanvasBounds(page) : null
+  return page ? pageSnapBounds(page) : null
 }
 
+/**
+ * Bounds for selection/hover/group-outline purposes: the snap rect extended
+ * upward by the chrome strip. Wraps everything the user can see.
+ */
 export function pageSelectableBounds(
   page: Exclude<ReturnType<typeof findPageById>, undefined>,
 ): WorkspaceBounds {
-  const outer = pageOuterCanvasBounds(page)
-  return {
-    x: outer.x,
-    y: outer.y,
-    width: outer.width,
-    height: outer.height + page.chromeHeight,
-  }
+  return pageVisualBounds(page)
 }
 
 export function unionBounds(boundsList: WorkspaceBounds[]): WorkspaceBounds | null {
@@ -87,24 +86,17 @@ export function entityBoundsById(entityId: string): WorkspaceBounds | null {
 
 /**
  * Offset from the entity's outer top-left (as returned by `entityBoundsById`)
- * to its data origin (`canvasX`/`canvasY`). For framed pages this is the
- * device-shell top/left insets; otherwise zero.
- *
- * Asymmetry to keep in mind: `entityBoundsById` for a page returns
- * `pageSelectableBounds` whose `height` includes `page.chromeHeight` (the
- * hover-only action band). This function does NOT include `chromeHeight` in
- * `insetY`, because the bounds' `y` is `outer.y` (no chrome band above the
- * top edge). The consequence is that re-layout against an existing page in
- * a column or below-`near` arrangement reserves an extra `chromeHeight` of
- * vertical space — by design, since the action band needs somewhere to live.
+ * to its data origin (`canvasX`/`canvasY`). For pages, `canvasY` is the
+ * snap-rect top and `pageSelectableBounds.y` is `canvasY - CHROME_HEADER_HEIGHT`,
+ * so the Y inset is the chrome strip; the snap rect's left edge already
+ * equals `canvasX` so the X inset is zero.
  */
 export function entityDataInsetsById(entityId: string): { insetX: number; insetY: number } {
   const page = findPageById(entityId)
   if (page) {
-    const insets = pageShellInsets(page)
     return {
-      insetX: insets?.left ?? 0,
-      insetY: insets?.top ?? 0,
+      insetX: 0,
+      insetY: CHROME_HEADER_HEIGHT,
     }
   }
   return { insetX: 0, insetY: 0 }

--- a/src/main/workspace-placement.ts
+++ b/src/main/workspace-placement.ts
@@ -20,8 +20,7 @@ import { pages } from './runtime/page-runtime'
 import { textEntities } from './runtime/text-entity-state'
 import { fileEntities } from './runtime/file-entity-state'
 import {
-  pageCanvasBounds,
-  pageOuterCanvasBounds,
+  pageSnapBounds,
   snapToGrid,
 } from './runtime/surface-layout'
 import { workspaceGroups } from './runtime/workspace-model'
@@ -53,9 +52,10 @@ function extendUpwardForChrome(bounds: WorkspaceBounds, headerHeight: number): W
 
 export function occupiedRegions(): WorkspaceBounds[] {
   return [
-    // Pages: use outer bounds (includes device shell) and extend up for chrome.
+    // Pages: use the snap rect (body + device-frame insets) and extend
+    // upward by the chrome strip.
     ...pages.map((page) =>
-      extendUpwardForChrome(pageOuterCanvasBounds(page), page.chromeHeight),
+      extendUpwardForChrome(pageSnapBounds(page), CHROME_HEADER_HEIGHT),
     ),
     ...textEntities.map((entity) => ({
       x: entity.canvasX,

--- a/src/renderer/above-view/useAnchoredPosition.ts
+++ b/src/renderer/above-view/useAnchoredPosition.ts
@@ -106,9 +106,9 @@ function findAnchorTarget(layout: LayoutUpdateData, id: string): AnchorTarget | 
 /**
  * Returns the unified entity rect (body + chrome) in window-space coords.
  *
- * Today scene entities encode body-only geometry, so we extend upward by
- * `CHROME_HEADER_HEIGHT` for kinds that have chrome. After ADR 0002's rect
- * unification this becomes a one-liner returning the entity rect as-is.
+ * `entity.screenY` is the snap-rect top — bezel top for framed pages, body
+ * top otherwise. Chrome lives `CHROME_HEADER_HEIGHT` above it; extend the
+ * rect upward to include the strip for kinds that have chrome.
  */
 function entityRectFor(entity: AnchorTarget): Rect {
   const hasHeader = entity.kind === 'page' || entity.kind === 'file' || entity.kind === 'group'

--- a/src/shared/canvas-hit-geometry.ts
+++ b/src/shared/canvas-hit-geometry.ts
@@ -1,6 +1,6 @@
 import type { EdgeSide } from './types'
 
-export const PAGE_CHROME_HEIGHT_PX = 36
+export { CHROME_HEADER_HEIGHT } from './entity-chrome-slots'
 
 export const EDGE_ANCHOR_DOT_OFFSET_PX = 8
 export const EDGE_ANCHOR_HIT_ALONG_PX = 56

--- a/src/shared/hit-test.ts
+++ b/src/shared/hit-test.ts
@@ -17,7 +17,7 @@ import {
   EDGE_ANCHOR_HIT_ALONG_PX,
   EDGE_ANCHOR_HIT_GAP_PX,
   EDGE_SIDES,
-  PAGE_CHROME_HEIGHT_PX,
+  CHROME_HEADER_HEIGHT,
   MULTI_SELECTION_OUTLINE_PADDING_PX,
   RESIZE_HANDLE_HIT_PX,
   scaleEdgeAnchorHitSize,
@@ -341,9 +341,9 @@ function handleRect(entity: CanvasSceneEntity, handle: ResizeHandle): Rect {
 function chromeRect(entity: CanvasSceneEntity): Rect {
   return {
     x: entity.screenX,
-    y: entity.screenY - PAGE_CHROME_HEIGHT_PX,
+    y: entity.screenY - CHROME_HEADER_HEIGHT,
     width: entity.screenWidth,
-    height: PAGE_CHROME_HEIGHT_PX,
+    height: CHROME_HEADER_HEIGHT,
   }
 }
 

--- a/tests/unit/page-bounds.test.ts
+++ b/tests/unit/page-bounds.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  pageBodyCanvasBounds,
+  pageSnapBounds,
+  pageVisualBounds,
+} from '../../src/main/runtime/runtime-geometry'
+import { CHROME_HEADER_HEIGHT } from '../../src/shared/entity-chrome-slots'
+
+type PageStub = Parameters<typeof pageSnapBounds>[0]
+
+function unframedPage(overrides: Partial<PageStub> = {}): PageStub {
+  // presetIndex 0 = iPhone SE viewport 375×667 in the catalog.
+  return {
+    presetIndex: 0,
+    canvasX: 100,
+    canvasY: 200,
+    peekWidth: 375,
+    peekHeight: 667,
+    metadata: undefined,
+    ...overrides,
+  }
+}
+
+function framedPage(overrides: Partial<PageStub> = {}): PageStub {
+  // Force the custom-shell path (CUSTOM_SHELL_INSETS = 12px all around) by
+  // turning on the frame metadata without a real deviceId.
+  return unframedPage({
+    metadata: { showDeviceFrame: true },
+    ...overrides,
+  })
+}
+
+describe('page bounds (Path A semantics)', () => {
+  it('unframed page: snap rect == body rect, anchored at canvasY', () => {
+    const page = unframedPage()
+    expect(pageSnapBounds(page)).toEqual({ x: 100, y: 200, width: 375, height: 667 })
+    expect(pageBodyCanvasBounds(page)).toEqual({ x: 100, y: 200, width: 375, height: 667 })
+  })
+
+  it('framed page: snap rect grows by insets; body is offset inward', () => {
+    const page = framedPage()
+    // CUSTOM_SHELL_INSETS = { top: 12, right: 12, bottom: 12, left: 12 }
+    expect(pageSnapBounds(page)).toEqual({
+      x: 100,
+      y: 200,
+      width: 375 + 24,
+      height: 667 + 24,
+    })
+    expect(pageBodyCanvasBounds(page)).toEqual({
+      x: 100 + 12,
+      y: 200 + 12,
+      width: 375,
+      height: 667,
+    })
+  })
+
+  it('chrome lives above the snap rect (visual bounds extend upward)', () => {
+    const page = unframedPage()
+    const visual = pageVisualBounds(page)
+    expect(visual.y).toBe(200 - CHROME_HEADER_HEIGHT)
+    expect(visual.height).toBe(667 + CHROME_HEADER_HEIGHT)
+    expect(visual.x).toBe(100)
+    expect(visual.width).toBe(375)
+  })
+
+  it('toggling a frame on keeps canvasY stable and pushes body down', () => {
+    const unframed = unframedPage()
+    const framed = framedPage()
+    // Snap-rect top is anchored.
+    expect(pageSnapBounds(framed).y).toBe(pageSnapBounds(unframed).y)
+    // Body moves down to make room for the bezel.
+    expect(pageBodyCanvasBounds(framed).y).toBeGreaterThan(pageBodyCanvasBounds(unframed).y)
+    expect(pageBodyCanvasBounds(framed).y - pageBodyCanvasBounds(unframed).y).toBe(12)
+  })
+})


### PR DESCRIPTION
## Summary

Re-anchors `page.canvasY` to the **top of the snap rect** — the bezel top when a page has a device frame, the body top otherwise. Chrome renders above the snap rect at `y - CHROME_HEADER_HEIGHT`. The snap rect *is* the alignment and grid-snap rect.

Fixes the floating alignment-guide edges introduced by #97: `pageOuterCanvasBounds` returned a rect whose **top** was the chrome-band top but whose **height** was body-only — so guides snapped to a phantom edge that matched no visible element.

Background: `docs/explorations/page-bounds-snap-alignment.md` (current-system map and smoking gun). Plan: `docs/plans/page-bounds-snap-alignment.md`.

## Key changes

- **Constant collapse:** single `CHROME_HEADER_HEIGHT = 36` in `src/shared/entity-chrome-slots.ts`; drop the conflicting 44 in `runtime-constants.ts` and the duplicate `PAGE_CHROME_HEIGHT_PX` in `canvas-hit-geometry.ts`. The renderer drew 36 px while main positioned views as if 44 — now reconciled.
- **`Page` interface:** drop `chromeHeight` field (effectively constant).
- **Geometry helpers:**
  - `pageCanvasBounds` → `pageBodyCanvasBounds` (offsets into bezel when framed)
  - `pageOuterCanvasBounds` → `pageSnapBounds` (anchored at `canvasY`; body + frame insets)
  - new `pageVisualBounds` (snap + chrome above) for selection / group outlines
- **`computeScreenBoundsForPage`:** chrome floats above `canvasY`; body at `canvasY + insets.top` (or `canvasY` unframed); shell anchored at `canvasY`.
- **Snap + alignment guides:** routed through `pageSnapBounds`.
- **Group bounds** now wrap chrome *above* instead of *below* (matches what users see).
- **`+ chromeHeight` offsets** stripped from `presence-manager`, `canvas-layout-data`, `region-capture`, `register-canvas-entity-ipc`, `workspace-placement`.

## Frame toggle behavior

Adding a frame to an existing page keeps `canvasY` anchored — the bezel-top occupies the line where the body-top used to be, and the body shifts *down* by `insets.top` to make room. Removing the frame pulls the body back up. The snap-rect-top is the stable anchor; body floats inside it.

## Accepted visible drift (no migration)

Existing \`.canvas\` files reopen with pages shifted by:
- **36 px** (unframed) — the old \`canvasY\` was the chrome top, which is now interpreted as the snap-rect top, so the body lands where the chrome top used to be.
- **36 + insets.top** (framed) — bezel top is now where the chrome top used to be.

CLI \`specular create page --y\` semantics also shift accordingly. By design — no migration shims.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test:unit\` — 584/584 passing (4 new tests in \`tests/unit/page-bounds.test.ts\` pin the contract for unframed, framed, and frame-toggle)
- [ ] Manual smoke in \`pnpm dev\`:
  - [ ] Drag two unframed pages → guide fires flush with visible top edges
  - [ ] Drag a framed page next to an unframed one → guide fires when B's body-top aligns with A's *bezel top*
  - [ ] Toggle frame ON an existing page → body shifts down by \`insets.top\`; bezel-top stays put
  - [ ] Toggle frame OFF → body pulls back up
  - [ ] Click on chrome strip → drags the page
  - [ ] Click on bezel (framed page) → does NOT drag (deliberate, follow-up if needed)
  - [ ] Group two pages → outline wraps chrome+frame+body
  - [ ] Open a pre-Path-A workspace → pages reposition by 36 px / 36+insets.top; stored coordinates unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)