### PR TITLE
fix: batch multi-selection and group resize gestures into one undo step

### DIFF
--- a/src/main/ipc/register-canvas-drag-ipc.ts
+++ b/src/main/ipc/register-canvas-drag-ipc.ts
@@ -376,6 +376,17 @@ export function registerCanvasDragIpc(): void {
     commitActive()
   })
 
+  ipcMain.on('canvas-multi-resize-begin', () => {
+    tryEnter({ kind: 'resizing-multi-selection' })
+    beginBatch()
+  })
+
+  ipcMain.on('canvas-multi-resize-end', () => {
+    endBatch()
+    markUndoBoundary()
+    commitActive()
+  })
+
   ipcMain.on(
     'canvas-edge-drag-begin',
     (

--- a/src/main/routes/test.ts
+++ b/src/main/routes/test.ts
@@ -15,6 +15,7 @@ import {
   commit as commitInteraction,
   cancel as cancelInteraction,
   cancelActive,
+  commitActive,
   __resetForTests as resetInteractionForTests,
   type TryEnterInput,
 } from '../runtime/interaction-controller'
@@ -36,7 +37,9 @@ import {
   redo as redoCanvas,
   canUndo as canUndoCanvas,
   canRedo as canRedoCanvas,
+  markUndoBoundary,
 } from '../runtime/workspace-undo'
+import { beginBatch, endBatch } from '../runtime/workspace-observers'
 import { flushWorkspaceAutosaveSync } from '../runtime/workspace-autosave'
 import {
   DEFAULT_WORKSPACE_ID,
@@ -46,7 +49,8 @@ import {
 } from '../runtime/workspace-persistence'
 import { getActiveDoc } from '../runtime/workspace-doc'
 import { workspaceTabs, activeWorkspaceTabId } from '../runtime/workspace-model'
-import { applyDragDelta, finalizeDrag, initializeDrag } from '../runtime/document-commands'
+import { applyDragDelta, finalizeDrag, initializeDrag, resizeMultiSelection } from '../runtime/document-commands'
+import type { MultiResizeEntry } from '../runtime/document-commands'
 import { currentCanvasGuides } from '../runtime/canvas-guides'
 
 // --- Y.Doc transaction counter (test-only) ---
@@ -219,6 +223,36 @@ export const testRoutes: Route[] = [
     async handler({ response }) {
       finalizeDrag()
       writeJson(response, 200, { ok: true, guides: currentCanvasGuides() })
+    },
+  },
+
+  // --- Multi-selection resize simulation ---
+  {
+    method: 'POST',
+    pattern: '/test/canvas-multi-resize/begin',
+    async handler({ response }) {
+      tryEnter({ kind: 'resizing-multi-selection' })
+      beginBatch()
+      writeJson(response, 200, { ok: true })
+    },
+  },
+  {
+    method: 'POST',
+    pattern: '/test/canvas-multi-resize/apply',
+    async handler({ response, body }) {
+      const { entries } = body as { entries: MultiResizeEntry[] }
+      resizeMultiSelection(entries)
+      writeJson(response, 200, { ok: true })
+    },
+  },
+  {
+    method: 'POST',
+    pattern: '/test/canvas-multi-resize/end',
+    async handler({ response }) {
+      endBatch()
+      markUndoBoundary()
+      commitActive()
+      writeJson(response, 200, { ok: true })
     },
   },
   {

--- a/src/main/runtime/focus-reconciler-runtime.ts
+++ b/src/main/runtime/focus-reconciler-runtime.ts
@@ -28,6 +28,7 @@ function interactionModeKey(): FocusState['interactionMode'] {
     case 'marquee-select': return 'marquee'
     case 'dragging-entities': return 'dragging-entities'
     case 'resizing-entity': return 'resizing-entity'
+    case 'resizing-multi-selection': return 'resizing-multi-selection'
     case 'dragging-edge': return 'dragging-edge'
     case 'editing-entity': return 'editing-entity'
   }

--- a/src/main/runtime/focus-reconciler.ts
+++ b/src/main/runtime/focus-reconciler.ts
@@ -21,7 +21,7 @@
 import type { FocusTarget } from '../../shared/interaction-types'
 
 export type FocusState = {
-  interactionMode: 'idle' | 'panning' | 'marquee' | 'dragging-entities' | 'resizing-entity' | 'dragging-edge' | 'editing-entity'
+  interactionMode: 'idle' | 'panning' | 'marquee' | 'dragging-entities' | 'resizing-entity' | 'resizing-multi-selection' | 'dragging-edge' | 'editing-entity'
   editingEntityId: string | null
   selectedPageId: string | null
   workspaceViewMode: 'canvas' | 'browser'
@@ -54,6 +54,7 @@ export function expectedFocus(state: FocusState): FocusTarget {
     case 'marquee':
     case 'dragging-entities':
     case 'resizing-entity':
+    case 'resizing-multi-selection':
     case 'dragging-edge':
       return { kind: 'aboveView' }
     case 'editing-entity':

--- a/src/main/runtime/interaction-controller.ts
+++ b/src/main/runtime/interaction-controller.ts
@@ -28,6 +28,7 @@ import {
   beginEntityEditing,
   beginEntityResize,
   beginMarqueeSelect,
+  beginMultiSelectionResize,
   clearInteractionState,
 } from './interaction-state'
 import type { CanvasSelectableTarget, EdgeSide } from '../../shared/types'
@@ -66,6 +67,8 @@ function snapshotMode(): InteractionMode {
       return { kind: 'dragging-entities', ids: [...s.entityIds], anchor: { x: 0, y: 0 } }
     case 'resizing-entity':
       return { kind: 'resizing-entity', id: s.entity.id, edge: 'se' }
+    case 'resizing-multi-selection':
+      return { kind: 'resizing-multi-selection' }
     case 'editing-entity':
       return { kind: 'editing-entity', id: s.entityId }
     case 'dragging-edge':
@@ -97,6 +100,7 @@ export type TryEnterInput =
   | { kind: 'marquee' }
   | { kind: 'dragging-entities'; entityIds: string[] }
   | { kind: 'resizing-entity'; target: CanvasSelectableTarget }
+  | { kind: 'resizing-multi-selection' }
   | { kind: 'editing-entity'; entityId: string }
   | { kind: 'dragging-edge'; from: CanvasSelectableTarget; fromSide: EdgeSide }
 
@@ -113,6 +117,7 @@ export function tryEnter(input: TryEnterInput): Token | InteractionRefused {
     case 'marquee': beginMarqueeSelect(); break
     case 'dragging-entities': beginDraggingEntities(input.entityIds); break
     case 'resizing-entity': beginEntityResize(input.target); break
+    case 'resizing-multi-selection': beginMultiSelectionResize(); break
     case 'editing-entity': beginEntityEditing(input.entityId); break
     case 'dragging-edge': beginEdgeDrag(input.from, input.fromSide); break
   }

--- a/src/main/runtime/interaction-state.ts
+++ b/src/main/runtime/interaction-state.ts
@@ -47,6 +47,14 @@ export function beginEntityResize(entity: CanvasSelectableTarget): CanvasInterac
   return next
 }
 
+export function beginMultiSelectionResize(): CanvasInteractionState {
+  const next: CanvasInteractionState = { kind: 'resizing-multi-selection' }
+  setInteractionState(next)
+  markDirty('canvas')
+  requestLayout()
+  return next
+}
+
 export function beginEntityEditing(entityId: string): CanvasInteractionState {
   const next: CanvasInteractionState = { kind: 'editing-entity', entityId }
   setInteractionState(next)
@@ -89,6 +97,7 @@ export function interactionBlocksPageHover(state: CanvasInteractionState = inter
   return (
     state.kind === 'dragging-edge' ||
     state.kind === 'resizing-entity' ||
+    state.kind === 'resizing-multi-selection' ||
     state.kind === 'dragging-entities'
   )
 }

--- a/src/main/runtime/selection-controller.ts
+++ b/src/main/runtime/selection-controller.ts
@@ -77,6 +77,7 @@ function predicateInteractionKind(
     case 'marquee-select': return 'marquee'
     case 'dragging-entities': return 'dragging-entities'
     case 'resizing-entity': return 'resizing-entity'
+    case 'resizing-multi-selection': return 'resizing-multi-selection'
     case 'dragging-edge': return 'dragging-edge'
     case 'editing-entity': return 'editing-entity'
   }

--- a/src/preload/canvas-bg.ts
+++ b/src/preload/canvas-bg.ts
@@ -208,6 +208,8 @@ const api: CanvasBgElectronAPI = {
   beginResize: (entityId, entityKind, handle) =>
     ipcRenderer.send('canvas-resize-begin', { entityId, entityKind, handle }),
   endResize: () => ipcRenderer.send('canvas-resize-end'),
+  beginMultiResize: () => ipcRenderer.send('canvas-multi-resize-begin'),
+  endMultiResize: () => ipcRenderer.send('canvas-multi-resize-end'),
   commitRegionSelect: (canvasRect) => ipcRenderer.send('canvas-commit-region-select', canvasRect),
   commitCommentClickAt: (windowX, windowY) =>
     ipcRenderer.send('canvas-comment-click-at', { windowX, windowY }),

--- a/src/renderer/above-view/useCanvasPointerRouter.ts
+++ b/src/renderer/above-view/useCanvasPointerRouter.ts
@@ -720,6 +720,12 @@ function runMultiResize(
   const acc = startMultiResize(seed)
   const zoom = layout.zoom ?? 1
 
+  // Enter multi-resize interaction state in main BEFORE the first
+  // resizeMultiSelection dispatch — same ordering requirement as single-entity
+  // resize (see runResize comment above). Also opens a batch so all per-tick
+  // mutations coalesce into one Y.Doc transaction / one undo step.
+  api.beginMultiResize()
+
   let lastX = event.screenX
   let lastY = event.screenY
   const cleanup = () => {
@@ -728,6 +734,7 @@ function runMultiResize(
     window.removeEventListener('pointerup', onUp)
     window.removeEventListener('pointercancel', onCancel)
     window.removeEventListener('blur', onCancel)
+    api.endMultiResize()
   }
   const onMove = (ev: PointerEvent) => {
     if (ev.pointerId !== pointerId) return

--- a/src/shared/interaction-types.ts
+++ b/src/shared/interaction-types.ts
@@ -10,6 +10,7 @@ export type InteractionMode =
   | { kind: 'marquee'; origin: CanvasPoint; current: CanvasPoint }
   | { kind: 'dragging-entities'; ids: string[]; anchor: CanvasPoint }
   | { kind: 'resizing-entity'; id: string; edge: ResizeEdge }
+  | { kind: 'resizing-multi-selection' }
   | { kind: 'dragging-edge'; from: EdgeEndpoint; target: EdgeEndpoint | null }
   | { kind: 'editing-entity'; id: string }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -108,6 +108,7 @@ export type CanvasInteractionState =
   | { kind: 'marquee-select' }
   | { kind: 'panning-canvas' }
   | { kind: 'resizing-entity'; entity: CanvasSelectableTarget }
+  | { kind: 'resizing-multi-selection' }
   | { kind: 'editing-entity'; entityId: string }
 
 export interface CanvasScenePageEntity {
@@ -1772,6 +1773,8 @@ export interface CanvasBgElectronAPI {
   endDragEntity: () => void
   beginResize: (entityId: string, entityKind: CanvasEntityKind, handle: ResizeHandle) => void
   endResize: () => void
+  beginMultiResize: () => void
+  endMultiResize: () => void
   commitRegionSelect: (canvasRect: WorkspaceBounds) => void
   /** Comment tool click below the drag threshold. Main resolves the page +
    *  element under the window-coord point and either fires

--- a/tests/smoke/app-client.ts
+++ b/tests/smoke/app-client.ts
@@ -343,6 +343,7 @@ type InteractionMode =
   | { kind: 'marquee'; origin: { x: number; y: number }; current: { x: number; y: number } }
   | { kind: 'dragging-entities'; ids: string[]; anchor: { x: number; y: number } }
   | { kind: 'resizing-entity'; id: string; edge: string }
+  | { kind: 'resizing-multi-selection' }
   | { kind: 'dragging-edge'; from: unknown; target: unknown }
   | { kind: 'editing-entity'; id: string }
 
@@ -354,6 +355,7 @@ export type TryEnterInput =
   | { kind: 'marquee' }
   | { kind: 'dragging-entities'; entityIds: string[] }
   | { kind: 'resizing-entity'; target: { kind: string; id: string } }
+  | { kind: 'resizing-multi-selection' }
   | { kind: 'editing-entity'; entityId: string }
   | { kind: 'dragging-edge'; from: { kind: string; id: string }; fromSide: 'top' | 'right' | 'bottom' | 'left' }
 
@@ -436,6 +438,27 @@ export function endCanvasDrag() {
 
 export function getCanvasGuides() {
   return get<CanvasGuidesPayload>('/test/canvas-guides/current')
+}
+
+export type MultiResizeEntry = {
+  id: string
+  kind: 'page' | 'text' | 'file' | 'drawing' | 'shape'
+  width: number
+  height: number
+  canvasX: number
+  canvasY: number
+}
+
+export function beginMultiResize() {
+  return post<{ ok: true }>('/test/canvas-multi-resize/begin')
+}
+
+export function applyMultiResize(entries: MultiResizeEntry[]) {
+  return post<{ ok: true }>('/test/canvas-multi-resize/apply', { entries })
+}
+
+export function endMultiResize() {
+  return post<{ ok: true }>('/test/canvas-multi-resize/end')
 }
 
 // --- Tool state ---

--- a/tests/smoke/gestures.test.ts
+++ b/tests/smoke/gestures.test.ts
@@ -54,6 +54,10 @@ const modes: Array<{ label: string; build: () => Promise<TryEnterInput> | TryEnt
     build: async () => ({ kind: 'resizing-entity', target: { kind: 'page', id: await createPage() } }),
   },
   {
+    label: 'resizing-multi-selection',
+    build: () => ({ kind: 'resizing-multi-selection' as const }),
+  },
+  {
     label: 'editing-entity',
     build: async () => ({ kind: 'editing-entity', entityId: await createPage() }),
   },

--- a/tests/smoke/undo.test.ts
+++ b/tests/smoke/undo.test.ts
@@ -16,13 +16,16 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
+  applyMultiResize,
+  beginMultiResize,
   createGroup,
   createTextEntities,
   deleteGroups,
   deleteTextEntities,
+  endMultiResize,
   getTextEntities,
-  getWorkspace,
   getUndoState,
+  getWorkspace,
   redoWorkspace,
   resetSmokeState,
   undoWorkspace,
@@ -186,5 +189,51 @@ describe('undo', () => {
       const after = await getTextEntities()
       expect(after.textEntities.some((t) => t.id === firstIds[0])).toBe(false)
     }
+  })
+
+  it('multi-selection resize gesture collapses to one undo step', async () => {
+    // Create two text entities to resize together.
+    const { ids: idsA } = await createTextEntities([
+      { canvasX: 0, canvasY: 0, text: 'a', width: 100, height: 50 },
+    ])
+    await wait(50)
+    const { ids: idsB } = await createTextEntities([
+      { canvasX: 200, canvasY: 0, text: 'b', width: 100, height: 50 },
+    ])
+    await wait(50)
+
+    const before = await getTextEntities()
+    const aInit = before.textEntities.find((t) => t.id === idsA[0])!
+    const bInit = before.textEntities.find((t) => t.id === idsB[0])!
+
+    // Simulate a multi-resize gesture: begin → multiple apply ticks → end.
+    await beginMultiResize()
+    await applyMultiResize([
+      { id: idsA[0], kind: 'text', width: 120, height: 60, canvasX: aInit.canvasX, canvasY: aInit.canvasY },
+      { id: idsB[0], kind: 'text', width: 120, height: 60, canvasX: bInit.canvasX, canvasY: bInit.canvasY },
+    ])
+    await applyMultiResize([
+      { id: idsA[0], kind: 'text', width: 140, height: 70, canvasX: aInit.canvasX, canvasY: aInit.canvasY },
+      { id: idsB[0], kind: 'text', width: 140, height: 70, canvasX: bInit.canvasX, canvasY: bInit.canvasY },
+    ])
+    await endMultiResize()
+    await wait(50)
+
+    // Both entities should be resized.
+    const afterResize = await getTextEntities()
+    const aResized = afterResize.textEntities.find((t) => t.id === idsA[0])!
+    const bResized = afterResize.textEntities.find((t) => t.id === idsB[0])!
+    expect(aResized.width).toBe(140)
+    expect(bResized.width).toBe(140)
+
+    // One undo should restore both entities to their pre-resize bounds.
+    await undoWorkspace()
+    await wait(50)
+
+    const afterUndo = await getTextEntities()
+    const aUndone = afterUndo.textEntities.find((t) => t.id === idsA[0])!
+    const bUndone = afterUndo.textEntities.find((t) => t.id === idsB[0])!
+    expect(aUndone.width).toBe(aInit.width)
+    expect(bUndone.width).toBe(bInit.width)
   })
 })

--- a/tests/unit/focus-reconciler.test.ts
+++ b/tests/unit/focus-reconciler.test.ts
@@ -29,7 +29,7 @@ describe('expectedFocus', () => {
       .toEqual({ kind: 'aboveView' })
   })
 
-  for (const mode of ['panning', 'marquee', 'dragging-entities', 'resizing-entity', 'dragging-edge'] as const) {
+  for (const mode of ['panning', 'marquee', 'dragging-entities', 'resizing-entity', 'resizing-multi-selection', 'dragging-edge'] as const) {
     it(`routes ${mode} to aboveView`, () => {
       expect(expectedFocus(state({ interactionMode: mode }))).toEqual({ kind: 'aboveView' })
     })

--- a/tests/unit/gate-predicate.test.ts
+++ b/tests/unit/gate-predicate.test.ts
@@ -28,6 +28,7 @@ describe('shouldGateBeOpen — canvas mode (default-open per ADR 0002 Step 7)', 
     'marquee',
     'dragging-entities',
     'resizing-entity',
+    'resizing-multi-selection',
     'dragging-edge',
   ] as const)('open when interaction is %s', (kind) => {
     expect(shouldGateBeOpen({ ...base(), interactionKind: kind })).toBe(true)

--- a/tests/unit/should-focus-selected-page.test.ts
+++ b/tests/unit/should-focus-selected-page.test.ts
@@ -89,6 +89,7 @@ describe('shouldFocusSelectedPage — interaction modes other than idle exclude'
     'marquee',
     'dragging-entities',
     'resizing-entity',
+    'resizing-multi-selection',
     'dragging-edge',
     'editing-entity',
   ] as const) {


### PR DESCRIPTION
Closes #149

## What changed

Multi-selection (and group) resize was dispatching `resizeMultiSelection` on every `pointermove` tick with no surrounding batch — each tick became its own Y.Doc transaction and its own undo step. Pressing undo after a resize rewound by one tick instead of one gesture.

Wire the multi-resize path the same way single-entity resize is wired:

- New `canvas-multi-resize-begin` IPC: enters `resizing-multi-selection` interaction state (so focus reconciler keeps focus on aboveView) and opens a batch.
- New `canvas-multi-resize-end` IPC: closes the batch, marks an undo boundary, commits the interaction token.
- `runMultiResize` in `useCanvasPointerRouter` dispatches `beginMultiResize()` before installing listeners and `endMultiResize()` in the cleanup callback, mirroring the existing `runResize` ordering.

## Touch points

| File | Change |
|---|---|
| `src/shared/types.ts` | Add `resizing-multi-selection` to `CanvasInteractionState`; add `beginMultiResize`/`endMultiResize` to `CanvasBgElectronAPI` |
| `src/shared/interaction-types.ts` | Add `resizing-multi-selection` to `InteractionMode` |
| `src/main/runtime/interaction-state.ts` | Add `beginMultiSelectionResize()`; add `resizing-multi-selection` to `interactionBlocksPageHover` |
| `src/main/runtime/interaction-controller.ts` | Add `resizing-multi-selection` to `TryEnterInput`, `snapshotMode`, and `tryEnter` |
| `src/main/runtime/focus-reconciler.ts` | Add `resizing-multi-selection` → `aboveView` in `FocusState` switch |
| `src/main/runtime/focus-reconciler-runtime.ts` | Map `resizing-multi-selection` in `interactionModeKey()` |
| `src/main/ipc/register-canvas-drag-ipc.ts` | Add `canvas-multi-resize-begin` / `canvas-multi-resize-end` handlers |
| `src/preload/canvas-bg.ts` | Add `beginMultiResize` / `endMultiResize` preload API |
| `src/renderer/above-view/useCanvasPointerRouter.ts` | Call begin/end in `runMultiResize` |
| `src/main/routes/test.ts` | Add `/test/canvas-multi-resize/{begin,apply,end}` simulation routes |
| `tests/smoke/app-client.ts` | Add `beginMultiResize`/`applyMultiResize`/`endMultiResize` helpers; update types |
| `tests/smoke/undo.test.ts` | Smoke test: one gesture → one undo step |
| `tests/smoke/gestures.test.ts` | Add `resizing-multi-selection` to the interaction modes matrix |
| `tests/unit/focus-reconciler.test.ts` | Add `resizing-multi-selection` to modes that route to `aboveView` |
| `tests/unit/gate-predicate.test.ts` | Add `resizing-multi-selection` to modes that open the gate |
| `tests/unit/should-focus-selected-page.test.ts` | Add `resizing-multi-selection` to modes that exclude page focus |

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7ojtQHpiSYvgzunqVEnwn)_