### PR TITLE
feat: manifest-driven component extensions + Vite host-route template

### DIFF
--- a/.claude/skills/specular/SKILL.md
+++ b/.claude/skills/specular/SKILL.md
@@ -232,6 +232,45 @@ Keep entries terse: one-line description, observed behavior, expected behavior. 
 
 When a limitation is fixed (confirmed by testing, not just by a closed issue), **remove it from the "Known CLI limitations" list above** and close or note it on the GitHub issue. A stale warning is worse than no warning.
 
+## Component rendering (React / Svelte / Vue)
+
+Specular can render live component files (`.tsx`, `.jsx`, `.svelte`, `.vue`)
+from a connected Vite dev server directly on the canvas. The extension set is
+controlled by a JSON manifest in the app's userData directory
+(`component-extensions.json`); edit it to add or remove extensions without
+rebuilding the app.
+
+### Setting up a project
+
+The canvas talks to the user's own Vite dev server via a `/__specular?path=`
+route. That route is not built into Vite — you add it by stamping a host-route
+plugin into the project.
+
+A self-contained template is bundled with the app at
+`resources/specular-host.ts`. To locate it at runtime:
+
+```bash
+# Find the bundled template (macOS packaged app)
+ls "$(dirname "$(which specular)")/../Resources/specular-host.ts" 2>/dev/null \
+  || ls "$(dirname "$(which specular)")/../../Resources/specular-host.ts" 2>/dev/null
+```
+
+To set up a project, copy the template into the repo and wire it into `vite.config`:
+
+```bash
+cp /path/to/specular-host.ts ./specular-host.ts
+```
+
+```ts
+// vite.config.ts
+import specularHost from './specular-host'
+export default defineConfig({ plugins: [specularHost(), yourOtherPlugins()] })
+```
+
+The project must already have the framework's Vite plugin (`@vitejs/plugin-react`,
+`@sveltejs/vite-plugin-svelte`, or `@vitejs/plugin-vue`). No separate `npm install`
+is required for the template itself.
+
 ## See also
 
 - `agent-browser` skill — deeper browser-automation reference (invoked via

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -34,7 +34,9 @@
 
     "vite.main.config.ts",
     "vite.preload.config.ts",
-    "vite.renderer.config.ts"
+    "vite.renderer.config.ts",
+
+    "resources/specular-host.ts"
   ],
   "rules": {
     "unused-dependencies": "warn"

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -17,6 +17,7 @@ const config: ForgeConfig = {
       'resources/specular-cli.sh',
       'resources/skills',
       'resources/bin',
+      'resources/specular-host.ts',
     ],
     ignore: [],
     ...(isSigning && {

--- a/resources/skills/specular/SKILL.md
+++ b/resources/skills/specular/SKILL.md
@@ -215,6 +215,45 @@ active page.
 - **`upsert --json` ignores `x`/`y`/`width` for `file` entities** — text entities honor explicit coordinates; file entities (markdown, wireframe, image) are always placed by layout. Images additionally ignore `width` and land at 128×128.
 - **Search box `fill` + `click` may not trigger navigation** — `fill` may not fire input events. If a click on Search fails, re-fill and retry, or click an autocomplete option ref instead.
 
+## Component rendering (React / Svelte / Vue)
+
+Specular can render live component files (`.tsx`, `.jsx`, `.svelte`, `.vue`)
+from a connected Vite dev server directly on the canvas. The extension set is
+controlled by a JSON manifest in the app's userData directory
+(`component-extensions.json`); edit it to add or remove extensions without
+rebuilding the app.
+
+### Setting up a project
+
+The canvas talks to the user's own Vite dev server via a `/__specular?path=`
+route. That route is not built into Vite — you add it by stamping a host-route
+plugin into the project.
+
+A self-contained template is bundled with the app at
+`resources/specular-host.ts`. To locate it at runtime:
+
+```bash
+# Find the bundled template (macOS packaged app)
+ls "$(dirname "$(which specular)")/../Resources/specular-host.ts" 2>/dev/null \
+  || ls "$(dirname "$(which specular)")/../../Resources/specular-host.ts" 2>/dev/null
+```
+
+To set up a project, copy the template into the repo and wire it into `vite.config`:
+
+```bash
+cp /path/to/specular-host.ts ./specular-host.ts
+```
+
+```ts
+// vite.config.ts
+import specularHost from './specular-host'
+export default defineConfig({ plugins: [specularHost(), yourOtherPlugins()] })
+```
+
+The project must already have the framework's Vite plugin (`@vitejs/plugin-react`,
+`@sveltejs/vite-plugin-svelte`, or `@vitejs/plugin-vue`). No separate `npm install`
+is required for the template itself.
+
 ## See also
 
 - `agent-browser` skill — deeper browser-automation reference (invoked via

--- a/resources/specular-host.ts
+++ b/resources/specular-host.ts
@@ -1,0 +1,175 @@
+/**
+ * specular-host.ts — Specular component-render host route for Vite.
+ *
+ * HOW TO USE
+ * ----------
+ * 1. Copy this file into your project (e.g. `specular-host.ts` at the repo root).
+ * 2. Add one import and one line to your `vite.config`:
+ *
+ *    import specularHost from './specular-host'
+ *    export default defineConfig({ plugins: [specularHost(), yourOtherPlugins()] })
+ *
+ * 3. Your project must already have the framework's Vite plugin installed:
+ *    - React:  @vitejs/plugin-react (or plugin-react-swc)
+ *    - Svelte: @sveltejs/vite-plugin-svelte
+ *    - Vue:    @vitejs/plugin-vue
+ *
+ * This plugin registers `GET /__specular?path=<repo-relative-path>` and
+ * returns an HTML host document that dynamically imports the component module,
+ * picks a framework-specific mount shim based on the file extension, and mounts
+ * the module's default export. HMR re-mounts the component on hot update without
+ * a full page reload. Compile errors surface through Vite's existing overlay;
+ * runtime mount errors are caught and displayed in-frame.
+ *
+ * CONTRACT
+ * --------
+ * The `/__specular?path=` route shape is part of Specular's stable API surface
+ * and must not change without a corresponding update to the app.
+ *
+ * FRAMEWORKS SUPPORTED
+ * --------------------
+ * - React  (.tsx, .jsx) — requires react-dom/client
+ * - Svelte (.svelte)    — Svelte 5 mount() or Svelte 4 new Component()
+ * - Vue    (.vue)       — requires vue
+ *
+ * Mount shims are lazily imported so a project missing a framework's runtime
+ * never loads that shim.
+ */
+
+import type { Plugin, ViteDevServer } from 'vite'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+function hostHtml(componentPath: string): string {
+  const ext = componentPath.split('.').pop()?.toLowerCase() ?? ''
+
+  // language=HTML
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body, #root { width: 100%; height: 100%; }
+    #specular-error {
+      position: fixed; inset: 0; display: none;
+      background: #1a0010; color: #ff6b9d;
+      font: 13px/1.5 ui-monospace, monospace;
+      padding: 24px; white-space: pre-wrap; overflow: auto;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <div id="specular-error"></div>
+  <script type="module">
+    const path = ${JSON.stringify(componentPath)}
+    const ext = ${JSON.stringify(ext)}
+
+    function showError(err) {
+      const el = document.getElementById('specular-error')
+      el.style.display = 'block'
+      el.textContent = String(err?.stack ?? err)
+    }
+
+    async function mountReact(Component, root) {
+      const { createRoot } = await import('react-dom/client')
+      const { createElement } = await import('react')
+      const reactRoot = createRoot(root)
+      reactRoot.render(createElement(Component))
+      return () => reactRoot.unmount()
+    }
+
+    async function mountSvelte(Component, root) {
+      // Svelte 5: mount(Component, { target })
+      // Svelte 4: new Component({ target })
+      if (typeof Component.mount === 'function') {
+        const { mount, unmount } = await import('svelte')
+        const instance = mount(Component, { target: root })
+        return () => unmount(instance)
+      }
+      const instance = new Component({ target: root })
+      return () => instance.$destroy()
+    }
+
+    async function mountVue(Component, root) {
+      const { createApp } = await import('vue')
+      const app = createApp(Component)
+      app.mount(root)
+      return () => app.unmount()
+    }
+
+    let unmountCurrent = null
+
+    async function mount() {
+      const root = document.getElementById('root')
+      if (unmountCurrent) {
+        try { unmountCurrent() } catch {}
+        unmountCurrent = null
+        root.innerHTML = ''
+      }
+
+      try {
+        const mod = await import(/* @vite-ignore */ path)
+        const Component = mod.default
+        if (!Component) throw new Error('Module has no default export: ' + path)
+
+        if (ext === 'tsx' || ext === 'jsx') {
+          unmountCurrent = await mountReact(Component, root)
+        } else if (ext === 'svelte') {
+          unmountCurrent = await mountSvelte(Component, root)
+        } else if (ext === 'vue') {
+          unmountCurrent = await mountVue(Component, root)
+        } else {
+          throw new Error('Unsupported extension: .' + ext)
+        }
+
+        document.getElementById('specular-error').style.display = 'none'
+      } catch (err) {
+        showError(err)
+      }
+    }
+
+    mount()
+
+    if (import.meta.hot) {
+      import.meta.hot.accept(/* @vite-ignore */ path, (newMod) => {
+        if (newMod) mount()
+      })
+    }
+  </script>
+</body>
+</html>`
+}
+
+export default function specularHost(): Plugin {
+  let server: ViteDevServer | undefined
+
+  return {
+    name: 'specular-host',
+    apply: 'serve',
+
+    configureServer(s) {
+      server = s
+
+      s.middlewares.use((req, res, next) => {
+        const url = req.url ?? ''
+        if (!url.startsWith('/__specular')) return next()
+
+        const qs = new URL(url, 'http://localhost').searchParams
+        const path = qs.get('path')
+        if (!path) {
+          res.statusCode = 400
+          res.end('Missing ?path= parameter')
+          return
+        }
+
+        const html = hostHtml(`/${path}`)
+        res.setHeader('Content-Type', 'text/html; charset=utf-8')
+        res.statusCode = 200
+        res.end(html)
+      })
+    },
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,6 +30,7 @@ import {
   initDevServerManager,
   shutdownDevServerManager,
 } from './runtime/dev-server-manager'
+import { initComponentExtensions } from './runtime/component-extensions'
 import { spawn as nodeSpawn } from 'node:child_process'
 import { initializeDocObservers } from './runtime/workspace-observers'
 import { cancelActive as cancelActiveInteraction } from './runtime/interaction-controller'
@@ -124,6 +125,7 @@ app.whenReady().then(async () => {
 
   identifyInstall()
   configureBundledAgentBrowser()
+  initComponentExtensions(app.getPath('userData'))
   registerBuiltInPlugins()
   initDevServerManager({
     userDataDir: app.getPath('userData'),

--- a/src/main/plugins/builtin/component-render.ts
+++ b/src/main/plugins/builtin/component-render.ts
@@ -1,13 +1,15 @@
 /**
  * Built-in component-render plugin.
  *
- * Claims `.tsx` and `.jsx` file entities. The drop handler stamps
- * `metadata.componentRender = { repoId, repoRelativePath }` at drop time
- * for diagnostics, but resolveUrl re-derives the repo from `entity.file`
- * on every call. That way a file dropped while the wrong repo was the
- * only match, or dropped before its repo was connected, heals the
- * moment the right repo shows up — without needing the canvas to be
- * re-saved.
+ * Claims component file entities (default: .tsx, .jsx, .svelte, .vue). The
+ * extension set is driven by the userData `component-extensions.json` manifest
+ * so it can be changed without rebuilding the app.
+ *
+ * The drop handler stamps `metadata.componentRender = { repoId, repoRelativePath }`
+ * at drop time for diagnostics, but resolveUrl re-derives the repo from
+ * `entity.file` on every call. That way a file dropped while the wrong repo
+ * was the only match, or dropped before its repo was connected, heals the
+ * moment the right repo shows up — without needing the canvas to be re-saved.
  *
  * Returning null (file outside any connected repo, or dev server failed
  * to start) tells the host to render the placeholder.
@@ -17,16 +19,15 @@ import {
   findRepoForPath,
   urlForComponent,
 } from '../../runtime/dev-server-manager'
+import { isComponentFile } from '../../runtime/component-extensions'
 import type { WcvPageRendererClaim } from '../registry'
-
-const COMPONENT_EXTENSIONS = /\.(tsx|jsx)$/i
 
 export const componentRenderPlugin: WcvPageRendererClaim = {
   id: 'specular.component-render',
   kind: 'wcv-page',
   rendererTag: 'component',
   editable: false,
-  claims: (entity) => COMPONENT_EXTENSIONS.test(entity.file),
+  claims: (entity) => isComponentFile(entity.file),
   resolveUrl: async (entity) => {
     const repo = findRepoForPath(entity.file)
     if (!repo) return null

--- a/src/main/runtime/component-extensions.ts
+++ b/src/main/runtime/component-extensions.ts
@@ -1,0 +1,71 @@
+/**
+ * Component-render extension manifest.
+ *
+ * Reads a small JSON file from userData (`component-extensions.json`) that
+ * controls which file extensions are claimed by the component-render plugin.
+ * Seeded with defaults on first run; a missing or corrupt file falls back
+ * silently. Takes effect on the next app launch (re-read at boot).
+ *
+ * Designed for testability: inject userDataDir via initComponentExtensions().
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const MANIFEST_FILENAME = 'component-extensions.json'
+
+export const DEFAULT_COMPONENT_EXTENSIONS = ['tsx', 'jsx', 'svelte', 'vue']
+
+interface ComponentExtensionsManifest {
+  extensions: string[]
+}
+
+let extensions: string[] = [...DEFAULT_COMPONENT_EXTENSIONS]
+
+function isValidManifest(parsed: unknown): parsed is ComponentExtensionsManifest {
+  return (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    Array.isArray((parsed as ComponentExtensionsManifest).extensions) &&
+    (parsed as ComponentExtensionsManifest).extensions.length > 0 &&
+    (parsed as ComponentExtensionsManifest).extensions.every((e) => typeof e === 'string')
+  )
+}
+
+export function initComponentExtensions(userDataDir: string): void {
+  const filePath = join(userDataDir, MANIFEST_FILENAME)
+
+  if (!existsSync(filePath)) {
+    const manifest: ComponentExtensionsManifest = { extensions: DEFAULT_COMPONENT_EXTENSIONS }
+    try {
+      writeFileSync(filePath, JSON.stringify(manifest, null, 2), 'utf8')
+    } catch {
+      // Non-fatal if userData dir isn't writable yet; defaults still apply.
+    }
+    extensions = [...DEFAULT_COMPONENT_EXTENSIONS]
+    return
+  }
+
+  try {
+    const raw = readFileSync(filePath, 'utf8')
+    const parsed: unknown = JSON.parse(raw)
+    if (isValidManifest(parsed)) {
+      extensions = parsed.extensions
+    } else {
+      extensions = [...DEFAULT_COMPONENT_EXTENSIONS]
+    }
+  } catch {
+    extensions = [...DEFAULT_COMPONENT_EXTENSIONS]
+  }
+}
+
+/** Returns true when `filePath` matches one of the loaded component extensions. */
+export function isComponentFile(filePath: string): boolean {
+  const lower = filePath.toLowerCase()
+  return extensions.some((ext) => lower.endsWith(`.${ext}`))
+}
+
+/** Test-only: reset to defaults. */
+export function __resetComponentExtensionsForTests(): void {
+  extensions = [...DEFAULT_COMPONENT_EXTENSIONS]
+}

--- a/tests/unit/component-render-plugin.test.ts
+++ b/tests/unit/component-render-plugin.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { EventEmitter } from 'node:events'
@@ -13,6 +13,11 @@ import {
   initDevServerManager,
   shutdownDevServerManager,
 } from '../../src/main/runtime/dev-server-manager'
+import {
+  initComponentExtensions,
+  __resetComponentExtensionsForTests,
+  DEFAULT_COMPONENT_EXTENSIONS,
+} from '../../src/main/runtime/component-extensions'
 import type { PersistedFileEntity } from '../../src/shared/types'
 
 function fileEntity(file: string): PersistedFileEntity {
@@ -83,6 +88,7 @@ describe('componentRenderPlugin.resolveUrl', () => {
 
   beforeEach(() => {
     __resetDevServerManagerForTests()
+    __resetComponentExtensionsForTests()
     dir = mkdtempSync(join(tmpdir(), 'specular-component-render-'))
     pendingChildren = []
     initDevServerManager({
@@ -97,6 +103,7 @@ describe('componentRenderPlugin.resolveUrl', () => {
 
   afterEach(async () => {
     await shutdownDevServerManager()
+    __resetComponentExtensionsForTests()
     rmSync(dir, { recursive: true, force: true })
   })
 
@@ -120,5 +127,95 @@ describe('componentRenderPlugin.resolveUrl', () => {
     expect(url).toBe(
       'http://localhost:5173/__specular?path=src%2FButton.tsx',
     )
+  })
+
+  it('resolveUrl works for .svelte files inside a connected repo', async () => {
+    connectRepo('/Users/alice/Developer/my-app')
+    const promise = componentRenderPlugin.resolveUrl(
+      fileEntity('/Users/alice/Developer/my-app/src/Counter.svelte'),
+    )
+    await Promise.resolve()
+    pendingChildren[0].stdout.push('  Local:   http://localhost:5173/\n')
+    const url = await promise
+    expect(url).toBe('http://localhost:5173/__specular?path=src%2FCounter.svelte')
+  })
+
+  it('resolveUrl works for .vue files inside a connected repo', async () => {
+    connectRepo('/Users/alice/Developer/my-app')
+    const promise = componentRenderPlugin.resolveUrl(
+      fileEntity('/Users/alice/Developer/my-app/src/App.vue'),
+    )
+    await Promise.resolve()
+    pendingChildren[0].stdout.push('  Local:   http://localhost:5173/\n')
+    const url = await promise
+    expect(url).toBe('http://localhost:5173/__specular?path=src%2FApp.vue')
+  })
+
+  it('returns null for .svelte files outside every connected repo', async () => {
+    connectRepo('/Users/alice/Developer/my-app')
+    expect(await componentRenderPlugin.resolveUrl(fileEntity('/elsewhere/Counter.svelte'))).toBeNull()
+  })
+})
+
+describe('componentRenderPlugin.claims — manifest-driven extensions', () => {
+  let dir: string
+
+  beforeEach(() => {
+    __resetComponentExtensionsForTests()
+    dir = mkdtempSync(join(tmpdir(), 'specular-ext-manifest-'))
+  })
+
+  afterEach(() => {
+    __resetComponentExtensionsForTests()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('claims tsx and jsx by default', () => {
+    expect(componentRenderPlugin.claims(fileEntity('/repo/Button.tsx'))).toBe(true)
+    expect(componentRenderPlugin.claims(fileEntity('/repo/Input.jsx'))).toBe(true)
+  })
+
+  it('claims svelte and vue by default', () => {
+    expect(componentRenderPlugin.claims(fileEntity('/repo/Counter.svelte'))).toBe(true)
+    expect(componentRenderPlugin.claims(fileEntity('/repo/App.vue'))).toBe(true)
+  })
+
+  it('does not claim .ts, .js, .md, or .json files', () => {
+    expect(componentRenderPlugin.claims(fileEntity('/repo/utils.ts'))).toBe(false)
+    expect(componentRenderPlugin.claims(fileEntity('/repo/index.js'))).toBe(false)
+    expect(componentRenderPlugin.claims(fileEntity('/repo/README.md'))).toBe(false)
+    expect(componentRenderPlugin.claims(fileEntity('/repo/config.json'))).toBe(false)
+  })
+
+  it('seeds a manifest file with defaults on first run', () => {
+    initComponentExtensions(dir)
+    const manifest = JSON.parse(
+      require('node:fs').readFileSync(join(dir, 'component-extensions.json'), 'utf8'),
+    )
+    expect(manifest.extensions).toEqual(DEFAULT_COMPONENT_EXTENSIONS)
+  })
+
+  it('reads custom extensions from the manifest', () => {
+    writeFileSync(
+      join(dir, 'component-extensions.json'),
+      JSON.stringify({ extensions: ['tsx', 'astro'] }),
+      'utf8',
+    )
+    initComponentExtensions(dir)
+    expect(componentRenderPlugin.claims(fileEntity('/repo/Page.astro'))).toBe(true)
+    expect(componentRenderPlugin.claims(fileEntity('/repo/Counter.svelte'))).toBe(false)
+  })
+
+  it('falls back to defaults when the manifest is corrupt', () => {
+    writeFileSync(join(dir, 'component-extensions.json'), 'not json', 'utf8')
+    initComponentExtensions(dir)
+    expect(componentRenderPlugin.claims(fileEntity('/repo/Button.tsx'))).toBe(true)
+    expect(componentRenderPlugin.claims(fileEntity('/repo/App.vue'))).toBe(true)
+  })
+
+  it('falls back to defaults when the manifest has an invalid shape', () => {
+    writeFileSync(join(dir, 'component-extensions.json'), JSON.stringify({ extensions: [] }), 'utf8')
+    initComponentExtensions(dir)
+    expect(componentRenderPlugin.claims(fileEntity('/repo/Button.tsx'))).toBe(true)
   })
 })


### PR DESCRIPTION
Closes #135

## Summary

- **Manifest-driven extension set**: moves the component-render plugin's hardcoded `.tsx`/`.jsx` regex to a `component-extensions.json` file in the app's `userData` directory. Seeded with `tsx`, `jsx`, `svelte`, `vue` on first run; a missing or corrupt file falls back silently to defaults. Editing the manifest changes which files are claimed as components with no rebuild.
- **`initComponentExtensions(userDataDir)`** called at boot in `src/main/index.ts` before `registerBuiltInPlugins()`, following the same injection pattern as `initDevServerManager`.
- **Vite host-route template** (`resources/specular-host.ts`): a self-contained Vite plugin (copy-paste, no npm package) that registers `GET /__specular?path=` and returns an HTML host page with lazy-loaded React/Svelte/Vue mount shims and HMR support. Bundled as an extra resource in `forge.config.ts`.
- **Skill docs** updated in both `resources/skills/specular/SKILL.md` and `.claude/skills/specular/SKILL.md` with a "Component rendering" section explaining the manifest and how to stamp the template into a project.
- **Tests extended**: new manifest-driven `claims()` tests and `resolveUrl` tests for `.svelte`/`.vue` files; all 593 unit tests pass.

## Test plan

- [ ] `pnpm test:unit` passes (593 tests, all green)
- [ ] Drop a `.svelte` or `.vue` file from a connected repo — entity broadcasts `rendererTag: 'component'`
- [ ] Edit `component-extensions.json` in userData to remove `svelte`, relaunch — `.svelte` files no longer claimed
- [ ] Copy `resources/specular-host.ts` into a React/Svelte/Vue project, wire into `vite.config`, visit `/__specular?path=src/MyComponent.tsx` — component renders live

---
_Generated by [Claude Code](https://claude.ai/code/session_0184cpNby69nR6eFzVHy7rrD)_