### PR TITLE
Canvas grid: <canvas>-based dot renderer with zoom-aware step + alpha fade

### DIFF
--- a/src/renderer/canvas-bg/CanvasGridSurface.tsx
+++ b/src/renderer/canvas-bg/CanvasGridSurface.tsx
@@ -1,7 +1,7 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { PLAIN_TEXT_PLACEHOLDER } from '../../shared/constants'
 import type { TextEntityStyle } from '../../shared/types'
-import { buildCanvasGridStyle } from './canvasGridStyle'
+import { buildCanvasGridStyle, drawCanvasGrid } from './canvasGridStyle'
 
 function previewBoxStyle(
   isDark: boolean,
@@ -55,17 +55,36 @@ export function CanvasGridSurface({
   pan: { x: number; y: number }
   zoom: number
 }) {
-  const gridStyle = useMemo(
-    () =>
-      buildCanvasGridStyle({
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const gridStyle = useMemo(() => buildCanvasGridStyle(), [])
+
+  useEffect(() => {
+    const surface = bgRef.current
+    const canvas = canvasRef.current
+    if (!surface || !canvas) return
+
+    const draw = () => {
+      drawCanvasGrid({
+        canvas,
+        color: isDark ? '#78716c' : '#a8a29e',
         canvasOrigin,
         pan,
         zoom,
         isDark,
         devicePixelRatio: window.devicePixelRatio || 1,
-      }),
-    [canvasOrigin, isDark, pan, zoom],
-  )
+      })
+    }
+
+    draw()
+    const resizeObserver = new ResizeObserver(draw)
+    resizeObserver.observe(surface)
+    window.addEventListener('resize', draw)
+
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', draw)
+    }
+  }, [bgRef, canvasOrigin, isDark, pan, zoom])
 
   return (
     <div
@@ -76,7 +95,13 @@ export function CanvasGridSurface({
         touchAction: 'none',
         ...gridStyle,
       }}
-    />
+    >
+      <canvas
+        ref={canvasRef}
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 h-full w-full"
+      />
+    </div>
   )
 }
 

--- a/src/renderer/canvas-bg/canvasGridStyle.ts
+++ b/src/renderer/canvas-bg/canvasGridStyle.ts
@@ -1,15 +1,36 @@
 import { GRID_SIZE } from '../../shared/constants'
 
-function snapToDevicePixel(value: number, devicePixelRatio: number) {
-  const step = 1 / Math.max(devicePixelRatio, 1)
-  return Math.max(step, Math.round(value / step) * step)
+const MIN_GRID_SPACING_PX = 8
+const FULL_OPACITY_SPACING_PX = 18
+const MAX_GRID_STEP_MULTIPLIER = 64
+
+function devicePixelRatioOrOne(devicePixelRatio: number) {
+  return Math.max(devicePixelRatio, 1)
 }
 
-function normalizeOffset(offset: number, spacing: number) {
-  return ((offset % spacing) + spacing) % spacing
+export function snapToDevicePixel(value: number, devicePixelRatio: number) {
+  const dpr = devicePixelRatioOrOne(devicePixelRatio)
+  return Math.round(value * dpr) / dpr
 }
 
-export function buildCanvasGridStyle({
+function gridStepMultiplierForZoom(zoom: number) {
+  let multiplier = 1
+  while (
+    GRID_SIZE * zoom * multiplier < MIN_GRID_SPACING_PX &&
+    multiplier < MAX_GRID_STEP_MULTIPLIER
+  ) {
+    multiplier *= 2
+  }
+  return multiplier
+}
+
+function gridAlpha(spacing: number, isDark: boolean) {
+  const minAlpha = isDark ? 0.56 : 0.52
+  const alpha = spacing / FULL_OPACITY_SPACING_PX
+  return Math.max(minAlpha, Math.min(1, alpha))
+}
+
+export function buildCanvasGridMetrics({
   canvasOrigin,
   pan,
   zoom,
@@ -22,14 +43,89 @@ export function buildCanvasGridStyle({
   isDark: boolean
   devicePixelRatio: number
 }) {
-  const spacing = snapToDevicePixel(GRID_SIZE * zoom, devicePixelRatio)
-  const offsetX = normalizeOffset(canvasOrigin.x + pan.x, spacing)
-  const offsetY = normalizeOffset(canvasOrigin.y + pan.y, spacing)
+  const stepMultiplier = gridStepMultiplierForZoom(zoom)
+  const spacing = GRID_SIZE * zoom * stepMultiplier
+  const originX = canvasOrigin.x + pan.x
+  const originY = canvasOrigin.y + pan.y
 
   return {
-    backgroundColor: 'var(--surface-canvas)',
-    backgroundImage: 'radial-gradient(circle, var(--surface-canvas-grid) 0.75px, transparent 0.75px)',
-    backgroundSize: `${spacing}px ${spacing}px`,
-    backgroundPosition: `${offsetX}px ${offsetY}px`,
+    originX,
+    originY,
+    spacing,
+    stepMultiplier,
+    dotRadius: Math.max(
+      0.6,
+      Math.round(0.7 * devicePixelRatioOrOne(devicePixelRatio)) /
+        devicePixelRatioOrOne(devicePixelRatio),
+    ),
+    alpha: gridAlpha(spacing, isDark),
   }
+}
+
+export function buildCanvasGridStyle() {
+  return {
+    backgroundColor: 'var(--surface-canvas)',
+  }
+}
+
+export function drawCanvasGrid({
+  canvas,
+  color,
+  canvasOrigin,
+  pan,
+  zoom,
+  isDark,
+  devicePixelRatio,
+}: {
+  canvas: HTMLCanvasElement
+  color: string
+  canvasOrigin: { x: number; y: number }
+  pan: { x: number; y: number }
+  zoom: number
+  isDark: boolean
+  devicePixelRatio: number
+}) {
+  const dpr = devicePixelRatioOrOne(devicePixelRatio)
+  const width = canvas.clientWidth
+  const height = canvas.clientHeight
+  const targetWidth = Math.max(1, Math.ceil(width * dpr))
+  const targetHeight = Math.max(1, Math.ceil(height * dpr))
+
+  if (canvas.width !== targetWidth) canvas.width = targetWidth
+  if (canvas.height !== targetHeight) canvas.height = targetHeight
+
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  ctx.clearRect(0, 0, width, height)
+
+  const metrics = buildCanvasGridMetrics({
+    canvasOrigin,
+    pan,
+    zoom,
+    isDark,
+    devicePixelRatio: dpr,
+  })
+
+  const { spacing, originX, originY, dotRadius, alpha } = metrics
+  if (!Number.isFinite(spacing) || spacing <= 0) return
+
+  const startX = originX + Math.ceil((0 - originX) / spacing) * spacing
+  const startY = originY + Math.ceil((0 - originY) / spacing) * spacing
+
+  ctx.fillStyle = color
+  ctx.globalAlpha = alpha
+
+  for (let y = startY; y <= height; y += spacing) {
+    const snappedY = snapToDevicePixel(y, dpr)
+    for (let x = startX; x <= width; x += spacing) {
+      const snappedX = snapToDevicePixel(x, dpr)
+      ctx.beginPath()
+      ctx.arc(snappedX, snappedY, dotRadius, 0, Math.PI * 2)
+      ctx.fill()
+    }
+  }
+
+  ctx.globalAlpha = 1
 }


### PR DESCRIPTION
## Summary

Replace the CSS radial-gradient grid background with a `<canvas>`-based dot renderer.

- **Zoom-aware step:** the grid step multiplier doubles whenever `GRID_SIZE * zoom` falls below `MIN_GRID_SPACING_PX`, keeping dots legible at low zoom levels instead of smearing into noise.
- **Alpha fade:** opacity ramps from a theme-aware minimum up to 1 as on-screen spacing approaches `FULL_OPACITY_SPACING_PX`, so a new step level fades in smoothly across a zoom doubling.
- **HiDPI:** dot radius and positions snap to device pixels for crisp rendering.

`CanvasGridSurface` now mounts a `<canvas>` inside the surface div, redraws on dep change, and listens for `ResizeObserver` + `window resize` to keep the backing buffer in sync.

## Test plan

- [x] `pnpm typecheck` — clean
- [ ] `pnpm dev`:
  - [ ] Pan and zoom: dot grid stays aligned with content
  - [ ] Zoom out smoothly: spacing doubles cleanly, no flicker; opacity fades in as new step crosses threshold
  - [ ] Light/dark themes: dot color matches theme
  - [ ] Resize window: grid re-renders to fill the new size
  - [ ] HiDPI: dots are crisp, not blurry

🤖 Generated with [Claude Code](https://claude.com/claude-code)