### PR TITLE
Cmd+1 centers any selected canvas item, not just pages

### DIFF
--- a/src/main/runtime/binding-handlers.ts
+++ b/src/main/runtime/binding-handlers.ts
@@ -3,7 +3,7 @@ import { DRAWING_FEATURE_ENABLED } from '../../shared/featureFlags'
 import { setActiveTool } from './tool-mode'
 import { applyToolDefaultPatch } from './tool-defaults'
 import { undo, redo } from './workspace-undo'
-import { setZoom, setPan, focusSelectedPage } from './viewport-control'
+import { setZoom, setPan, focusSelection } from './viewport-control'
 import { groupSelectedEntities, ungroupSelectedGroup } from './document-commands'
 import { selectAdjacentPage } from './selection-state'
 import { selectEntities, selectNone } from './selection-controller'
@@ -70,7 +70,7 @@ export const mainHandlers: Record<MainBindingId, (ctx: BindingContext) => void> 
   },
   'reset-viewport': () => {
     setZoom(1.0)
-    if (!focusSelectedPage()) {
+    if (!focusSelection()) {
       setPan(0, 0)
       requestLayout()
     }

--- a/src/main/runtime/ui-actions.ts
+++ b/src/main/runtime/ui-actions.ts
@@ -42,6 +42,7 @@ export { selectedPageId } from './runtime-context'
 export {
   focusCanvasBounds,
   focusSelectedPage,
+  focusSelection,
 } from './viewport-control'
 
 export {

--- a/src/main/runtime/viewport-control.ts
+++ b/src/main/runtime/viewport-control.ts
@@ -13,6 +13,12 @@ import { scheduleWorkspaceAutosave } from './workspace-autosave'
 import { safeSend } from './safe-send'
 import { clampCanvasZoom } from '../../shared/zoom'
 import type { WorkspaceBounds } from '../../shared/types'
+import { selectedCanvasTargets as uiSelectedCanvasTargets } from '../ui-state'
+import { textEntities } from './text-entity-state'
+import { fileEntities } from './file-entity-state'
+import { drawingEntities } from './drawing-entity-state'
+import { shapeEntities } from './shape-entity-state'
+import { workspaceGroups, workspaceEdges } from './workspace-model'
 
 export function setZoom(value: number): void {
   const nextZoom = clampCanvasZoom(value)
@@ -67,5 +73,64 @@ export function focusSelectedPage(): boolean {
   )
   setPan(targetX, targetY)
   requestLayout()
+  return true
+}
+
+function resolveEntityBounds(entityId: string): WorkspaceBounds | null {
+  const page = pages.find((p) => p.id === entityId)
+  if (page) {
+    const size = effectivePageContentSize(page)
+    return { x: page.canvasX, y: page.canvasY, width: size.width, height: size.height }
+  }
+  const text = textEntities.find((e) => e.id === entityId)
+  if (text) return { x: text.canvasX, y: text.canvasY, width: text.width, height: text.height }
+  const file = fileEntities.find((e) => e.id === entityId)
+  if (file) return { x: file.canvasX, y: file.canvasY, width: file.width, height: file.height }
+  const drawing = drawingEntities.find((e) => e.id === entityId)
+  if (drawing) return { x: drawing.canvasX, y: drawing.canvasY, width: drawing.width, height: drawing.height }
+  const shape = shapeEntities.find((e) => e.id === entityId)
+  if (shape) return { x: shape.canvasX, y: shape.canvasY, width: shape.width, height: shape.height }
+  const group = workspaceGroups.find((g) => g.id === entityId)
+  if (group) return { x: group.canvasX, y: group.canvasY, width: group.width, height: group.height }
+  return null
+}
+
+function unionBounds(boundsArr: WorkspaceBounds[]): WorkspaceBounds | null {
+  if (!boundsArr.length) return null
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+  for (const b of boundsArr) {
+    minX = Math.min(minX, b.x)
+    minY = Math.min(minY, b.y)
+    maxX = Math.max(maxX, b.x + b.width)
+    maxY = Math.max(maxY, b.y + b.height)
+  }
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
+}
+
+export function focusSelection(): boolean {
+  if (!win) return false
+  const targets = uiSelectedCanvasTargets()
+  if (!targets.length) return false
+
+  const allBounds: WorkspaceBounds[] = []
+  for (const { id, kind } of targets) {
+    if (kind === 'edge') {
+      const edge = workspaceEdges.find((e) => e.id === id)
+      if (edge) {
+        const fromBounds = resolveEntityBounds(edge.fromEntityId)
+        const toBounds = resolveEntityBounds(edge.toEntityId)
+        if (fromBounds) allBounds.push(fromBounds)
+        if (toBounds) allBounds.push(toBounds)
+      }
+      continue
+    }
+    const bounds = resolveEntityBounds(id)
+    if (bounds) allBounds.push(bounds)
+  }
+
+  const combined = unionBounds(allBounds)
+  if (!combined) return false
+
+  focusCanvasBounds(combined)
   return true
 }


### PR DESCRIPTION
## Summary

- Adds `focusSelection()` to `viewport-control.ts` alongside `focusSelectedPage()` — resolves bounds for every canvas entity kind (page, text, file, drawing, shape, group, edge) and centers the union of all selected items
- Edges are centered on the bounding box of their two endpoint entities
- The `reset-viewport` binding handler now calls `focusSelection()` instead of `focusSelectedPage()`, so Cmd+1 works for any selection, not only pages

## How it works

`focusSelection()` iterates the current selection targets (from `selectedCanvasTargets()` in ui-state), resolves each entity's canvas bounds, and unions them into a combined bounding box. It then calls the existing `focusCanvasBounds()` to center that box at the current zoom (already set to 1.0 by the handler). When nothing is selected, it returns `false` and the handler falls back to resetting pan to origin (unchanged behavior).

## Test plan

- [x] `pnpm typecheck` — no new errors (685 pre-existing errors unchanged)
- [x] `pnpm test:unit` — 583 tests, all pass

Closes #150

https://claude.ai/code/session_01PNzVSZfkydd1BWrtM621v9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNzVSZfkydd1BWrtM621v9)_