### PR TITLE
Drop 6px page selection padding hack; unify outline to 2px for all entity kinds

### DIFF
--- a/src/renderer/above-view/SelectionOutlineLayer.tsx
+++ b/src/renderer/above-view/SelectionOutlineLayer.tsx
@@ -50,10 +50,10 @@ function PageSelectionOverlay({ page, originY, isDark, showResizeHandles }: Page
     <div
       className="absolute border-2"
       style={{
-        left: page.screenX - 6,
-        top: page.screenY - 6 - originY,
-        width: page.screenWidth + 12,
-        height: page.screenHeight + 12,
+        left: page.screenX - 2,
+        top: page.screenY - 2 - originY,
+        width: page.screenWidth + 4,
+        height: page.screenHeight + 4,
         borderColor: selectionColor(isDark),
         pointerEvents: 'none',
       }}
@@ -92,10 +92,10 @@ function PageHoverOutline({
     <div
       className="absolute border-2"
       style={{
-        left: page.screenX - 6,
-        top: page.screenY - 6 - originY,
-        width: page.screenWidth + 12,
-        height: page.screenHeight + 12,
+        left: page.screenX - 2,
+        top: page.screenY - 2 - originY,
+        width: page.screenWidth + 4,
+        height: page.screenHeight + 4,
         borderColor: selectionColor(isDark),
         pointerEvents: 'none',
       }}
@@ -260,10 +260,10 @@ function GroupSelectionOverlay({
       className="absolute border-2"
       data-overlay-ui
       style={{
-        left: group.screenX,
-        top: group.screenY - originY,
-        width: group.screenWidth,
-        height: group.screenHeight,
+        left: group.screenX - 2,
+        top: group.screenY - 2 - originY,
+        width: group.screenWidth + 4,
+        height: group.screenHeight + 4,
         borderColor: selectionColor(isDark),
         borderRadius: 2,
         pointerEvents: 'none',

--- a/src/shared/hit-test.ts
+++ b/src/shared/hit-test.ts
@@ -333,12 +333,10 @@ const HANDLES: readonly ResizeHandle[] = ['nw', 'ne', 'se', 'sw', 'n', 'e', 's',
 // are centered on the outline corners/edges, not the entity itself. Match
 // the padding used by SelectionOutlineLayer so hit-test geometry tracks the
 // pixels users actually see.
-function outlinePaddingFor(kind: CanvasEntityKind): number {
-  switch (kind) {
-    case 'page': return 6
-    case 'group': return 0
-    default: return 2
-  }
+const SINGLE_SELECTION_OUTLINE_PADDING_PX = 2
+
+function outlinePaddingFor(_kind: CanvasEntityKind): number {
+  return SINGLE_SELECTION_OUTLINE_PADDING_PX
 }
 
 function handleRect(entity: CanvasSceneEntity, handle: ResizeHandle): Rect {

--- a/tests/unit/hit-test.test.ts
+++ b/tests/unit/hit-test.test.ts
@@ -130,10 +130,10 @@ describe('hit-test — resize handles vs body', () => {
   })
 
   it('clicking on the visible NE handle (offset by page outline padding) resizes', () => {
-    // Page outline pads the NE corner outward by 6px; the visible 8×8
-    // white handle is centered there, so a real user click typically lands
-    // a few pixels past the entity edge. Pre-fix this fell through to
-    // background → marquee.
+    // Page outline pads the NE corner outward by 2px; the visible handle
+    // is centered there, so a real user click typically lands a few pixels
+    // past the entity edge. Pre-fix this fell through to background → marquee.
+    // NE handle rect: x ∈ [596, 608], y ∈ [192, 204]. Click (606,194) is inside.
     const result = hitTest(inputs([f], ['f1']), { x: 606, y: 194 })
     expect(result.layer).toBe('resize-handles')
     expect(result.payload).toMatchObject({ kind: 'resize-handle', handle: 'ne' })
@@ -266,6 +266,25 @@ describe('hit-test — body z-order (front-to-back)', () => {
     // layer.
     const result = hitTest(inputs([t, g]), { x: 350, y: 320 })
     expect(result.payload).toMatchObject({ kind: 'entity-body', entityId: 't1' })
+  })
+})
+
+describe('hit-test — group resize handles', () => {
+  // Group at (100,100), 600×500. SE corner at (700, 600).
+  // With 2px outline padding, SE handle rect: x ∈ [696, 708], y ∈ [596, 608].
+  const g = group('g1', 100, 100, 600, 500)
+
+  it('resize handle wins at the SE corner when group is selected', () => {
+    const result = hitTest(inputs([g], ['g1']), { x: 700, y: 600 })
+    expect(result.layer).toBe('resize-handles')
+    expect(result.payload).toMatchObject({ kind: 'resize-handle', handle: 'se', entityId: 'g1' })
+  })
+
+  it('clicking 2px past the SE corner hits the handle (2px outline padding)', () => {
+    // Handle rect SE: x ∈ [696, 708], y ∈ [596, 608]. Click (702, 602) is inside.
+    const result = hitTest(inputs([g], ['g1']), { x: 702, y: 602 })
+    expect(result.layer).toBe('resize-handles')
+    expect(result.payload).toMatchObject({ kind: 'resize-handle', handle: 'se' })
   })
 })
 


### PR DESCRIPTION
Closes #151

## What changed

- `PageSelectionOverlay` and `PageHoverOutline`: changed from `-6 / +12` offset to `-2 / +4` (matching all other entities)
- `GroupSelectionOverlay`: changed from `0` offset to `-2 / +4` (matching all other entities)
- `outlinePaddingFor()` in `hit-test.ts`: collapsed the per-kind switch to a single `SINGLE_SELECTION_OUTLINE_PADDING_PX = 2` constant; `handleRect()` consumes it unchanged
- Updated hit-test unit test comments to reflect the new 2px geometry; added group resize handle tests covering the new 2px boundary

All 585 unit tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AucBewDE8fpeakHRjpqMEj)_