### PR TITLE
ci: add PR workflow for typecheck, lint, test:unit, fallow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm lint
+      - run: pnpm test:unit
+
+  fallow:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: npx fallow check

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "engines": {
     "node": ">=22"
   },
+  "packageManager": "pnpm@9.5.0",
   "scripts": {
     "dev": "pnpm build:mcp-helper && pnpm build:cli && electron-forge start",
     "dev:restart": "bash scripts/dev-restart.sh",

--- a/src/main/routes/test.ts
+++ b/src/main/routes/test.ts
@@ -254,9 +254,7 @@ export const testRoutes: Route[] = [
       if (cmd) modifiers.push('meta')
       if (shift) modifiers.push('shift')
       if (alt) modifiers.push('alt')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       wc.sendInputEvent({ type: 'keyDown', keyCode: key, modifiers } as any)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       wc.sendInputEvent({ type: 'keyUp', keyCode: key, modifiers } as any)
       writeJson(response, 200, { ok: true })
     },

--- a/src/renderer/above-view/useAnchoredPosition.ts
+++ b/src/renderer/above-view/useAnchoredPosition.ts
@@ -91,7 +91,6 @@ export function useMultiAnchoredPosition(
     }
     if (!any) return null
     return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [layout, key, slot])
 }
 

--- a/src/renderer/shared/MarkdownEditor.tsx
+++ b/src/renderer/shared/MarkdownEditor.tsx
@@ -132,7 +132,6 @@ export function MarkdownEditor({
       viewRef.current = null
       themeCompartmentRef.current = null
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {

--- a/src/renderer/shared/PresenceParticleTrail.tsx
+++ b/src/renderer/shared/PresenceParticleTrail.tsx
@@ -540,7 +540,6 @@ export function PresenceParticleTrail({
       canvas.remove()
       handleRef.current = null
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` on `ubuntu-latest` with two jobs:
  - **check** (gating): install → typecheck → lint → test:unit
  - **fallow** (advisory, `continue-on-error: true`): `npx fallow check`
- Pins pnpm via `"packageManager": "pnpm@9.5.0"` so `pnpm/action-setup` doesn't pick up a new major and break unrelated PRs
- Removes 4 stale `eslint-disable-next-line` comments that referenced rules (`react-hooks/exhaustive-deps`, `@typescript-eslint/no-explicit-any`) not loaded in the minimal flat config — these were producing 5 lint errors that would have failed CI from day one

Closes #63.

## Why fallow is advisory
The `.fallowrc.json` currently has `unused-dependencies: warn` only, and `npx fallow check` exits non-zero on cycles and other findings that aren't yet promoted to errors. Running it as a gating job would block every PR. Advisory keeps the signal visible in PR checks without making it a merge gate; if/when the rules are promoted, flip `continue-on-error` off.

## Deferred from the proposal
- **SKILL.md sync check.** Plain `diff` between `resources/skills/specular/SKILL.md` and `.claude/skills/specular/SKILL.md` won't work — CLAUDE.md explicitly allows dev-only sections (e.g. the tracking-issue link to #7) to live only in `.claude/`. A real check needs a marker convention (e.g. `<!-- dev-only -->` blocks stripped before diffing). Worth a separate issue.
- **Smoke tests.** `pnpm test:smoke` spawns Electron, needs `xvfb-run` or a mac runner. Separate workflow later.
- **Branch protection.** Once `check` has been green for a stretch on `main`, mark it required in repo settings.

## Local verification
- `pnpm typecheck` — green
- `pnpm lint` — 0 errors (100 pre-existing warnings remain — `local/no-mouse-events`, `local/no-direct-view-mutation`, both intentionally `warn`)
- `pnpm test:unit` — 623/623 passing
- `npx fallow check` — finds 7 files / 32 exports / 22 circular dependencies; expected, advisory

## Test plan
- [ ] CI runs on this PR
- [ ] `check` job is green
- [ ] `fallow` job runs and reports findings without blocking
- [ ] pnpm version in CI matches local (9.5.0) via `packageManager` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)