### PR TITLE
Fix middle-mouse pan stuck when button released outside window

### DIFF
--- a/src/renderer/canvas-bg/useCanvasViewportGestures.ts
+++ b/src/renderer/canvas-bg/useCanvasViewportGestures.ts
@@ -72,12 +72,24 @@ export function useCanvasViewportGestures({
 
     const handleMiddlePointerMove = (event: PointerEvent) => {
       if (event.pointerId !== middleDragPointerId || !middleDrag) return
+      if ((event.buttons & 4) === 0) {
+        middleDrag = null
+        middleDragPointerId = null
+        return
+      }
       const delta = middleDragDelta(middleDrag, event)
       middleDrag = { screenX: event.screenX, screenY: event.screenY }
       api.canvasPan(delta.deltaX, delta.deltaY)
     }
 
     const handleMiddlePointerUp = (event: PointerEvent) => {
+      if (event.pointerId === middleDragPointerId) {
+        middleDrag = null
+        middleDragPointerId = null
+      }
+    }
+
+    const handleMiddlePointerCancel = (event: PointerEvent) => {
       if (event.pointerId === middleDragPointerId) {
         middleDrag = null
         middleDragPointerId = null
@@ -133,6 +145,7 @@ export function useCanvasViewportGestures({
     document.addEventListener('pointerdown', handleMiddlePointerDown)
     document.addEventListener('pointermove', handleMiddlePointerMove)
     document.addEventListener('pointerup', handleMiddlePointerUp)
+    document.addEventListener('pointercancel', handleMiddlePointerCancel)
     document.addEventListener('dragover', handleDragOver)
     document.addEventListener('drop', handleDrop)
     el.addEventListener('pointerenter', handlePointerEnter)
@@ -144,6 +157,7 @@ export function useCanvasViewportGestures({
       document.removeEventListener('pointerdown', handleMiddlePointerDown)
       document.removeEventListener('pointermove', handleMiddlePointerMove)
       document.removeEventListener('pointerup', handleMiddlePointerUp)
+      document.removeEventListener('pointercancel', handleMiddlePointerCancel)
       document.removeEventListener('dragover', handleDragOver)
       document.removeEventListener('drop', handleDrop)
       el.removeEventListener('pointerenter', handlePointerEnter)

--- a/src/renderer/shared/hooks/useViewportWheelAndMiddlePan.ts
+++ b/src/renderer/shared/hooks/useViewportWheelAndMiddlePan.ts
@@ -54,6 +54,11 @@ export function useViewportWheelAndMiddlePan(
 
     const onPointerMove = (event: PointerEvent) => {
       if (event.pointerId !== middleDragPointerId || !middleDrag) return
+      if ((event.buttons & 4) === 0) {
+        middleDrag = null
+        middleDragPointerId = null
+        return
+      }
       const delta = middleDragDelta(middleDrag, event)
       middleDrag = { screenX: event.screenX, screenY: event.screenY }
       api.canvasPan(delta.deltaX, delta.deltaY)
@@ -66,22 +71,37 @@ export function useViewportWheelAndMiddlePan(
       }
     }
 
+    const onPointerCancel = (event: PointerEvent) => {
+      if (event.pointerId === middleDragPointerId) {
+        middleDrag = null
+        middleDragPointerId = null
+      }
+    }
+
     const cleanup = () => {
       middleDrag = null
       middleDragPointerId = null
+    }
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') cleanup()
     }
 
     window.addEventListener('wheel', onWheel, { passive: false })
     window.addEventListener('pointerdown', onPointerDown)
     window.addEventListener('pointermove', onPointerMove)
     window.addEventListener('pointerup', onPointerUp)
+    window.addEventListener('pointercancel', onPointerCancel)
     window.addEventListener('blur', cleanup)
+    document.addEventListener('visibilitychange', onVisibilityChange)
     return () => {
       window.removeEventListener('wheel', onWheel)
       window.removeEventListener('pointerdown', onPointerDown)
       window.removeEventListener('pointermove', onPointerMove)
       window.removeEventListener('pointerup', onPointerUp)
+      window.removeEventListener('pointercancel', onPointerCancel)
       window.removeEventListener('blur', cleanup)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
       cleanup()
     }
   }, [api, enabled])


### PR DESCRIPTION
Closes #148

## Summary

- Check `event.buttons & 4` in `pointermove` handlers in both `useViewportWheelAndMiddlePan` and `useCanvasViewportGestures` — if the middle button is no longer pressed when a move event arrives, clear pan state and skip the delta
- Add `pointercancel` handler to both hooks so system-initiated cancels (palm rejection, gesture takeover) also clean up pan state
- Add `visibilitychange` cleanup to `useViewportWheelAndMiddlePan` (already present in `useCanvasViewportGestures`) for consistency

## Test plan

- [ ] Start middle-click pan, drag cursor outside OS window, release middle button outside, move cursor back inside — pan should end cleanly with no stuck state
- [ ] Normal middle-click pan inside the window still works
- [ ] `pnpm typecheck` passes (no new errors in changed files)
- [ ] `pnpm test:unit` passes (583/583)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBX8RR6EQfjTzageJBmZzK)_