### PR TITLE
Migrate renderer mouse events to pointer events (spec §6 I8)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,9 +30,7 @@ export default tseslint.config(
       // setBounds/setVisible/addChildView/removeChildView outside
       // layout-engine / layer-stack is a real invariant break.
       'local/no-direct-view-mutation': 'error',
-      // no-mouse-events stays a warning: legacy wireframe mouse-event call
-      // sites are still pervasive (invariant I8 migration is a follow-up).
-      'local/no-mouse-events': 'warn',
+      'local/no-mouse-events': 'error',
     },
   },
 )

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -624,14 +624,16 @@ export default function App({
     }
     // The top toolbar is a sibling WebContentsView, so when the cursor moves
     // up into it the above-view stops receiving pointer events without
-    // window.pointerleave firing. mouseleave on documentElement is the
-    // reliable "cursor left this webcontents" signal.
+    // pointerleave firing. mouseleave on documentElement is the reliable
+    // "cursor left this webcontents" signal in Electron's multi-view layout.
     const docEl = document.documentElement
     window.addEventListener('pointermove', handleMove)
+    // eslint-disable-next-line local/no-mouse-events
     docEl.addEventListener('mouseleave', clearHover)
     window.addEventListener('blur', clearHover)
     return () => {
       window.removeEventListener('pointermove', handleMove)
+      // eslint-disable-next-line local/no-mouse-events
       docEl.removeEventListener('mouseleave', clearHover)
       window.removeEventListener('blur', clearHover)
       clearHover()

--- a/src/renderer/above-view/CanvasItemChrome.tsx
+++ b/src/renderer/above-view/CanvasItemChrome.tsx
@@ -21,8 +21,8 @@ function Root({
   isActive,
   dragEnabled = true,
   onPointerDown,
-  onMouseEnter,
-  onMouseLeave,
+  onPointerEnter,
+  onPointerLeave,
   children,
 }: {
   entityId: string
@@ -31,8 +31,8 @@ function Root({
   isActive: boolean
   dragEnabled?: boolean
   onPointerDown?: (e: React.PointerEvent) => void
-  onMouseEnter?: () => void
-  onMouseLeave?: () => void
+  onPointerEnter?: () => void
+  onPointerLeave?: () => void
   children: ReactNode
 }) {
   const headerRect = useAnchoredPosition(layout, entityId, 'header')
@@ -49,8 +49,8 @@ function Root({
       isActive={isActive}
       dragEnabled={dragEnabled}
       onPointerDown={onPointerDown}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
     >
       {children}
     </EntityChrome.Root>

--- a/src/renderer/above-view/CanvasItemPopup.tsx
+++ b/src/renderer/above-view/CanvasItemPopup.tsx
@@ -144,7 +144,7 @@ function Frame({
           ? '0 10px 8px -6px rgba(0,0,0,.58), 0 4px 16px 0 rgba(0,0,0,.5)'
           : '0 10px 8px -6px rgba(0,0,0,.18), 0 4px 16px 0 rgba(199,193,188,.5)',
       }}
-      onMouseDown={(event) => event.stopPropagation()}
+      onPointerDown={(event) => event.stopPropagation()}
     >
       {children}
     </div>

--- a/src/renderer/above-view/EdgeLayer.tsx
+++ b/src/renderer/above-view/EdgeLayer.tsx
@@ -181,8 +181,8 @@ function AnchorDots({
               ry={EDGE_ANCHOR_HIT_CORNER_PX}
               fill="transparent"
               style={{ cursor: 'crosshair', pointerEvents: 'all' }}
-              onMouseEnter={() => setHoveredSide(side)}
-              onMouseLeave={() => {
+              onPointerEnter={() => setHoveredSide(side)}
+              onPointerLeave={() => {
                 if (isDragging) return
                 setHoveredSide((current) => (current === side ? null : current))
               }}

--- a/src/renderer/above-view/FileChrome.tsx
+++ b/src/renderer/above-view/FileChrome.tsx
@@ -127,8 +127,8 @@ const FileChromeItem = memo(function FileChromeItem({
       isDark={isDark}
       isActive={isActive}
       onPointerDown={onPointerDown}
-      onMouseEnter={() => api.hoverPage(entity.id)}
-      onMouseLeave={() => api.hoverPage(null)}
+      onPointerEnter={() => api.hoverPage(entity.id)}
+      onPointerLeave={() => api.hoverPage(null)}
     >
       <CanvasItemChrome.DragTrigger>
         <FileIcon size={13} className="shrink-0 text-zinc-400" />

--- a/src/renderer/above-view/GroupRenameLabel.tsx
+++ b/src/renderer/above-view/GroupRenameLabel.tsx
@@ -91,9 +91,9 @@ function GroupRenameItem({
   // colour for future styling extension; today we lean on existing tokens.
   void resolveCanvasColor
 
-  const onMouseDown = isRenaming
-    ? (event: React.MouseEvent) => event.stopPropagation()
-    : (event: React.MouseEvent) => {
+  const onPointerDown = isRenaming
+    ? (event: React.PointerEvent) => event.stopPropagation()
+    : (event: React.PointerEvent) => {
         event.preventDefault()
         event.stopPropagation()
         const additive = event.shiftKey || event.metaKey || event.ctrlKey
@@ -101,10 +101,12 @@ function GroupRenameItem({
           api.selectGroup(group.id)
           return
         }
+        const pointerId = event.pointerId
         let dragging = false
         const startX = event.screenX
         const startY = event.screenY
-        const onMove = (ev: MouseEvent) => {
+        const onMove = (ev: PointerEvent) => {
+          if (ev.pointerId !== pointerId) return
           const totalDx = ev.screenX - startX
           const totalDy = ev.screenY - startY
           if (
@@ -121,7 +123,7 @@ function GroupRenameItem({
               api,
               layout: layoutData,
               groupId: group.id,
-              event,
+              event: event.nativeEvent,
               initialPointer: ev,
               isOptionHeld: () => optionHeldRef.current,
               setPreview: setDragCopyPreview,
@@ -130,11 +132,12 @@ function GroupRenameItem({
           }
         }
         const cleanup = () => {
-          window.removeEventListener('mousemove', onMove)
-          window.removeEventListener('mouseup', onUp)
+          window.removeEventListener('pointermove', onMove)
+          window.removeEventListener('pointerup', onUp)
           window.removeEventListener('blur', onCancel)
         }
-        const onUp = () => {
+        const onUp = (ev: PointerEvent) => {
+          if (ev.pointerId !== pointerId) return
           cleanup()
           if (dragging) {
             api.endDragGroup()
@@ -146,8 +149,8 @@ function GroupRenameItem({
           cleanup()
           if (dragging) api.endDragGroup()
         }
-        window.addEventListener('mousemove', onMove)
-        window.addEventListener('mouseup', onUp)
+        window.addEventListener('pointermove', onMove)
+        window.addEventListener('pointerup', onUp)
         window.addEventListener('blur', onCancel)
       }
 
@@ -162,7 +165,7 @@ function GroupRenameItem({
         whiteSpace: 'nowrap',
         cursor: isRenaming ? 'text' : 'grab',
       }}
-      onMouseDown={onMouseDown}
+      onPointerDown={onPointerDown}
       onDoubleClick={() => api.requestEntityEdit(group.id)}
     >
       <span className="inline-flex items-center gap-1 pb-1">

--- a/src/renderer/above-view/PageChrome.tsx
+++ b/src/renderer/above-view/PageChrome.tsx
@@ -163,8 +163,8 @@ function PageChromeItem({
       isActive={isActive}
       dragEnabled={dragEnabled}
       onPointerDown={onPointerDown}
-      onMouseEnter={() => api.hoverPage(page.id)}
-      onMouseLeave={() => api.hoverPage(null)}
+      onPointerEnter={() => api.hoverPage(page.id)}
+      onPointerLeave={() => api.hoverPage(null)}
     >
       <CanvasItemChrome.DragTrigger
         onPointerDown={isEditing ? (e) => e.stopPropagation() : undefined}

--- a/src/renderer/above-view/PagePopup.tsx
+++ b/src/renderer/above-view/PagePopup.tsx
@@ -151,7 +151,7 @@ export function PagePopup({
                     inputRef.current?.blur()
                   }
                 }}
-                onMouseDown={(e) => e.stopPropagation()}
+                onPointerDown={(e) => e.stopPropagation()}
                 className={`min-w-0 flex-1 rounded-[6px] border px-2 py-1 text-xs outline-none focus:ring-1 ${
                   isDark
                     ? 'border-zinc-700 bg-zinc-950 text-zinc-100 placeholder:text-zinc-500 focus:ring-blue-500/40'

--- a/src/renderer/above-view/ShapeBodyLayer.tsx
+++ b/src/renderer/above-view/ShapeBodyLayer.tsx
@@ -96,7 +96,6 @@ function ShapeText({
         contentEditable={editing}
         suppressContentEditableWarning
         onInput={(e) => onChange((e.target as HTMLDivElement).textContent ?? '')}
-        onMouseDown={(e) => { if (editing) e.stopPropagation() }}
         onPointerDown={(e) => { if (editing) e.stopPropagation() }}
         onBlur={(e) => {
           onCommit((e.target as HTMLDivElement).textContent ?? '')

--- a/src/renderer/above-view/StickyBodyLayer.tsx
+++ b/src/renderer/above-view/StickyBodyLayer.tsx
@@ -306,7 +306,7 @@ function StickyCard({
         {!isPlain ? (
           <div
             style={{ minHeight: 8, cursor: 'grab' }}
-            onMouseDown={(e) => {
+            onPointerDown={(e) => {
               if (e.button !== 0) return
               e.stopPropagation()
             }}

--- a/src/renderer/above-view/TextSizeDropdown.tsx
+++ b/src/renderer/above-view/TextSizeDropdown.tsx
@@ -105,7 +105,7 @@ export function TextSizeDropdown({
           <Menu.Popup
             data-overlay-ui
             className={popupClass(isDark)}
-            onMouseDown={(event) => event.stopPropagation()}
+            onPointerDown={(event) => event.stopPropagation()}
           >
             {TEXT_SIZE_PRESETS.map((preset) => {
               const active = preset.value === value

--- a/src/renderer/above-view/optionDragCopy.ts
+++ b/src/renderer/above-view/optionDragCopy.ts
@@ -1,5 +1,4 @@
 import type {
-  MouseEvent as ReactMouseEvent,
   PointerEvent as ReactPointerEvent,
 } from 'react'
 import type {
@@ -313,20 +312,20 @@ export function startOptionAwareGroupDrag(input: {
   api: CanvasBgElectronAPI
   layout: LayoutUpdateData
   groupId: string
-  event: PointerEvent | MouseEvent | ReactPointerEvent | ReactMouseEvent
+  event: PointerEvent | ReactPointerEvent
   releasePointer?: (() => void) | null
   captureTarget?: Element | null
   initialPointer?: DragPointer
   isOptionHeld: () => boolean
   setPreview: (preview: DragCopyPreviewBox[]) => void
 }) {
-  const pointerId = 'pointerId' in input.event ? input.event.pointerId : null
+  const pointerId = input.event.pointerId
   const entityIds = draggedEntityIdsForGroup(input.layout, input.groupId)
   input.api.startDragGroup(input.groupId)
 
   const release = () => {
     input.releasePointer?.()
-    if (pointerId === null || !input.captureTarget) return
+    if (!input.captureTarget) return
     try {
       if (input.captureTarget.hasPointerCapture(pointerId)) {
         input.captureTarget.releasePointerCapture(pointerId)
@@ -363,7 +362,7 @@ export function startOptionAwareGroupDrag(input: {
 }
 
 function installOptionAwareDragListeners(input: {
-  pointerId: number | null
+  pointerId: number
   session: ReturnType<typeof createOptionDragCopySession>
   isOptionHeld: () => boolean
 }) {
@@ -371,27 +370,16 @@ function installOptionAwareDragListeners(input: {
     window.removeEventListener('pointermove', onPointerMove)
     window.removeEventListener('pointerup', onPointerUp)
     window.removeEventListener('pointercancel', onCancel)
-    window.removeEventListener('mousemove', onMouseMove)
-    window.removeEventListener('mouseup', onMouseUp)
     window.removeEventListener('keydown', onKeyChange)
     window.removeEventListener('keyup', onKeyChange)
     window.removeEventListener('blur', onCancel)
   }
   const onPointerMove = (event: PointerEvent) => {
-    if (input.pointerId !== null && event.pointerId !== input.pointerId) return
+    if (event.pointerId !== input.pointerId) return
     input.session.move(event)
   }
   const onPointerUp = (event: PointerEvent) => {
-    if (input.pointerId !== null && event.pointerId !== input.pointerId) return
-    cleanup()
-    input.session.finish(event)
-  }
-  const onMouseMove = (event: MouseEvent) => {
-    if (input.pointerId !== null) return
-    input.session.move(event)
-  }
-  const onMouseUp = (event: MouseEvent) => {
-    if (input.pointerId !== null) return
+    if (event.pointerId !== input.pointerId) return
     cleanup()
     input.session.finish(event)
   }
@@ -404,14 +392,9 @@ function installOptionAwareDragListeners(input: {
     input.session.cancel()
   }
 
-  if (input.pointerId === null) {
-    window.addEventListener('mousemove', onMouseMove)
-    window.addEventListener('mouseup', onMouseUp)
-  } else {
-    window.addEventListener('pointermove', onPointerMove)
-    window.addEventListener('pointerup', onPointerUp)
-    window.addEventListener('pointercancel', onCancel)
-  }
+  window.addEventListener('pointermove', onPointerMove)
+  window.addEventListener('pointerup', onPointerUp)
+  window.addEventListener('pointercancel', onCancel)
   window.addEventListener('keydown', onKeyChange)
   window.addEventListener('keyup', onKeyChange)
   window.addEventListener('blur', onCancel)

--- a/src/renderer/canvas-bg/ResizeHandles.tsx
+++ b/src/renderer/canvas-bg/ResizeHandles.tsx
@@ -10,7 +10,7 @@ export function CornerResizeHandle({
 }: {
   corner: ResizeCorner
   isDark: boolean
-  beginResize?: (e: React.MouseEvent) => void
+  beginResize?: (e: React.PointerEvent) => void
   scaleWithZoom?: boolean
 }) {
   const half = scaleWithZoom ? `calc(${HANDLE_SIZE / 2}px / var(--canvas-zoom, 1))` : HANDLE_SIZE / 2
@@ -27,7 +27,7 @@ export function CornerResizeHandle({
     <div
       data-resize-handle
       data-overlay-ui={scaleWithZoom ? undefined : true}
-      onMouseDown={beginResize}
+      onPointerDown={beginResize}
       style={{
         position: 'absolute',
         ...pos,
@@ -51,7 +51,7 @@ export function EdgeResizeHandle({
   scaleWithZoom = false,
 }: {
   edge: ResizeEdge
-  beginResize?: (e: React.MouseEvent) => void
+  beginResize?: (e: React.PointerEvent) => void
   scaleWithZoom?: boolean
 }) {
   const half = scaleWithZoom ? `calc(${HANDLE_SIZE / 2}px / var(--canvas-zoom, 1))` : HANDLE_SIZE / 2
@@ -68,7 +68,7 @@ export function EdgeResizeHandle({
     <div
       data-resize-handle
       data-overlay-ui={scaleWithZoom ? undefined : true}
-      onMouseDown={beginResize}
+      onPointerDown={beginResize}
       style={{
         position: 'absolute',
         ...pos,

--- a/src/renderer/canvas-bg/useCanvasViewportGestures.ts
+++ b/src/renderer/canvas-bg/useCanvasViewportGestures.ts
@@ -57,30 +57,36 @@ export function useCanvasViewportGestures({
 
     // Document-level middle-click pan (works over entities).
     let middleDrag: { screenX: number; screenY: number } | null = null
+    let middleDragPointerId: number | null = null
 
-    const handleMiddleMouseDown = (event: MouseEvent) => {
+    const handleMiddlePointerDown = (event: PointerEvent) => {
       const layout = layoutRef.current
       if (event.button !== 1) return
       if (layout.viewMode === 'browser') return
       if (isOverlayUiTarget(event.target)) return
       if (event.clientY < layout.canvasOrigin.y) return
+      middleDragPointerId = event.pointerId
       middleDrag = { screenX: event.screenX, screenY: event.screenY }
       event.preventDefault()
     }
 
-    const handleMiddleMouseMove = (event: MouseEvent) => {
-      if (!middleDrag) return
+    const handleMiddlePointerMove = (event: PointerEvent) => {
+      if (event.pointerId !== middleDragPointerId || !middleDrag) return
       const delta = middleDragDelta(middleDrag, event)
       middleDrag = { screenX: event.screenX, screenY: event.screenY }
       api.canvasPan(delta.deltaX, delta.deltaY)
     }
 
-    const handleMiddleMouseUp = () => {
-      middleDrag = null
+    const handleMiddlePointerUp = (event: PointerEvent) => {
+      if (event.pointerId === middleDragPointerId) {
+        middleDrag = null
+        middleDragPointerId = null
+      }
     }
 
     const handleWindowBlur = () => {
       middleDrag = null
+      middleDragPointerId = null
     }
 
     const handleVisibilityChange = () => {
@@ -124,9 +130,9 @@ export function useCanvasViewportGestures({
     }
 
     document.addEventListener('wheel', handleWheel, { passive: false })
-    document.addEventListener('mousedown', handleMiddleMouseDown)
-    document.addEventListener('mousemove', handleMiddleMouseMove)
-    document.addEventListener('mouseup', handleMiddleMouseUp)
+    document.addEventListener('pointerdown', handleMiddlePointerDown)
+    document.addEventListener('pointermove', handleMiddlePointerMove)
+    document.addEventListener('pointerup', handleMiddlePointerUp)
     document.addEventListener('dragover', handleDragOver)
     document.addEventListener('drop', handleDrop)
     el.addEventListener('pointerenter', handlePointerEnter)
@@ -135,9 +141,9 @@ export function useCanvasViewportGestures({
 
     return () => {
       document.removeEventListener('wheel', handleWheel)
-      document.removeEventListener('mousedown', handleMiddleMouseDown)
-      document.removeEventListener('mousemove', handleMiddleMouseMove)
-      document.removeEventListener('mouseup', handleMiddleMouseUp)
+      document.removeEventListener('pointerdown', handleMiddlePointerDown)
+      document.removeEventListener('pointermove', handleMiddlePointerMove)
+      document.removeEventListener('pointerup', handleMiddlePointerUp)
       document.removeEventListener('dragover', handleDragOver)
       document.removeEventListener('drop', handleDrop)
       el.removeEventListener('pointerenter', handlePointerEnter)

--- a/src/renderer/canvas-bg/wireframe/WireframeNodeRenderer.tsx
+++ b/src/renderer/canvas-bg/wireframe/WireframeNodeRenderer.tsx
@@ -21,7 +21,7 @@ export interface WireframeNodeRendererProps {
   draggedNodeId: string | null
   dropTarget: DropTarget | null
   editingNodeId: string | null
-  onNodePointerDown: (nodeId: string, parentId: string, e: React.MouseEvent) => void
+  onNodePointerDown: (nodeId: string, parentId: string, e: React.PointerEvent) => void
   onDropTargetChange: (target: DropTarget) => void
   onStartEdit: (nodeId: string) => void
   onCommitEdit: (nodeId: string, value: string) => void
@@ -65,7 +65,7 @@ function EditableText({
           }
           e.stopPropagation()
         }}
-        onMouseDown={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}
         onClick={(e) => e.stopPropagation()}
         style={{
           ...style,
@@ -153,7 +153,7 @@ function FrameNodeRenderer({
   const indicatorDir = isVertical ? 'horizontal' : 'vertical'
 
   const lastDropRef = useRef<{ parentId: string; index: number } | null>(null)
-  const handleMouseMove = (e: React.MouseEvent) => {
+  const handlePointerMove = (e: React.PointerEvent) => {
     if (!props.draggedNodeId) return
     const container = containerRef.current
     if (!container) return
@@ -202,7 +202,7 @@ function FrameNodeRenderer({
   }
 
   return (
-    <div ref={containerRef} style={frameStyle} onMouseMove={handleMouseMove}>
+    <div ref={containerRef} style={frameStyle} onPointerMove={handlePointerMove}>
       {node.children.map((child, index) => {
         const isDragged = props.draggedNodeId === child.id
         const showIndicator =
@@ -230,7 +230,7 @@ function FrameNodeRenderer({
                       )
                     : {}),
               }}
-              onMouseDown={(e) => {
+              onPointerDown={(e) => {
                 if (props.canEdit && !props.editingNodeId) {
                   e.stopPropagation()
                   props.onNodePointerDown(child.id, node.id, e)

--- a/src/renderer/canvas-bg/wireframe/WireframeRenderer.tsx
+++ b/src/renderer/canvas-bg/wireframe/WireframeRenderer.tsx
@@ -89,9 +89,11 @@ export function WireframeRenderer({
   // --- Drag handlers ---
 
   const handleNodePointerDown = useCallback(
-    (nodeId: string, parentId: string, e: React.MouseEvent) => {
+    (nodeId: string, parentId: string, e: React.PointerEvent) => {
       if (!canEdit || editingNodeId) return
       e.preventDefault()
+
+      const pointerId = e.pointerId
 
       pendingRef.current = {
         nodeId,
@@ -100,7 +102,8 @@ export function WireframeRenderer({
         y: e.clientY,
       }
 
-      const handleMove = (me: MouseEvent) => {
+      const handleMove = (me: PointerEvent) => {
+        if (me.pointerId !== pointerId) return
         if (!pendingRef.current) return
         const dx = me.clientX - pendingRef.current.x
         const dy = me.clientY - pendingRef.current.y
@@ -110,9 +113,10 @@ export function WireframeRenderer({
         }
       }
 
-      const handleUp = () => {
-        window.removeEventListener('mousemove', handleMove)
-        window.removeEventListener('mouseup', handleUp)
+      const handleUp = (me: PointerEvent) => {
+        if (me.pointerId !== pointerId) return
+        window.removeEventListener('pointermove', handleMove)
+        window.removeEventListener('pointerup', handleUp)
 
         if (pendingRef.current) {
           // It was a click — trigger edit if applicable
@@ -132,8 +136,8 @@ export function WireframeRenderer({
         }
       }
 
-      window.addEventListener('mousemove', handleMove)
-      window.addEventListener('mouseup', handleUp)
+      window.addEventListener('pointermove', handleMove)
+      window.addEventListener('pointerup', handleUp)
     },
     [canEdit, editingNodeId],
   )
@@ -156,8 +160,8 @@ export function WireframeRenderer({
       setDropTarget(null)
     }
 
-    window.addEventListener('mouseup', handleUp)
-    return () => window.removeEventListener('mouseup', handleUp)
+    window.addEventListener('pointerup', handleUp)
+    return () => window.removeEventListener('pointerup', handleUp)
   }, [draggedNodeId, dropTarget, persist])
 
   // --- Edit handlers ---
@@ -253,7 +257,7 @@ export function WireframeRenderer({
           <textarea
             value={jsonText}
             onChange={(e) => handleJsonTextChange(e.target.value)}
-            onMouseDown={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
             spellCheck={false}
             style={{
               width: '100%',

--- a/src/renderer/right-details-panel/components/InspectTree.tsx
+++ b/src/renderer/right-details-panel/components/InspectTree.tsx
@@ -102,8 +102,8 @@ function InspectTreeNode({
     return (
       <div
         className={rowClassName}
-        onMouseEnter={() => rightDetailsPanelApi.setInspectHoverNode(pageId, node.id)}
-        onMouseLeave={() => rightDetailsPanelApi.setInspectHoverNode(pageId, null)}
+        onPointerEnter={() => rightDetailsPanelApi.setInspectHoverNode(pageId, node.id)}
+        onPointerLeave={() => rightDetailsPanelApi.setInspectHoverNode(pageId, null)}
       >
         {rowButton}
       </div>
@@ -124,8 +124,8 @@ function InspectTreeNode({
     >
       <div
         className={rowClassName}
-        onMouseEnter={() => rightDetailsPanelApi.setInspectHoverNode(pageId, node.id)}
-        onMouseLeave={() => rightDetailsPanelApi.setInspectHoverNode(pageId, null)}
+        onPointerEnter={() => rightDetailsPanelApi.setInspectHoverNode(pageId, node.id)}
+        onPointerLeave={() => rightDetailsPanelApi.setInspectHoverNode(pageId, null)}
       >
         <Collapsible.Trigger
           className="absolute top-1/2 inline-flex size-4 -translate-y-1/2 items-center justify-center text-zinc-500 hover:bg-[var(--surface-interactive-hover)] hover:text-zinc-900 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 dark:text-zinc-300 dark:hover:bg-[var(--surface-interactive-hover)] dark:hover:text-zinc-100"

--- a/src/renderer/right-details-panel/components/PagePane.tsx
+++ b/src/renderer/right-details-panel/components/PagePane.tsx
@@ -100,7 +100,7 @@ export function PagePane({
   return (
     <div
       className="flex h-full min-h-0 flex-col"
-      onMouseDownCapture={(event) => {
+      onPointerDownCapture={(event) => {
         if (inspect.enabled) return
         if (!inspect.selectedNodeId && !inspect.hoveredNodeId) return
         const elementsSection = elementsSectionRef.current
@@ -206,7 +206,7 @@ export function PagePane({
             <Collapsible.Panel className={collapsiblePanelClass}>
               <div
                 className="thin-scrollbar pb-2"
-                onMouseLeave={() => {
+                onPointerLeave={() => {
                   if (inspect.activePageId) {
                     rightDetailsPanelApi.setInspectHoverNode(
                       inspect.activePageId,

--- a/src/renderer/right-details-panel/useClearInspectHoverOnLeave.ts
+++ b/src/renderer/right-details-panel/useClearInspectHoverOnLeave.ts
@@ -27,11 +27,11 @@ export function useClearInspectHoverOnLeave(
     if (!selectedNodeId && !mouseInsideRef.current) {
       rightDetailsPanelApi.setInspectHoverNode(activePageId, null)
     }
-    document.documentElement.addEventListener('mouseenter', handleDocEnter)
-    document.documentElement.addEventListener('mouseleave', handleDocLeave)
+    document.documentElement.addEventListener('pointerenter', handleDocEnter)
+    document.documentElement.addEventListener('pointerleave', handleDocLeave)
     return () => {
-      document.documentElement.removeEventListener('mouseenter', handleDocEnter)
-      document.documentElement.removeEventListener('mouseleave', handleDocLeave)
+      document.documentElement.removeEventListener('pointerenter', handleDocEnter)
+      document.documentElement.removeEventListener('pointerleave', handleDocLeave)
     }
   }, [activePageId, selectedNodeId])
 }

--- a/src/renderer/shared/EntityChrome.tsx
+++ b/src/renderer/shared/EntityChrome.tsx
@@ -34,8 +34,8 @@ function Root({
   dragEnabled = true,
   isActive,
   onPointerDown,
-  onMouseEnter,
-  onMouseLeave,
+  onPointerEnter,
+  onPointerLeave,
   children,
 }: {
   screenX: number
@@ -45,8 +45,8 @@ function Root({
   dragEnabled?: boolean
   isActive: boolean
   onPointerDown?: (e: React.PointerEvent) => void
-  onMouseEnter?: () => void
-  onMouseLeave?: () => void
+  onPointerEnter?: () => void
+  onPointerLeave?: () => void
   children: ReactNode
 }) {
   const [isHovered, setIsHovered] = useState(false)
@@ -70,8 +70,8 @@ function Root({
       <div
         className="pointer-events-auto absolute"
         data-overlay-ui
-        onMouseEnter={() => { setIsHovered(true); onMouseEnter?.() }}
-        onMouseLeave={() => { setIsHovered(false); onMouseLeave?.() }}
+        onPointerEnter={() => { setIsHovered(true); onPointerEnter?.() }}
+        onPointerLeave={() => { setIsHovered(false); onPointerLeave?.() }}
         style={{
           left: screenX,
           top: screenY,

--- a/src/renderer/shared/InlineEditLabel.tsx
+++ b/src/renderer/shared/InlineEditLabel.tsx
@@ -87,7 +87,7 @@ export function InlineEditLabel({
         onFocus={(event) => event.target.select()}
         onClick={(event) => event.stopPropagation()}
         onDoubleClick={(event) => event.stopPropagation()}
-        onMouseDown={(event) => event.stopPropagation()}
+        onPointerDown={(event) => event.stopPropagation()}
         placeholder={placeholder}
         spellCheck={false}
         className={inputClassName ?? defaultInputClass(variant, isDark)}

--- a/src/renderer/shared/MarkdownEditor.tsx
+++ b/src/renderer/shared/MarkdownEditor.tsx
@@ -162,7 +162,7 @@ export function MarkdownEditor({
       ref={containerRef}
       className={className}
       style={style}
-      onMouseDown={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
     />
   )
 }

--- a/src/renderer/shared/hooks/useViewportWheelAndMiddlePan.ts
+++ b/src/renderer/shared/hooks/useViewportWheelAndMiddlePan.ts
@@ -42,38 +42,45 @@ export function useViewportWheelAndMiddlePan(
       api.canvasPan(action.deltaX, action.deltaY)
     }
 
-    const onMouseDown = (event: MouseEvent) => {
+    let middleDragPointerId: number | null = null
+
+    const onPointerDown = (event: PointerEvent) => {
       if (isOverlayUiTarget(event.target)) return
       if (!shouldStartMouseViewportPan(event)) return
+      middleDragPointerId = event.pointerId
       middleDrag = { screenX: event.screenX, screenY: event.screenY }
       event.preventDefault()
     }
 
-    const onMouseMove = (event: MouseEvent) => {
-      if (!middleDrag) return
+    const onPointerMove = (event: PointerEvent) => {
+      if (event.pointerId !== middleDragPointerId || !middleDrag) return
       const delta = middleDragDelta(middleDrag, event)
       middleDrag = { screenX: event.screenX, screenY: event.screenY }
       api.canvasPan(delta.deltaX, delta.deltaY)
     }
 
-    const onMouseUp = (event: MouseEvent) => {
-      if (event.button === 1) middleDrag = null
+    const onPointerUp = (event: PointerEvent) => {
+      if (event.pointerId === middleDragPointerId) {
+        middleDrag = null
+        middleDragPointerId = null
+      }
     }
 
     const cleanup = () => {
       middleDrag = null
+      middleDragPointerId = null
     }
 
     window.addEventListener('wheel', onWheel, { passive: false })
-    window.addEventListener('mousedown', onMouseDown)
-    window.addEventListener('mousemove', onMouseMove)
-    window.addEventListener('mouseup', onMouseUp)
+    window.addEventListener('pointerdown', onPointerDown)
+    window.addEventListener('pointermove', onPointerMove)
+    window.addEventListener('pointerup', onPointerUp)
     window.addEventListener('blur', cleanup)
     return () => {
       window.removeEventListener('wheel', onWheel)
-      window.removeEventListener('mousedown', onMouseDown)
-      window.removeEventListener('mousemove', onMouseMove)
-      window.removeEventListener('mouseup', onMouseUp)
+      window.removeEventListener('pointerdown', onPointerDown)
+      window.removeEventListener('pointermove', onPointerMove)
+      window.removeEventListener('pointerup', onPointerUp)
       window.removeEventListener('blur', cleanup)
       cleanup()
     }

--- a/src/shared/gesture-utils.ts
+++ b/src/shared/gesture-utils.ts
@@ -119,13 +119,13 @@ export function classifyViewportWheel(event: Pick<WheelEvent, 'metaKey' | 'ctrlK
   }
 }
 
-export function shouldStartMouseViewportPan(event: Pick<MouseEvent, 'button'>): boolean {
+export function shouldStartMouseViewportPan(event: Pick<PointerEvent, 'button'>): boolean {
   return event.button === 1
 }
 
 export function middleDragDelta(
   previous: { screenX: number; screenY: number },
-  next: Pick<MouseEvent, 'screenX' | 'screenY'>,
+  next: Pick<PointerEvent, 'screenX' | 'screenY'>,
 ) {
   return {
     deltaX: previous.screenX - next.screenX,


### PR DESCRIPTION
Closes #126

## Summary

- Replaces all mouse-event call sites in `src/renderer/` with pointer events per spec §6 I8
- Flips `local/no-mouse-events` ESLint rule from `warn` → `error`
- Zero `no-mouse-events` violations after migration (one intentional suppress for Electron WebContentsView quirk in `App.tsx`)

## Changes

**Hover handlers** (`onMouseEnter/Leave` → `onPointerEnter/Leave`):
- `EntityChrome`, `CanvasItemChrome`, `FileChrome`, `PageChrome`, `EdgeLayer`, `InspectTree`, `PagePane`, `useClearInspectHoverOnLeave`

**Stop-propagation only** (`onMouseDown` → `onPointerDown`):
- `MarkdownEditor`, `InlineEditLabel`, `PagePopup`, `CanvasItemPopup`, `TextSizeDropdown`, `StickyBodyLayer`, `WireframeRenderer`, `WireframeNodeRenderer`
- `ShapeBodyLayer`: duplicate `onMouseDown` removed (identical `onPointerDown` already present)

**Drag gestures**:
- `GroupRenameLabel`: migrated from `mousemove/mouseup` window listeners to `pointermove/pointerup` with `pointerId` filtering
- `WireframeRenderer`: `handleNodePointerDown` accepts `React.PointerEvent`, uses `pointermove/pointerup` with `pointerId` tracking; commit-reorder effect migrated to `pointerup`
- `useViewportWheelAndMiddlePan` + `useCanvasViewportGestures`: middle-button pan migrated from `mousedown/mousemove/mouseup` to `pointerdown/pointermove/pointerup` with `pointerId` tracking
- `ResizeHandles`: `beginResize` prop type `MouseEvent` → `PointerEvent`
- `optionDragCopy`: mouse-event fallback removed from `installOptionAwareDragListeners`; `startOptionAwareGroupDrag` event type narrowed to `PointerEvent | ReactPointerEvent`
- `gesture-utils`: `shouldStartMouseViewportPan` and `middleDragDelta` types updated to `PointerEvent`

**Intentional suppress**: `App.tsx` keeps `mouseleave` on `documentElement` with `// eslint-disable-next-line local/no-mouse-events` — `pointerleave` does not fire when the cursor moves to a sibling Electron WebContentsView (the toolbar), making `mouseleave` the only reliable "cursor left this webcontents" signal here.

## Verification

- `pnpm test:unit`: 583 tests pass
- `pnpm typecheck`: no new errors (pre-existing node-tsconfig errors unchanged)
- `npx eslint src/renderer/`: zero `local/no-mouse-events` violations

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrTXQXKzfsbBUZ9Comvvxd)_