### PR TITLE
Fix neutral sticky note text unreadable in dark mode

### DIFF
--- a/src/main/runtime/canvas-layout-data.ts
+++ b/src/main/runtime/canvas-layout-data.ts
@@ -511,6 +511,7 @@ export function toolbarSelectionData(): ToolbarSelectionData {
       activeTool: uiActiveTool(),
       drawBrushType: getToolDefaults().draw.brushType,
       drawColor: getToolDefaults().draw.color,
+      stickyColor: getToolDefaults()['add-sticky'].color,
     }
   }
 
@@ -548,5 +549,6 @@ export function toolbarSelectionData(): ToolbarSelectionData {
     activeTool: uiActiveTool(),
     drawBrushType: getToolDefaults().draw.brushType,
     drawColor: getToolDefaults().draw.color,
+    stickyColor: getToolDefaults()['add-sticky'].color,
   }
 }

--- a/src/main/runtime/canvas-layout-data.ts
+++ b/src/main/runtime/canvas-layout-data.ts
@@ -303,6 +303,8 @@ function buildPlacementPreview(tool: ReturnType<typeof uiActiveTool>): PendingPl
       : tool.kind === 'add-text'
         ? 'plain'
         : undefined
+  const color =
+    tool.kind === 'add-sticky' ? getToolDefaults()['add-sticky'].color : undefined
   const customSize = tool.kind === 'add-page' ? tool.customSize === true : false
   const sourcePageId = tool.kind === 'add-page' ? tool.sourcePageId : undefined
   // shapeKind moved to tool defaults per ADR 0009 — preview reads the persisted
@@ -320,6 +322,7 @@ function buildPlacementPreview(tool: ReturnType<typeof uiActiveTool>): PendingPl
     presetIndex,
     shapeKind,
     textStyle,
+    color,
     width: isText
       ? DEFAULT_TEXT_WIDTH
       : isFile

--- a/src/renderer/above-view/StickyBodyLayer.tsx
+++ b/src/renderer/above-view/StickyBodyLayer.tsx
@@ -297,7 +297,7 @@ function StickyCard({
       height={note.height}
       isDark={isDark}
       isSelected={isSelected}
-      background={resolveCanvasColor(note.color, { role: 'fill', isDark: false, palette: 'soft' })}
+      background={resolveCanvasColor(note.color, { role: 'fill', isDark, palette: 'soft' })}
       textStyle={textStyle}
       isAuto={isAuto}
       shellRef={shellRef}

--- a/src/renderer/above-view/StickyBodyLayer.tsx
+++ b/src/renderer/above-view/StickyBodyLayer.tsx
@@ -24,7 +24,7 @@ import { memo, useEffect, useRef, useState } from 'react'
 import Markdown from 'react-markdown'
 import { PLAIN_TEXT_PLACEHOLDER } from '../../shared/constants'
 import type { CanvasSceneTextEntity, TextEntityStyle } from '../../shared/types'
-import { NEUTRAL_STORAGE, resolveCanvasColor } from '../../shared/canvas-colors'
+import { resolveCanvasColor } from '../../shared/canvas-colors'
 import { MarkdownEditor } from '../shared/MarkdownEditor'
 import { remarkLineBreaks } from '../shared/remark-line-breaks'
 import { lineHeightForTextSize } from './TextSizeDropdown'
@@ -245,17 +245,10 @@ function StickyCard({
     }
   }, [isAuto, note.id, onUpdateSize])
 
-  // Non-plain stickies: the neutral slot is theme-aware (dark fill in dark mode);
-  // hue slots keep light pastel fills in both themes so they always use dark ink.
-  const isNeutralColor = note.color === NEUTRAL_STORAGE
-  const editorIsDark = isPlain ? isDark : isNeutralColor && isDark
-  const textColor = isPlain
-    ? isDark
-      ? '#e7e5e4'
-      : '#1c1917'
-    : isNeutralColor
-      ? resolveCanvasColor(note.color, { role: 'ink', isDark })
-      : '#1c1917'
+  // Stickies render with a light fill in both themes (neutral is pinned light
+  // below via `isDark: false`), so non-plain text always uses dark ink.
+  const editorIsDark = isPlain ? isDark : false
+  const textColor = isPlain ? (isDark ? '#e7e5e4' : '#1c1917') : '#1c1917'
   const placeholder = isPlain ? PLAIN_TEXT_PLACEHOLDER : 'Type a note...'
 
   const innerColumnStyle: React.CSSProperties =
@@ -304,7 +297,7 @@ function StickyCard({
       height={note.height}
       isDark={isDark}
       isSelected={isSelected}
-      background={resolveCanvasColor(note.color, { role: 'fill', isDark, palette: 'soft' })}
+      background={resolveCanvasColor(note.color, { role: 'fill', isDark: false, palette: 'soft' })}
       textStyle={textStyle}
       isAuto={isAuto}
       shellRef={shellRef}

--- a/src/renderer/above-view/StickyBodyLayer.tsx
+++ b/src/renderer/above-view/StickyBodyLayer.tsx
@@ -24,7 +24,7 @@ import { memo, useEffect, useRef, useState } from 'react'
 import Markdown from 'react-markdown'
 import { PLAIN_TEXT_PLACEHOLDER } from '../../shared/constants'
 import type { CanvasSceneTextEntity, TextEntityStyle } from '../../shared/types'
-import { resolveCanvasColor } from '../../shared/canvas-colors'
+import { NEUTRAL_STORAGE, resolveCanvasColor } from '../../shared/canvas-colors'
 import { MarkdownEditor } from '../shared/MarkdownEditor'
 import { remarkLineBreaks } from '../shared/remark-line-breaks'
 import { lineHeightForTextSize } from './TextSizeDropdown'
@@ -245,10 +245,17 @@ function StickyCard({
     }
   }, [isAuto, note.id, onUpdateSize])
 
-  // Stickies always sit on a light colored background; pass isDark=false so
-  // CodeMirror renders dark text matching the view-mode color below.
-  const editorIsDark = isPlain ? isDark : false
-  const textColor = isPlain ? (isDark ? '#e7e5e4' : '#1c1917') : '#1c1917'
+  // Non-plain stickies: the neutral slot is theme-aware (dark fill in dark mode);
+  // hue slots keep light pastel fills in both themes so they always use dark ink.
+  const isNeutralColor = note.color === NEUTRAL_STORAGE
+  const editorIsDark = isPlain ? isDark : isNeutralColor && isDark
+  const textColor = isPlain
+    ? isDark
+      ? '#e7e5e4'
+      : '#1c1917'
+    : isNeutralColor
+      ? resolveCanvasColor(note.color, { role: 'ink', isDark })
+      : '#1c1917'
   const placeholder = isPlain ? PLAIN_TEXT_PLACEHOLDER : 'Type a note...'
 
   const innerColumnStyle: React.CSSProperties =

--- a/src/renderer/canvas-bg/CanvasGridSurface.tsx
+++ b/src/renderer/canvas-bg/CanvasGridSurface.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { PLAIN_TEXT_PLACEHOLDER } from '../../shared/constants'
 import type { TextEntityStyle } from '../../shared/types'
+import { resolveCanvasColor } from '../../shared/canvas-colors'
 import { buildCanvasGridStyle, drawCanvasGrid } from './canvasGridStyle'
 
 function previewBoxStyle(
@@ -114,6 +115,7 @@ export function PlacementPreviewLayer({
     entityKind?: string
     shapeKind?: string
     textStyle?: TextEntityStyle
+    color?: string
     left: number
     top: number
     width: number
@@ -124,6 +126,7 @@ export function PlacementPreviewLayer({
   const isTextEntity = preview.entityKind === 'text'
   const isFileEntity = preview.entityKind === 'file'
   const isShape = preview.entityKind === 'shape'
+  const isStickyPreview = isTextEntity && preview.textStyle === 'sticky'
   if (isTextEntity && preview.textStyle === 'plain') {
     return (
       <div
@@ -183,18 +186,29 @@ export function PlacementPreviewLayer({
       className={`pointer-events-none absolute border ${isTextEntity || isFileEntity ? '' : 'rounded-[8px]'}`}
       style={{
         ...previewBoxStyle(isDark, preview),
-        ...(isTextEntity
+        ...(isStickyPreview && preview.color
           ? {
-              background: 'rgba(254, 240, 138, 0.7)',
-              borderColor: 'rgba(202, 138, 4, 0.4)',
+              // Stickies always render with a light fill (neutral pinned light),
+              // so pass isDark: false to keep the preview matching placed stickies.
+              background: resolveCanvasColor(preview.color, {
+                role: 'fill',
+                isDark: false,
+                palette: 'soft',
+              }),
+              borderColor: 'rgba(87, 83, 78, 0.18)',
             }
-          : isFileEntity
+          : isTextEntity
             ? {
-                background: isDark ? 'rgba(214, 211, 209, 0.15)' : 'rgba(250, 250, 249, 0.7)',
-                borderColor: isDark ? 'rgba(168, 162, 158, 0.4)' : 'rgba(120, 113, 108, 0.4)',
-                borderRadius: 4,
+                background: 'rgba(254, 240, 138, 0.7)',
+                borderColor: 'rgba(202, 138, 4, 0.4)',
               }
-            : {}),
+            : isFileEntity
+              ? {
+                  background: isDark ? 'rgba(214, 211, 209, 0.15)' : 'rgba(250, 250, 249, 0.7)',
+                  borderColor: isDark ? 'rgba(168, 162, 158, 0.4)' : 'rgba(120, 113, 108, 0.4)',
+                  borderRadius: 4,
+                }
+              : {}),
       }}
     />
   )

--- a/src/renderer/canvas-bg/CanvasGridSurface.tsx
+++ b/src/renderer/canvas-bg/CanvasGridSurface.tsx
@@ -188,11 +188,9 @@ export function PlacementPreviewLayer({
         ...previewBoxStyle(isDark, preview),
         ...(isStickyPreview && preview.color
           ? {
-              // Stickies always render with a light fill (neutral pinned light),
-              // so pass isDark: false to keep the preview matching placed stickies.
               background: resolveCanvasColor(preview.color, {
                 role: 'fill',
-                isDark: false,
+                isDark,
                 palette: 'soft',
               }),
               borderColor: 'rgba(87, 83, 78, 0.18)',

--- a/src/renderer/canvas-bg/canvasBgSelectors.ts
+++ b/src/renderer/canvas-bg/canvasBgSelectors.ts
@@ -29,6 +29,7 @@ export function buildPendingPlacementPreview(
     entityKind: layoutData.pendingPlacement.entityKind,
     shapeKind: layoutData.pendingPlacement.shapeKind,
     textStyle: layoutData.pendingPlacement.textStyle,
+    color: layoutData.pendingPlacement.color,
     left: layoutData.canvasOrigin.x + layoutData.pan.x + snappedX * layoutData.zoom,
     top: layoutData.canvasOrigin.y + layoutData.pan.y + snappedY * layoutData.zoom,
     width: layoutData.pendingPlacement.width * layoutData.zoom,

--- a/src/renderer/shared/CustomIcons.tsx
+++ b/src/renderer/shared/CustomIcons.tsx
@@ -402,9 +402,9 @@ export const AddShapeToolIcon = makeToolbarIcon(addShapeUrl, addShapeDarkUrl, 'A
 //
 // Geometry ported from icons/toolbar/add-sticky.svg. Light mode keeps the
 // paper pale via lighten(tint, 0.45) → lighten(tint, 0.15). Dark mode is
-// split: neutral darkens hard (0.55 → 0.70, matching the original raster)
-// so it doesn't outshine the toolbar surface and bleed past strokes; hue
-// stickies darken lightly (0.20 → 0.40) so the chroma stays readable.
+// split: neutral darkens hard (0.55 → 0.70, matching the original raster);
+// hues darken to 0.40 → 0.55 so the fill sits below the #C4BEBB stroke in
+// value and the outline reads clearly. Less darkening washed the stroke out.
 
 type AddStickyIconProps = {
   size?: number
@@ -433,10 +433,10 @@ export function AddStickyToolIcon({
   const clip = `add-sticky-clip-${uid}`
 
   const paperTop = isDark
-    ? darkenHex(tint, isNeutral ? 0.55 : 0.2)
+    ? darkenHex(tint, isNeutral ? 0.55 : 0.4)
     : lightenHex(tint, 0.45)
   const paperBottom = isDark
-    ? darkenHex(tint, isNeutral ? 0.7 : 0.4)
+    ? darkenHex(tint, isNeutral ? 0.7 : 0.55)
     : lightenHex(tint, 0.15)
   const stroke = isDark ? '#C4BEBB' : '#45403C'
   // Drop-shadow color matrix differs by theme: light uses 32% gray, dark uses

--- a/src/renderer/shared/CustomIcons.tsx
+++ b/src/renderer/shared/CustomIcons.tsx
@@ -1,4 +1,5 @@
 import { useId, type ComponentProps } from 'react'
+import { darkenHex, lightenHex } from '../../shared/canvas-colors'
 
 // Custom-drawn icons exported from the agent-canvas Figma file
 // (file key hgwwoe0EzUrErdviULmRtb).
@@ -23,7 +24,6 @@ import { useId, type ComponentProps } from 'react'
 
 import addPageUrl from './icons/toolbar/add-page.svg'
 import addShapeUrl from './icons/toolbar/add-shape.svg'
-import addStickyUrl from './icons/toolbar/add-sticky.svg'
 import addTextUrl from './icons/toolbar/add-text.svg'
 import commentUrl from './icons/toolbar/comment.svg'
 import handUrl from './icons/toolbar/hand.svg'
@@ -33,7 +33,6 @@ import themeUrl from './icons/toolbar/theme.svg'
 import zoomChevronUrl from './icons/toolbar/zoom-chevron.svg'
 import addPageDarkUrl from './icons/toolbar/dark/add-page.svg'
 import addShapeDarkUrl from './icons/toolbar/dark/add-shape.svg'
-import addStickyDarkUrl from './icons/toolbar/dark/add-sticky.svg'
 import addTextDarkUrl from './icons/toolbar/dark/add-text.svg'
 import commentDarkUrl from './icons/toolbar/dark/comment.svg'
 import handDarkUrl from './icons/toolbar/dark/hand.svg'
@@ -395,8 +394,189 @@ export function DrawHighlightToolIcon({
     </svg>
   )
 }
-export const AddStickyToolIcon = makeToolbarIcon(addStickyUrl, addStickyDarkUrl, 'AddStickyToolIcon')
 export const AddShapeToolIcon = makeToolbarIcon(addShapeUrl, addShapeDarkUrl, 'AddShapeToolIcon')
+
+// ── AddStickyToolIcon (inline JSX — `tint` colors the paper to match the
+// currently selected sticky color; gradient stops derived via lighten/darken
+// so the paper-highlight + paper-shadow visual is preserved across hues.) ───
+//
+// Geometry ported from icons/toolbar/add-sticky.svg. The grayscale stops in
+// the original raster (#F4F4F4/#DCDCDC light, #65625D/#484744 dark) map to
+// lighten(tint, 0.30) / darken(tint, 0.08) in light mode and darken(tint, 0.55)
+// / darken(tint, 0.70) in dark mode — picking those amounts keeps neutral
+// (#fdf8f5 light / #dcd2c4 dark) visually identical to the original raster.
+
+type AddStickyIconProps = {
+  size?: number
+  isDark?: boolean
+  /** Resolved soft-palette fill of the active sticky color. */
+  tint?: string
+  style?: React.CSSProperties
+  className?: string
+}
+
+const DEFAULT_STICKY_TINT_LIGHT = '#fdf8f5'
+
+export function AddStickyToolIcon({
+  size = 20,
+  isDark = false,
+  tint = DEFAULT_STICKY_TINT_LIGHT,
+  style,
+  className,
+}: AddStickyIconProps) {
+  const uid = useId()
+  const filter0 = `add-sticky-filter0-${uid}`
+  const filter1 = `add-sticky-filter1-${uid}`
+  const paint0 = `add-sticky-paint0-${uid}`
+  const paint1 = `add-sticky-paint1-${uid}`
+  const paint2 = `add-sticky-paint2-${uid}`
+  const clip = `add-sticky-clip-${uid}`
+
+  const paperTop = isDark ? darkenHex(tint, 0.55) : lightenHex(tint, 0.3)
+  const paperBottom = isDark ? darkenHex(tint, 0.7) : darkenHex(tint, 0.08)
+  const stroke = isDark ? '#C4BEBB' : '#45403C'
+  // Drop-shadow color matrix differs by theme: light uses 32% gray, dark uses
+  // 40% black — preserved from the original SVG assets so the shadow stays
+  // alpha-correct against either toolbar surface.
+  const shadowMatrix = isDark
+    ? '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4 0'
+    : '0 0 0 0 0.785325 0 0 0 0 0.785325 0 0 0 0 0.785325 0 0 0 0.32 0'
+  const innerShadowAlpha = isDark ? 0.3 : 0.2
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      style={style}
+    >
+      <g clipPath={`url(#${clip})`}>
+        <g filter={`url(#${filter0})`}>
+          <rect
+            width="15"
+            height="15"
+            rx="3"
+            transform="matrix(0.998628 0.0523679 -0.0416989 0.99913 4.40137 3.61328)"
+            fill={`url(#${paint0})`}
+          />
+          <rect
+            x="0.478464"
+            y="0.525749"
+            width="14"
+            height="14"
+            rx="2.5"
+            transform="matrix(0.998628 0.0523679 -0.0416989 0.99913 4.42395 3.58868)"
+            stroke={stroke}
+          />
+        </g>
+        <g filter={`url(#${filter1})`}>
+          <path
+            d="M1.00098 3V14C1.00098 15.1046 1.89641 16 3.00098 16H14.001C15.1055 16 16.001 15.1046 16.001 14V10.875C16.001 5 12.001 1 8.40098 1H3.00098C1.89641 1 1.00098 1.89543 1.00098 3Z"
+            fill={`url(#${paint1})`}
+          />
+          <path
+            d="M3.00098 1.5H8.40137C11.645 1.5003 15.501 5.18877 15.501 10.875V14C15.501 14.8284 14.8294 15.5 14.001 15.5H3.00098C2.17255 15.5 1.50098 14.8284 1.50098 14V3C1.50098 2.17157 2.17255 1.5 3.00098 1.5Z"
+            stroke={stroke}
+          />
+        </g>
+        <path
+          d="M8.40137 1.5C8.51643 1.5 8.6648 1.53695 8.83652 1.60729C10.9037 2.45409 10.8554 5.23078 9.81889 7.2097C9.72914 7.38106 9.87327 7.58141 10.0643 7.55079L10.6922 7.45012C12.4547 7.16758 14.379 7.70514 15.0699 9.35098C15.3914 10.1167 15.5 10.743 15.5 11"
+          stroke={stroke}
+        />
+        <path
+          d="M2 8H12C13.6569 8 15 9.34315 15 11V14C15 14.5523 14.5523 15 14 15H3C2.44772 15 2 14.5523 2 14V8Z"
+          fill={`url(#${paint2})`}
+        />
+      </g>
+      <defs>
+        <filter
+          id={filter0}
+          x="-0.101562"
+          y="1.76611"
+          width="23.3604"
+          height="23.4668"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset dy="2" />
+          <feGaussianBlur stdDeviation="2" />
+          <feComposite in2="hardAlpha" operator="out" />
+          <feColorMatrix type="matrix" values={shadowMatrix} />
+          <feBlend mode="normal" in2="BackgroundImageFix" result="effect1" />
+          <feBlend mode="normal" in="SourceGraphic" in2="effect1" result="shape" />
+        </filter>
+        <filter
+          id={filter1}
+          x="-2.99902"
+          y="-1"
+          width="23"
+          height="23"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset dy="2" />
+          <feGaussianBlur stdDeviation="2" />
+          <feComposite in2="hardAlpha" operator="out" />
+          <feColorMatrix type="matrix" values={shadowMatrix} />
+          <feBlend mode="normal" in2="BackgroundImageFix" result="effect1" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset dx="0.5" dy="0.5" />
+          <feGaussianBlur stdDeviation="0.25" />
+          <feComposite in2="hardAlpha" operator="out" />
+          <feColorMatrix type="matrix" values={`0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ${innerShadowAlpha} 0`} />
+          <feBlend mode="normal" in2="effect1" result="effect2" />
+          <feBlend mode="normal" in="SourceGraphic" in2="effect2" result="shape" />
+        </filter>
+        <linearGradient id={paint0} x1="7.5" y1="0" x2="7.5" y2="15" gradientUnits="userSpaceOnUse">
+          <stop stopColor={paperTop} />
+          <stop offset="1" stopColor={paperBottom} />
+        </linearGradient>
+        <radialGradient
+          id={paint1}
+          cx="0"
+          cy="0"
+          r="1"
+          gradientTransform="matrix(-4.59752 3.97059 -3.97059 -5.12255 13.3307 3.20588)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor={paperTop} />
+          <stop offset="0.0001" stopColor={paperBottom} />
+          <stop offset="1" stopColor={paperTop} />
+        </radialGradient>
+        <linearGradient id={paint2} x1="8.5" y1="8" x2="8.5" y2="15" gradientUnits="userSpaceOnUse">
+          <stop stopColor={paperTop} stopOpacity="0" />
+          <stop offset="1" stopColor={paperBottom} />
+        </linearGradient>
+        <clipPath id={clip}>
+          <rect width="20" height="20" fill="white" />
+        </clipPath>
+      </defs>
+    </svg>
+  )
+}
+
 export const AddPageToolIcon = makeToolbarIcon(addPageUrl, addPageDarkUrl, 'AddPageToolIcon')
 export const AddTextToolIcon = makeToolbarIcon(addTextUrl, addTextDarkUrl, 'AddTextToolIcon')
 export const CommentToolIcon = makeToolbarIcon(commentUrl, commentDarkUrl, 'CommentToolIcon')

--- a/src/renderer/shared/CustomIcons.tsx
+++ b/src/renderer/shared/CustomIcons.tsx
@@ -400,11 +400,10 @@ export const AddShapeToolIcon = makeToolbarIcon(addShapeUrl, addShapeDarkUrl, 'A
 // currently selected sticky color; gradient stops derived via lighten/darken
 // so the paper-highlight + paper-shadow visual is preserved across hues.) ───
 //
-// Geometry ported from icons/toolbar/add-sticky.svg. The grayscale stops in
-// the original raster (#F4F4F4/#DCDCDC light, #65625D/#484744 dark) map to
-// lighten(tint, 0.30) / darken(tint, 0.08) in light mode and darken(tint, 0.55)
-// / darken(tint, 0.70) in dark mode — picking those amounts keeps neutral
-// (#fdf8f5 light / #dcd2c4 dark) visually identical to the original raster.
+// Geometry ported from icons/toolbar/add-sticky.svg. Light mode keeps the
+// paper pale via lighten(tint, 0.45) → lighten(tint, 0.15); dark mode lifts
+// the value range via darken(tint, 0.35) → darken(tint, 0.50) so hues stay
+// readable on the dark toolbar surface.
 
 type AddStickyIconProps = {
   size?: number
@@ -432,8 +431,8 @@ export function AddStickyToolIcon({
   const paint2 = `add-sticky-paint2-${uid}`
   const clip = `add-sticky-clip-${uid}`
 
-  const paperTop = isDark ? darkenHex(tint, 0.55) : lightenHex(tint, 0.3)
-  const paperBottom = isDark ? darkenHex(tint, 0.7) : darkenHex(tint, 0.08)
+  const paperTop = isDark ? darkenHex(tint, 0.35) : lightenHex(tint, 0.45)
+  const paperBottom = isDark ? darkenHex(tint, 0.5) : lightenHex(tint, 0.15)
   const stroke = isDark ? '#C4BEBB' : '#45403C'
   // Drop-shadow color matrix differs by theme: light uses 32% gray, dark uses
   // 40% black — preserved from the original SVG assets so the shadow stays

--- a/src/renderer/shared/CustomIcons.tsx
+++ b/src/renderer/shared/CustomIcons.tsx
@@ -1,5 +1,5 @@
 import { useId, type ComponentProps } from 'react'
-import { darkenHex, lightenHex } from '../../shared/canvas-colors'
+import { darkenHex, lightenHex, NEUTRAL_STORAGE, resolveCanvasColor } from '../../shared/canvas-colors'
 
 // Custom-drawn icons exported from the agent-canvas Figma file
 // (file key hgwwoe0EzUrErdviULmRtb).
@@ -401,28 +401,29 @@ export const AddShapeToolIcon = makeToolbarIcon(addShapeUrl, addShapeDarkUrl, 'A
 // so the paper-highlight + paper-shadow visual is preserved across hues.) ───
 //
 // Geometry ported from icons/toolbar/add-sticky.svg. Light mode keeps the
-// paper pale via lighten(tint, 0.45) → lighten(tint, 0.15); dark mode lifts
-// the value range via darken(tint, 0.35) → darken(tint, 0.50) so hues stay
-// readable on the dark toolbar surface.
+// paper pale via lighten(tint, 0.45) → lighten(tint, 0.15). Dark mode is
+// split: neutral darkens hard (0.55 → 0.70, matching the original raster)
+// so it doesn't outshine the toolbar surface and bleed past strokes; hue
+// stickies darken lightly (0.20 → 0.40) so the chroma stays readable.
 
 type AddStickyIconProps = {
   size?: number
   isDark?: boolean
-  /** Resolved soft-palette fill of the active sticky color. */
-  tint?: string
+  /** Raw stored sticky-color value (slot sentinel, preset, or hex). */
+  color?: string
   style?: React.CSSProperties
   className?: string
 }
 
-const DEFAULT_STICKY_TINT_LIGHT = '#fdf8f5'
-
 export function AddStickyToolIcon({
   size = 20,
   isDark = false,
-  tint = DEFAULT_STICKY_TINT_LIGHT,
+  color = NEUTRAL_STORAGE,
   style,
   className,
 }: AddStickyIconProps) {
+  const tint = resolveCanvasColor(color, { role: 'fill', isDark, palette: 'soft' })
+  const isNeutral = color === NEUTRAL_STORAGE
   const uid = useId()
   const filter0 = `add-sticky-filter0-${uid}`
   const filter1 = `add-sticky-filter1-${uid}`
@@ -431,8 +432,12 @@ export function AddStickyToolIcon({
   const paint2 = `add-sticky-paint2-${uid}`
   const clip = `add-sticky-clip-${uid}`
 
-  const paperTop = isDark ? darkenHex(tint, 0.35) : lightenHex(tint, 0.45)
-  const paperBottom = isDark ? darkenHex(tint, 0.5) : lightenHex(tint, 0.15)
+  const paperTop = isDark
+    ? darkenHex(tint, isNeutral ? 0.55 : 0.2)
+    : lightenHex(tint, 0.45)
+  const paperBottom = isDark
+    ? darkenHex(tint, isNeutral ? 0.7 : 0.4)
+    : lightenHex(tint, 0.15)
   const stroke = isDark ? '#C4BEBB' : '#45403C'
   // Drop-shadow color matrix differs by theme: light uses 32% gray, dark uses
   // 40% black — preserved from the original SVG assets so the shadow stays

--- a/src/renderer/toolbar/App.tsx
+++ b/src/renderer/toolbar/App.tsx
@@ -23,6 +23,7 @@ export default function App({ initialTheme }: { initialTheme: ThemeData }) {
     activeTool,
     drawBrushType,
     drawColor,
+    stickyColor,
     selection,
     addressValue,
     setAddressValue,
@@ -152,6 +153,7 @@ export default function App({ initialTheme }: { initialTheme: ThemeData }) {
                 activeTool={activeTool}
                 drawBrushType={drawBrushType}
                 drawColor={drawColor}
+                stickyColor={stickyColor}
                 hasPages={hasPages}
                 drawingEnabled={DRAWING_FEATURE_ENABLED}
                 hasSelection={hasSelection}
@@ -193,6 +195,7 @@ export default function App({ initialTheme }: { initialTheme: ThemeData }) {
                 activeTool={activeTool}
                 drawBrushType={drawBrushType}
                 drawColor={drawColor}
+                stickyColor={stickyColor}
                 hasPages={hasPages}
                 drawingEnabled={DRAWING_FEATURE_ENABLED}
                 hasSelection={hasSelection}

--- a/src/renderer/toolbar/toolbarSections.tsx
+++ b/src/renderer/toolbar/toolbarSections.tsx
@@ -152,6 +152,7 @@ interface CenterActionsProps {
   activeTool: Tool
   drawBrushType: DrawingBrushType
   drawColor: string
+  stickyColor: string
   hasPages: boolean
   drawingEnabled: boolean
   hasSelection: boolean
@@ -169,6 +170,7 @@ export function CenterActions({
   activeTool,
   drawBrushType,
   drawColor,
+  stickyColor,
   hasPages,
   drawingEnabled,
   hasSelection,
@@ -205,6 +207,12 @@ export function CenterActions({
     role: 'ink',
     isDark,
     palette: 'vivid',
+  })
+  // Sticky glyph fills tint from the soft palette to match placed stickies.
+  const stickyTint = resolveCanvasColor(stickyColor, {
+    role: 'fill',
+    isDark,
+    palette: 'soft',
   })
   const selectTriggerClassName = isDark
     ? 'toolbar-squircle-btn flex h-7 w-[58px] cursor-pointer items-center justify-between gap-0.5 rounded-[6px] border border-transparent bg-transparent pl-2 pr-1 text-xs tabular-nums text-zinc-200 hover:bg-[rgba(253,248,245,0.1)]'
@@ -276,7 +284,7 @@ export function CenterActions({
             title="Add sticky"
             type="button"
           >
-            <AddStickyToolIcon size={TOOL_GLYPH_SIZE} isDark={isDark} />
+            <AddStickyToolIcon size={TOOL_GLYPH_SIZE} isDark={isDark} tint={stickyTint} />
           </button>
         ) : null}
 

--- a/src/renderer/toolbar/toolbarSections.tsx
+++ b/src/renderer/toolbar/toolbarSections.tsx
@@ -208,12 +208,6 @@ export function CenterActions({
     isDark,
     palette: 'vivid',
   })
-  // Sticky glyph fills tint from the soft palette to match placed stickies.
-  const stickyTint = resolveCanvasColor(stickyColor, {
-    role: 'fill',
-    isDark,
-    palette: 'soft',
-  })
   const selectTriggerClassName = isDark
     ? 'toolbar-squircle-btn flex h-7 w-[58px] cursor-pointer items-center justify-between gap-0.5 rounded-[6px] border border-transparent bg-transparent pl-2 pr-1 text-xs tabular-nums text-zinc-200 hover:bg-[rgba(253,248,245,0.1)]'
     : 'toolbar-squircle-btn flex h-7 w-[58px] cursor-pointer items-center justify-between gap-0.5 rounded-[6px] border border-transparent bg-transparent pl-2 pr-1 text-xs tabular-nums text-zinc-600 hover:bg-[#fdf8f5] hover:text-zinc-900'
@@ -284,7 +278,7 @@ export function CenterActions({
             title="Add sticky"
             type="button"
           >
-            <AddStickyToolIcon size={TOOL_GLYPH_SIZE} isDark={isDark} tint={stickyTint} />
+            <AddStickyToolIcon size={TOOL_GLYPH_SIZE} isDark={isDark} color={stickyColor} />
           </button>
         ) : null}
 

--- a/src/renderer/toolbar/useToolbarState.ts
+++ b/src/renderer/toolbar/useToolbarState.ts
@@ -29,6 +29,7 @@ const EMPTY_SELECTION: ToolbarSelectionData = {
   activeTool: { kind: 'select' },
   drawBrushType: 'pen',
   drawColor: '1',
+  stickyColor: 'neutral',
 }
 
 export interface ToolbarState {
@@ -38,6 +39,7 @@ export interface ToolbarState {
   activeTool: Tool
   drawBrushType: DrawingBrushType
   drawColor: string
+  stickyColor: string
   selection: ToolbarSelectionData
   addressValue: string
   setAddressValue: Dispatch<SetStateAction<string>>
@@ -105,6 +107,7 @@ export function useToolbarState(): ToolbarState {
     activeTool: selection.activeTool,
     drawBrushType: selection.drawBrushType,
     drawColor: selection.drawColor,
+    stickyColor: selection.stickyColor,
     selection,
     addressValue,
     setAddressValue,

--- a/src/shared/canvas-colors.ts
+++ b/src/shared/canvas-colors.ts
@@ -206,3 +206,16 @@ export function lightenHex(color: string, amount: number): string {
   const hex = (n: number) => n.toString(16).padStart(2, '0')
   return `#${hex(lr)}${hex(lg)}${hex(lb)}`
 }
+
+/** Darken a #RRGGBB hex by interpolating toward black. amount=0 leaves it; amount=1 returns black. */
+export function darkenHex(color: string, amount: number): string {
+  if (!color.startsWith('#') || color.length !== 7) return color
+  const r = parseInt(color.slice(1, 3), 16)
+  const g = parseInt(color.slice(3, 5), 16)
+  const b = parseInt(color.slice(5, 7), 16)
+  const dr = Math.round(r * (1 - amount))
+  const dg = Math.round(g * (1 - amount))
+  const db = Math.round(b * (1 - amount))
+  const hex = (n: number) => n.toString(16).padStart(2, '0')
+  return `#${hex(dr)}${hex(dg)}${hex(db)}`
+}

--- a/src/shared/canvas-colors.ts
+++ b/src/shared/canvas-colors.ts
@@ -67,7 +67,9 @@ export interface ResolvedColorSlot {
 export const NEUTRAL_STORAGE = 'neutral'
 
 const NEUTRAL_FILL_LIGHT = '#fdf8f5'
-const NEUTRAL_FILL_DARK = '#3a3836'
+// Slightly muted cream for dark mode — still light enough for dark ink to read,
+// but a touch less glaring on a dark canvas. Pairs with NEUTRAL_INK_LIGHT.
+const NEUTRAL_FILL_DARK = '#dcd2c4'
 const NEUTRAL_INK_LIGHT = '#1c1917'
 const NEUTRAL_INK_DARK = '#e7e5e4'
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -308,6 +308,8 @@ export interface PendingPlacement {
   presetIndex?: number
   shapeKind?: ShapeKind
   textStyle?: TextEntityStyle
+  /** Stored color of the in-flight placement (sticky fill, etc.) so the preview can match the picker. */
+  color?: string
   width: number
   height: number
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -647,6 +647,8 @@ export interface ToolbarSelectionData {
   drawBrushType: DrawingBrushType
   /** Current draw-tool color default (raw stored slot/hex) — tints the Draw glyph. */
   drawColor: string
+  /** Current sticky-tool color default (raw stored slot/hex) — tints the sticky glyph. */
+  stickyColor: string
 }
 
 export interface ThemeData {


### PR DESCRIPTION
Closes #147

## What changed

`StickyBodyLayer.tsx` hardcoded `textColor` and `editorIsDark` for non-plain stickies, assuming all sticky backgrounds are light. The neutral slot renders a dark fill (`#3a3836`) in dark mode, making dark-ink text (`#1c1917`) nearly invisible.

**Fix:** detect when `note.color === NEUTRAL_STORAGE` and route through `resolveCanvasColor(color, { role: 'ink', isDark })`, which returns `#e7e5e4` in dark mode. Hue-colored stickies (yellow, blue, etc.) keep their light pastel fills in both themes and continue using dark ink unchanged. `editorIsDark` is also corrected for neutral stickies so the CodeMirror editor renders matching light text while editing.

The stale comment ("Stickies always sit on a light colored background") predating ADR 0013 is replaced with an accurate one.

## Test plan

- `pnpm typecheck` — no new errors in renderer layer
- `pnpm test:unit` — 583/583 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQUTfFvLLczQKeFFuyunK6)_