### PR TITLE
afk: split stateless worker fires from orchestration

### DIFF
--- a/.claude/skills/afk-feature/orchestrator.md
+++ b/.claude/skills/afk-feature/orchestrator.md
@@ -1,0 +1,92 @@
+# AFK orchestrator — per-thread instructions
+
+You are the **orchestrator** for an AFK feature build, running in the Claude Code
+thread that launched `/afk-local`. You drive a multi-PR feature to completion by
+spawning stateless worker fires for the code work and handling the cheap
+mechanical steps (CI, merges, dex) yourself.
+
+You have the variables `<OWNER/REPO>`, `<FEATURE_BRANCH>` (`claude/feat-<slug>`),
+and `<EPIC_ID>` from the kickoff.
+
+`scripts/afk-loop.sh` is the unattended bash equivalent of this loop. This file
+is the attended version — same decision tree, run by you.
+
+## Prime directive: stay lean
+
+You will run for the whole feature, so your context must not bloat.
+
+- **Never read or edit feature-code files.** That is the worker's job.
+- **Never read a PR diff.** You merge based on CI status, not code inspection.
+- Spawn each worker as a separate process (`scripts/afk-fire.sh`) — its context
+  (reading code, holding diffs) lives in *its* process. You ingest only its short
+  stdout summary.
+- Run CI waits and worker fires as **background** commands and let the completion
+  notification wake you. Do not poll, do not `sleep`-loop.
+- Keep your own turns short: a status line per round, nothing more.
+
+## The loop
+
+Repeat until the feature is done. Each round, first `git fetch origin` and read
+the epic: `dex show <EPIC_ID> --json`.
+
+### 1. Feature finished?
+
+If every child task is `completed`:
+- If an integration PR is already open (`gh pr list --head <FEATURE_BRANCH>
+  --base main --state open`), you are done.
+- Otherwise open it: base `main`, head `<FEATURE_BRANCH>`, title
+  `<slug>: integration`. Write a **real** body — list each Part, its merged step
+  PR number, and the test results. This is the one place you summarize; it is
+  worth doing well because the user reviews this PR.
+- Stop. Tell the user the integration PR is open for review. **Never merge it
+  yourself** — that is the user's call.
+
+### 2. A step PR is open against the feature branch?
+
+`gh pr list --base <FEATURE_BRANCH> --state open --json number,headRefName`
+
+If one exists, wait for its CI without spending a fire — run this as a
+**background** command and continue when notified:
+
+```
+gh pr checks <pr> --watch
+```
+
+When it finishes, read the rollup (`gh pr view <pr> --json statusCheckRollup`):
+- If every check passed **except** ones on the soft-allowlist (default: `fallow`,
+  which fails on pre-existing repo-wide health issues and does not gate) →
+  merge: `gh pr merge <pr> --squash --delete-branch`. Then advance dex: derive
+  the task id from the branch name (`claude/task-<id>` → `<id>`), run
+  `dex complete <id> --result "Merged step PR #<pr>." --commit <squash-sha>`,
+  then commit and push `.dex/` to the feature branch.
+- If a non-soft check failed → **stop**. Surface the failing check to the user;
+  do not merge, do not start the next task.
+
+### 3. Tasks remain — spawn an implement-only worker fire
+
+Run as a **background** command; continue when notified it exited:
+
+```
+./scripts/afk-fire.sh <EPIC_ID>
+```
+
+This spawns one fresh headless `claude -p` that implements the next pending dex
+task and opens a step PR into the feature branch — nothing else. Read only its
+final summary. Next round, step 2 will pick up the PR it opened.
+
+If a fire exits and **no** new step PR appeared (and the feature is not
+finished), the remaining tasks are likely `BLOCKED` or the worker failed — stop
+and ask the user.
+
+## Recovery
+
+All state lives in git, dex, and open PRs — not in your context. If this thread
+dies, a new orchestrator (or `scripts/afk-loop.sh`) resumes by reading the same
+epic and open PRs. Nothing is lost.
+
+## Hard rules
+
+- Never push to `main`. Never merge the integration PR.
+- Never `git reset --hard` outside the loop's own working-tree refresh.
+- One worker fire in flight at a time — merge the open step PR before spawning
+  the next fire, so each task branches off the prior task's merged work.

--- a/.claude/skills/afk-feature/worker.md
+++ b/.claude/skills/afk-feature/worker.md
@@ -4,6 +4,8 @@ You are running in a fresh cloud context. The repo is checked out on the feature
 
 Do **one** unit of work per fire, then exit. Never wait inside a fire. If there's nothing to do, exit quickly. The cron is hourly — long fires waste tokens. The fast path between steps is `RemoteTrigger run <SELF_ROUTINE_ID>` after a state advance.
 
+> **Implement-only fires.** When invoked by `scripts/afk-fire.sh`, a fire runs **only decision rule 4** (Start the next pending task) — an orchestrator (the launching Claude Code thread, or `scripts/afk-loop.sh`) owns rules 1–3: merging step PRs, reconciling dex, opening the integration PR. The full decision tree below still applies when a fire runs the whole tree (cloud routine, `/afk-step`).
+
 ## Branch naming
 
 - Feature branch: `<FEATURE_BRANCH>` (already `claude/feat-<slug>`)

--- a/.claude/skills/afk-local/SKILL.md
+++ b/.claude/skills/afk-local/SKILL.md
@@ -9,14 +9,15 @@ One-shot kickoff for a multi-PR feature built by the **local** worker loop (`scr
 
 Input: a path to a planning doc under `docs/plans/` **or** a GitHub issue reference (`#81`, `81`, or full URL).
 
-Output: a `claude/feat-<slug>` branch with the plan committed, a dex epic with one subtask per worker-codeable step, and a running `afk-loop.sh` session.
+Output: a `claude/feat-<slug>` branch with the plan committed, a dex epic with one subtask per worker-codeable step, and an orchestration loop running the build.
 
 ## Architectural notes
 
-- The local loop has no cron floor — fires back-to-back as soon as each `claude -p` returns.
+- The build runs as an **orchestrator + stateless worker fires**. `scripts/afk-fire.sh` is one implement-only worker fire (a fresh `claude -p` — no compaction, predictable cost). The orchestrator handles the cheap mechanical steps (watch CI, merge step PRs, advance dex, open the integration PR) so they never burn a model fire.
+- Two orchestrators exist: the launching Claude Code thread (attended — see `.claude/skills/afk-feature/orchestrator.md`) or `scripts/afk-loop.sh` (unattended bash). Step 10 lets the user pick.
 - Subtasks come from `## Phase N` (or `## <heading>`) sections in the plan. The user picks which ones are worker-codeable before any dex tasks are created — "Decisions before starting" / "Goals" / "Non-goals" / "Success criteria" style sections usually shouldn't be tasks.
-- The script reads dex state from the working tree on each fire, so `.dex/` must be committed to the feature branch.
-- The script enforces `claude/feat-*` branch naming — it will exit if the branch doesn't match.
+- Each fire reads dex state from the working tree, so `.dex/` must be committed to the feature branch.
+- Both scripts enforce `claude/feat-*` branch naming — they exit if the branch doesn't match.
 
 ## Kickoff sequence
 
@@ -100,21 +101,33 @@ git commit -m "chore(afk): seed dex subtasks for <slug>"
 git push -u origin claude/feat-<slug>
 ```
 
-### 10. Hand off to the loop
+### 10. Hand off to orchestration
 
-Tell the user the kickoff is complete, print the epic ID and the subtask IDs, then ask which worker should run each fire:
+Tell the user the kickoff is complete and print the epic ID and the subtask IDs.
+Then ask two things:
 
-- `claude` (default) — Opus via the Claude CLI
-- `codex` — OpenAI Codex via `codex exec`
+**Which worker runs each fire** — `claude` (default, Opus via the Claude CLI) or
+`codex` (OpenAI Codex via `codex exec`). Passed through as `AFK_WORKER`.
 
-Pick the command based on the answer:
+**Which orchestration mode:**
 
-```
-./scripts/afk-loop.sh <epic-id>                       # claude (default)
-AFK_WORKER=codex ./scripts/afk-loop.sh <epic-id>      # codex
-```
+- **Attended (default)** — *this thread* becomes the orchestrator. Read
+  `.claude/skills/afk-feature/orchestrator.md` and run that loop yourself: spawn
+  one `scripts/afk-fire.sh` worker fire per task, watch CI and merge step PRs
+  in-thread, advance dex, and open the integration PR at the end. CI waits cost
+  no model fire. Requires this Claude Code session to stay open.
+- **Unattended** — run `./scripts/afk-loop.sh <epic-id>` (the bash orchestrator).
+  Survives without this session; use it for long overnight runs or when the user
+  will close the terminal. `AFK_WORKER=codex ./scripts/afk-loop.sh <epic-id>` for
+  codex.
 
-Don't run it for the user without confirmation — it'll consume tokens and write code. Once they say go, run it in the foreground (so they see fire output) or background via `run_in_background: true` per their preference.
+Both modes share the same primitives: `afk-fire.sh` is one stateless implement-only
+worker fire; the orchestrator (this thread, or the bash loop) handles CI/merge/dex.
+
+Don't start either without confirmation — both consume tokens and write code. Once
+the user says go: for **attended**, begin running the orchestrator loop; for
+**unattended**, run `afk-loop.sh` in the foreground (they see round output) or
+background (`run_in_background: true`) per their preference.
 
 ## Re-runnability
 

--- a/scripts/afk-fire.sh
+++ b/scripts/afk-fire.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# AFK fire — one implement-only worker fire.
+#
+# Spawns a single fresh headless `claude -p` (or `codex exec`) that executes
+# decision rule 4 of worker.md ONLY: pick the next pending dex task, implement
+# it, open a step PR into the feature branch, mark the task in-progress.
+#
+# It deliberately does NOT merge PRs, watch CI, reconcile dex state, or open the
+# integration PR — those are the orchestrator's job (the Claude Code thread that
+# launched /afk-local, or scripts/afk-loop.sh for unattended runs).
+#
+# Usage:
+#   ./scripts/afk-fire.sh <epic-id>
+#
+# Env knobs:
+#   AFK_WORKER   which CLI runs the fire: "claude" (default) or "codex"
+#
+# Exit status is the worker CLI's exit status. A fresh context every fire — no
+# compaction, predictable cost. This is the stateless-fire primitive; the
+# orchestrator loops over it.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+FEATURE_BRANCH="$(git branch --show-current)"
+if [[ ! "$FEATURE_BRANCH" =~ ^claude/feat- ]]; then
+  echo "Error: not on a claude/feat-* branch (currently: $FEATURE_BRANCH)" >&2
+  echo "       Switch to your feature branch and try again." >&2
+  exit 1
+fi
+
+EPIC_ID="${1:-}"
+if [[ -z "$EPIC_ID" ]]; then
+  echo "Error: epic ID required." >&2
+  echo "       Usage: ./scripts/afk-fire.sh <epic-id>" >&2
+  exit 1
+fi
+
+OWNER_REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+AFK_WORKER="${AFK_WORKER:-claude}"
+
+case "$AFK_WORKER" in
+  claude|codex) ;;
+  *)
+    echo "Error: AFK_WORKER must be 'claude' or 'codex' (got: $AFK_WORKER)" >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v "$AFK_WORKER" >/dev/null 2>&1; then
+  echo "Error: '$AFK_WORKER' CLI is not on PATH." >&2
+  exit 1
+fi
+
+# Start the fire from a clean checkout of the feature branch.
+git switch "$FEATURE_BRANCH" >/dev/null 2>&1 || true
+git fetch origin "$FEATURE_BRANCH" >/dev/null 2>&1 || true
+git reset --hard "origin/$FEATURE_BRANCH" >/dev/null 2>&1 || true
+
+# read -d '' (rather than $(cat <<EOF)) keeps this robust on macOS bash 3.2,
+# which mis-parses heredocs nested in command substitution. read returns
+# non-zero at EOF, hence `|| true`.
+IFS= read -r -d '' PROMPT <<EOF || true
+You are an AFK feature worker (local mode, implement-only fire).
+
+Repo: $OWNER_REPO
+Feature branch: $FEATURE_BRANCH
+Dex epic: $EPIC_ID
+
+Do this and only this:
+
+1. git fetch origin
+2. git switch $FEATURE_BRANCH -- if it no longer exists, exit cleanly: the feature is shipped or aborted.
+3. Read .claude/skills/afk-feature/worker.md from the working tree.
+4. Execute ONLY decision rule 4 -- "Start the next pending task" -- of that
+   decision tree, with the variables above substituted.
+   - Do NOT execute rules 1, 2, or 3. The orchestrator owns merging step PRs,
+     reconciling dex state, and opening the integration PR.
+   - If no pending task is available to start -- every child task is completed,
+     in-progress, or BLOCKED -- exit cleanly without doing anything.
+   - Skip every "RemoteTrigger run" / "RemoteTrigger update" instruction -- this
+     is a local shell loop, not a routine.
+
+Implement exactly one task, open exactly one step PR into $FEATURE_BRANCH, mark
+the task in-progress in dex, and exit. Never merge a PR. Never watch CI. Never
+open the integration PR. Do not refactor outside the task's scope. One PR per
+fire, maximum.
+EOF
+
+case "$AFK_WORKER" in
+  claude)
+    claude -p "$PROMPT" \
+      --allowedTools "Bash,Read,Write,Edit,Glob,Grep" \
+      --dangerously-skip-permissions
+    ;;
+  codex)
+    # --dangerously-bypass-approvals-and-sandbox: --full-auto's workspace-write
+    # sandbox blocks writes to .git/ so the worker can't `git switch -c` a step
+    # branch. Matches --dangerously-skip-permissions passed to claude.
+    # -c 'mcp_servers={}': wipe user-level MCP servers so codex doesn't hang on
+    # their handshake.
+    codex exec \
+      --dangerously-bypass-approvals-and-sandbox \
+      -c 'mcp_servers={}' \
+      "$PROMPT"
+    ;;
+esac

--- a/scripts/afk-loop.sh
+++ b/scripts/afk-loop.sh
@@ -1,23 +1,43 @@
 #!/usr/bin/env bash
-# AFK feature loop — runs fresh `claude -p` sessions in a tight loop, each
-# executing one fire of the AFK worker decision tree.
+# AFK feature loop — unattended orchestrator.
+#
+# Drives a multi-PR feature build to completion without a human in the loop.
+# Each round it does ONE orchestration step:
+#   - all child tasks done    -> open the integration PR into main, stop
+#   - a step PR is open       -> wait for its CI, merge it, advance dex
+#   - tasks remain            -> run scripts/afk-fire.sh (one implement-only
+#                                worker fire) to open the next step PR
+#
+# The expensive code work happens in stateless `claude -p` fires spawned by
+# afk-fire.sh — fresh context each time, no compaction. The cheap mechanical
+# work (watching CI, merging, advancing dex) happens here in the shell, so it
+# never burns a model fire.
+#
+# The attended equivalent — the Claude Code thread that ran /afk-local acting
+# as the orchestrator — is specified in .claude/skills/afk-feature/orchestrator.md.
+# Use this script for fully unattended runs, or as crash-recovery for an
+# attended run (all state lives in git + dex + open PRs).
 #
 # Usage:
 #   ./scripts/afk-loop.sh                 # auto-detect epic from dex
 #   ./scripts/afk-loop.sh <epic-id>       # explicit epic ID
 #
 # Env knobs:
-#   MAX_FIRES        max iterations before stopping (default 20)
-#   SLEEP_SECONDS    seconds to sleep between fires (default 5)
-#   AFK_WORKER       which CLI runs each fire: "claude" (default) or "codex"
+#   MAX_ROUNDS        max orchestration rounds before stopping (default 40)
+#   SLEEP_SECONDS     seconds to sleep between rounds (default 5)
+#   CI_POLL_SECONDS   seconds between CI re-checks while a PR has no checks yet
+#                     (default 15)
+#   AFK_WORKER        which CLI runs each fire: "claude" (default) or "codex"
+#   AFK_SOFT_CHECKS   comma-separated CI check names allowed to fail without
+#                     blocking a merge (default "fallow")
 #
-# Stop with Ctrl+C. Each fire is a fresh context — no compaction, predictable cost.
-# This is the local equivalent of the cloud worker routine, without the 1h cron floor.
+# Stop with Ctrl+C.
 
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 FEATURE_BRANCH="$(git branch --show-current)"
 if [[ ! "$FEATURE_BRANCH" =~ ^claude/feat- ]]; then
@@ -45,9 +65,12 @@ if [[ -z "$EPIC_ID" ]]; then
 fi
 
 OWNER_REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
-MAX_FIRES="${MAX_FIRES:-20}"
+MAX_ROUNDS="${MAX_ROUNDS:-40}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-5}"
+CI_POLL_SECONDS="${CI_POLL_SECONDS:-15}"
 AFK_WORKER="${AFK_WORKER:-claude}"
+AFK_SOFT_CHECKS="${AFK_SOFT_CHECKS:-fallow}"
+export AFK_WORKER AFK_SOFT_CHECKS
 
 case "$AFK_WORKER" in
   claude|codex) ;;
@@ -62,78 +85,20 @@ if ! command -v "$AFK_WORKER" >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "=== AFK loop ==="
+echo "=== AFK loop (unattended orchestrator) ==="
 echo "Repo:           $OWNER_REPO"
 echo "Feature branch: $FEATURE_BRANCH"
 echo "Epic:           $EPIC_ID"
 echo "Worker:         $AFK_WORKER"
-echo "Max fires:      $MAX_FIRES"
-echo "Sleep between:  ${SLEEP_SECONDS}s"
+echo "Max rounds:     $MAX_ROUNDS"
+echo "Soft checks:    $AFK_SOFT_CHECKS"
 echo ""
 
-PROMPT=$(cat <<EOF
-You are an AFK feature worker (local mode).
+# --- helpers --------------------------------------------------------------
 
-Repo: $OWNER_REPO
-Feature branch: $FEATURE_BRANCH
-Dex epic: $EPIC_ID
-
-Do this and only this:
-
-1. git fetch origin
-2. git switch $FEATURE_BRANCH (if it no longer exists, exit cleanly — feature is shipped or aborted)
-3. Read .claude/skills/afk-feature/worker.md from the working tree
-4. Follow its decision tree exactly ONCE, with the variables above substituted.
-   - Skip every "RemoteTrigger run <SELF_ROUTINE_ID>" and "RemoteTrigger update" instruction in worker.md — we are running in a local shell loop, not a routine.
-
-Exit when you have done one unit of work (opened/merged one PR, advanced one tasks state, or determined there is nothing to do).
-
-Do not invent extra work. Do not refactor outside the current steps scope. One PR per fire, max.
-EOF
-)
-
-for i in $(seq 1 "$MAX_FIRES"); do
-  echo "=== Fire $i/$MAX_FIRES — $(date -u +%H:%M:%SZ) ==="
-
-  # Always start a fire on the feature branch
-  git switch "$FEATURE_BRANCH" >/dev/null 2>&1 || true
-  git fetch origin "$FEATURE_BRANCH" >/dev/null 2>&1 || true
-  git reset --hard "origin/$FEATURE_BRANCH" >/dev/null 2>&1 || true
-
-  case "$AFK_WORKER" in
-    claude)
-      if ! claude -p "$PROMPT" \
-          --allowedTools "Bash,Read,Write,Edit,Glob,Grep" \
-          --dangerously-skip-permissions; then
-        echo "claude -p exited non-zero, stopping" >&2
-        exit 1
-      fi
-      ;;
-    codex)
-      # --dangerously-bypass-approvals-and-sandbox: --full-auto's workspace-write
-      # sandbox blocks writes to .git/ (e.g. .git/index.lock) so the worker can't
-      # `git switch -c` a step branch. Matches the --dangerously-skip-permissions
-      # we already pass to claude.
-      # -c 'mcp_servers={}': wipe user-level MCP servers so codex doesn't hang
-      # waiting on their handshake.
-      if ! codex exec \
-          --dangerously-bypass-approvals-and-sandbox \
-          -c 'mcp_servers={}' \
-          "$PROMPT"; then
-        echo "codex exec exited non-zero, stopping" >&2
-        exit 1
-      fi
-      ;;
-  esac
-
-  echo ""
-
-  # Check if epic is now complete. Two exit paths:
-  #   1. dex marks the epic completed (only happens after integration PR merges)
-  #   2. Every child task is completed AND an integration PR is open against main
-  #      (the worker can't merge the integration PR itself — that's the human's job —
-  #      so once it's open, every further fire is a no-op and we should stop early)
-  EPIC_STATE="$(dex show "$EPIC_ID" --json 2>/dev/null | python3 -c '
+# Echo the epic's state: "done" | "children-done" | "in-progress".
+epic_state() {
+  dex show "$EPIC_ID" --json 2>/dev/null | python3 -c '
 import sys, json
 try:
     t = json.load(sys.stdin)
@@ -147,23 +112,159 @@ try:
             print("in-progress")
 except Exception:
     print("in-progress")
-')"
+'
+}
 
-  if [[ "$EPIC_STATE" == "done" ]]; then
-    echo "✓ Epic $EPIC_ID complete. Loop done."
+# Echo the number of the first open step PR targeting the feature branch, if any.
+open_step_pr() {
+  gh pr list --base "$FEATURE_BRANCH" --state open --json number \
+    --jq '.[0].number // empty'
+}
+
+# Block until the given PR's CI checks finish, then echo "pass" or
+# "fail:<names>". Checks named in AFK_SOFT_CHECKS may fail without blocking.
+wait_for_ci() {
+  local pr="$1"
+  local attempt rc
+  for attempt in 1 2 3 4 5 6; do
+    # `gh pr checks --watch` blocks until every check completes.
+    # Exit 8 = no checks registered yet (PR just opened) -> wait and retry.
+    if gh pr checks "$pr" --watch >/dev/null 2>&1; then
+      break
+    fi
+    rc=$?
+    if [[ "$rc" -eq 8 ]]; then
+      sleep "$CI_POLL_SECONDS"
+      continue
+    fi
+    # rc 1: checks finished, at least one failed -> fall through to evaluate.
+    break
+  done
+  gh pr view "$pr" --json statusCheckRollup --jq '.statusCheckRollup' \
+    | python3 -c '
+import sys, json, os
+soft = set(s for s in os.environ.get("AFK_SOFT_CHECKS", "").split(",") if s)
+rollup = json.load(sys.stdin) or []
+failed = []
+for c in rollup:
+    name = c.get("name") or c.get("context") or "?"
+    concl = (c.get("conclusion") or "").upper()
+    state = (c.get("state") or "").upper()
+    if concl:
+        ok = concl in ("SUCCESS", "NEUTRAL", "SKIPPED")
+    elif state:
+        ok = state == "SUCCESS"
+    else:
+        ok = True
+    if not ok and name not in soft:
+        failed.append(name)
+print("fail:" + ",".join(failed) if failed else "pass")
+'
+}
+
+# Open the integration PR for the feature branch into main.
+open_integration_pr() {
+  local slug body
+  slug="${FEATURE_BRANCH#claude/feat-}"
+  body="$(dex show "$EPIC_ID" --json 2>/dev/null | python3 -c '
+import sys, json
+t = json.load(sys.stdin)
+children = t.get("subtasks", {}).get("children", []) or t.get("children", [])
+print("Integration PR for the AFK feature build.\n")
+print("Completed tasks:")
+for c in children:
+    print("- `%s` %s" % (c.get("id", "?"), c.get("name", "")))
+print("\nEach task shipped as a step PR into the feature branch. Review the")
+print("squashed history on this branch before merging to main.")
+')"
+  gh pr create \
+    --base main --head "$FEATURE_BRANCH" \
+    --title "${slug}: integration" \
+    --body "$body"
+}
+
+# --- orchestration loop ---------------------------------------------------
+
+prev_action=""
+
+for round in $(seq 1 "$MAX_ROUNDS"); do
+  echo "=== Round $round/$MAX_ROUNDS — $(date -u +%H:%M:%SZ) ==="
+
+  # Refresh the working tree to the remote feature branch.
+  git switch "$FEATURE_BRANCH" >/dev/null 2>&1 || true
+  git fetch origin "$FEATURE_BRANCH" >/dev/null 2>&1 || true
+  git reset --hard "origin/$FEATURE_BRANCH" >/dev/null 2>&1 || true
+
+  state="$(epic_state)"
+
+  # Step 1: feature finished?
+  if [[ "$state" == "done" ]]; then
+    echo "✓ Epic $EPIC_ID is complete. Loop done."
     exit 0
   fi
 
-  if [[ "$EPIC_STATE" == "children-done" ]]; then
-    INTEGRATION_PR="$(gh pr list --head "$FEATURE_BRANCH" --base main --state open --json number -q '.[0].number' 2>/dev/null || true)"
-    if [[ -n "$INTEGRATION_PR" ]]; then
-      echo "✓ All child tasks complete; integration PR #$INTEGRATION_PR is open against main. Loop done."
-      exit 0
+  if [[ "$state" == "children-done" ]]; then
+    integ="$(gh pr list --head "$FEATURE_BRANCH" --base main --state open \
+      --json number --jq '.[0].number // empty')"
+    if [[ -n "$integ" ]]; then
+      echo "✓ All tasks done; integration PR #$integ already open against main."
+    else
+      echo "All tasks done — opening the integration PR..."
+      open_integration_pr
     fi
+    echo "Loop done. Review and merge the integration PR."
+    exit 0
   fi
 
-  echo "Sleeping ${SLEEP_SECONDS}s before next fire..."
+  # Step 2: a step PR is open — wait for CI, then merge it.
+  pr="$(open_step_pr)"
+  if [[ -n "$pr" ]]; then
+    echo "Step PR #$pr is open. Waiting for CI..."
+    verdict="$(wait_for_ci "$pr")"
+    if [[ "$verdict" == "pass" ]]; then
+      head="$(gh pr view "$pr" --json headRefName --jq .headRefName)"
+      task_id="${head#claude/task-}"
+      echo "CI green — merging PR #$pr (task $task_id)..."
+      gh pr merge "$pr" --squash --delete-branch
+      git fetch origin "$FEATURE_BRANCH" >/dev/null 2>&1 || true
+      git switch "$FEATURE_BRANCH" >/dev/null 2>&1 || true
+      git reset --hard "origin/$FEATURE_BRANCH" >/dev/null 2>&1 || true
+      dex complete "$task_id" \
+        --result "Merged step PR #$pr into $FEATURE_BRANCH." \
+        --commit "$(git rev-parse HEAD)"
+      git add .dex/
+      git commit -m "chore(afk): complete $task_id"
+      git push
+      prev_action="merge"
+    else
+      echo "✗ CI failed on PR #$pr (${verdict#fail:})." >&2
+      echo "  Stopping for human review — fix the PR, then re-run this loop." >&2
+      exit 1
+    fi
+    echo "Sleeping ${SLEEP_SECONDS}s before next round..."
+    sleep "$SLEEP_SECONDS"
+    continue
+  fi
+
+  # No open step PR. If the previous round already ran a fire and still no PR
+  # appeared, the worker opened nothing — remaining tasks are likely BLOCKED.
+  if [[ "$prev_action" == "implement" ]]; then
+    echo "✗ Last fire opened no step PR — remaining tasks are likely BLOCKED" >&2
+    echo "  or the worker failed. Stopping for human review." >&2
+    exit 1
+  fi
+
+  # Step 4: implement the next pending task in a fresh worker fire.
+  echo "No open step PR — running an implement-only worker fire..."
+  if ! "$SCRIPT_DIR/afk-fire.sh" "$EPIC_ID"; then
+    echo "afk-fire.sh exited non-zero, stopping" >&2
+    exit 1
+  fi
+  prev_action="implement"
+
+  echo ""
+  echo "Sleeping ${SLEEP_SECONDS}s before next round..."
   sleep "$SLEEP_SECONDS"
 done
 
-echo "Reached MAX_FIRES=$MAX_FIRES without completing the epic. Stopping."
+echo "Reached MAX_ROUNDS=$MAX_ROUNDS without completing the epic. Stopping."


### PR DESCRIPTION
## Summary

Restructures the AFK feature loop so CI-waiting and merging no longer each cost a model fire. Diagnosed from an AFK run that burned 20 fires on a 4-Part feature — ~8–10 of them were no-op fires that just polled CI.

- **`scripts/afk-fire.sh`** (new) — one stateless implement-only worker fire: a fresh headless `claude -p` scoped to worker.md decision rule 4. Opens a step PR; never merges, waits on CI, or opens the integration PR.
- **`scripts/afk-loop.sh`** (rewritten) — unattended bash orchestrator. Per round it opens the integration PR / watches CI + merges a step PR / spawns `afk-fire.sh`. CI-wait uses `gh pr checks --watch` instead of a polling fire. `AFK_SOFT_CHECKS` (default `fallow`) lets known non-gating checks fail without blocking a merge.
- **`.claude/skills/afk-feature/orchestrator.md`** (new) — attended-mode spec: the Claude Code thread that launched `/afk-local` runs the same loop, keeping its context lean (never reads code, background CI waits).
- **`worker.md`** / **`afk-local/SKILL.md`** — note implement-only fires; step 10 now offers attended (default) vs unattended orchestration.

## Test plan

- [x] `bash -n` on both scripts (incl. macOS bash 3.2 heredoc compatibility — `read -d ''`)
- [x] Embedded Python verified against real `dex show --json` output
- [ ] End-to-end: run an unattended `afk-loop.sh` against a live epic
- [ ] End-to-end: run an attended orchestration loop from a `/afk-local` kickoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)