### PR TITLE
feat: auto-layout managed groups with reorder

### DIFF
--- a/.claude/skills/specular/SKILL.md
+++ b/.claude/skills/specular/SKILL.md
@@ -32,6 +32,7 @@ canvas and page operations go through the `specular` command.
 | `specular find-placement` | Find open canvas space for new entities |
 | `specular link <a> <b>` | Connect two pages with an edge |
 | `specular group <id…>` | Group entities together |
+| `specular auto-layout <id…>` | Make a managed auto-layout row from a selection (or convert a single group); children pack left-to-right and can be drag-reordered |
 | `specular breakpoints <id>` | Cycle through device breakpoints for a page |
 | `specular annotate "<text>"` | Leave a comment on the canvas (anchor type from context — viewport by default; `--page-id` for a page anchor) |
 | `specular annotations` | List unresolved annotations (pending + acknowledged) |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -85,6 +85,15 @@ Cross-surface stacking — putting a sticky behind a page, or a page in front of
 
 JSON Canvas note: the spec emits nodes and edges into separate arrays. The interleaved `entityOrder` (including edge ids) is persisted as a Specular extension (`specular.order` or equivalent); other JSON Canvas tools round-trip the data but lose precise stack interleaving for edges. Acceptable trade-off — same pattern as `specular.textStyle`.
 
+## Auto-layout
+
+A group can *manage* its children's layout instead of letting them float freely. See [ADR 0015](./docs/adr/0015-auto-layout-groups.md).
+
+- **Auto-layout group** — a group with `managedLayout: true`; its children are reflowed into a row (`layoutMode: 'row'`, the only live mode in Milestone 1), not freely positioned. `'freeform'` groups are plain selection/bbox containers. Reflow (`reflowManagedGroup`, built on the pure `computeRowReflow`) is the single writer of a managed child's `canvasX/canvasY` — those become outputs, re-derived on any membership / resize / reorder change.
+- **Layout sequence** — the left-to-right order of a managed row *is* the order of the group's run within `entityOrder` (no separate `childOrder` field). Reordering a child rewrites that run; reflow reads it. In a managed row, stack-order and layout-order are therefore the same axis (z-order is meaningless for non-overlapping row children).
+- **Reorder handle (center dot)** — the per-child drag target that reorders a child within its auto-layout group, dragging it to a new slot while siblings reflow. A geometric `hit-test` layer above `body` (below `anchors`), painted in `aboveView` like edge anchors — small at rest, larger when the child or its group is hovered. Dragging the child **body** still moves the whole group as a unit; only the dot reorders. The drag runs in the `reordering-child` interaction mode and commits as one undo step.
+- **Make auto-layout** — the headless entry point (no toolbar yet): `Shift+Cmd+A`, `specular auto-layout <ids|groupId>`, or `POST /groups/auto-layout`. Marks a selection (or existing group) as a managed row, seeding the sequence to current left-to-right order. The wrap-in-frame button, gap handles, direction/align/distribute controls are Milestone 2.
+
 ## Drag affordances
 
 Modifiers and visual feedback that ride on top of entity drag (and resize) gestures. The single magnetic pull on the canvas is grid-snap (`snapToGrid`, 20 px); everything below either projects the delta before the snap (axis lock) or renders informationally after it (alignment / distribution guides). See [ADR 0012](./docs/adr/0012-alignment-guides-are-visual-only.md).

--- a/docs/adr/0015-auto-layout-groups.md
+++ b/docs/adr/0015-auto-layout-groups.md
@@ -1,0 +1,47 @@
+# ADR 0015 — Auto-layout groups
+
+**Status:** Proposed
+**Date:** 2026-05-29
+**Related:** [ADR 0014 — Canvas stack order and the Notes/Pages sidebar](./0014-canvas-stack-order.md), [ADR 0001 — Click to enter page focus](./0001-click-to-enter-page-focus.md).
+**Origin:** Built from [`docs/plans/auto-layout-reorder.md`](../plans/auto-layout-reorder.md) (Milestone 1).
+
+## Context
+
+A selected group can be made to *manage* its children's layout: children pack into a row, and dragging a child's center dot reorders it while siblings reflow to make room (Figma auto-layout reorder).
+
+The seeds already existed: `WorkspaceGroupLayoutMode = 'freeform' | 'row' | 'grid'` and `managedLayout: boolean` were persisted and JSON-Canvas round-tripped, and a pages-only `reflowGroupRow` packed multi-breakpoint page rows on creation. What was missing: a generalized reflow engine for any entity kind, a reorder model, the drag gesture, and the dot affordance.
+
+This ADR records the hard-to-reverse decisions, because they make `managedLayout` load-bearing and couple a group's layout sequence to its `entityOrder` run.
+
+## Decision
+
+**D1 — An "auto-layout group" is a group with `managedLayout: true`.** Its children's positions are *derived* (managed), not free. `layoutMode` selects the packing — `'row'` is the only live mode in Milestone 1; `'column'`/`'grid'` follow. `'freeform'` groups are unchanged — purely a selection/bbox container.
+
+**D2 — Layout sequence = the group's `entityOrder` run.** A managed group's children are already a contiguous run in `entityOrder` (ADR 0014 group contiguity). The order *within that run* is the left-to-right layout sequence. Reordering a child rewrites that run (via `entity-order-math.moveBlockBefore` / `replaceSubsequence`, constrained to the run, then `enforceGroupContiguity`); reflow reads the run, not `canvasX`. **No new per-group `childOrder` field.** Tradeoff: in a managed row, stack-order and layout-order are the same axis — acceptable because z-order is meaningless for non-overlapping row children.
+
+**D3 — Reflow is the single writer of managed children's positions.** Any change to a managed group — membership, child resize, child reorder — triggers `reflowManagedGroup(groupId)`. Managed children never hold authoritative `canvasX/canvasY`; those are outputs. (They are still persisted so other tools / freeform fallback render correctly.) The pure kernel is `computeRowReflow(children, gap, originX, originY)` in `layout-math.ts`; the runtime writer is `reflowManagedGroup` in `src/main/managed-layout.ts`, which superseded the pages-only `reflowGroupRow`.
+
+**D4 — Two distinct drags on a managed child.** The **center dot** is the reorder handle (a new `reorder-handle` hit-test layer → `reordering-child` gesture). The child **body** keeps today's behavior: dragging the body moves the *whole group* as a unit, same as any group drag. You reorder with the dot, you move with the body. This keeps the managed invariant: you can't free-drag one child out of place.
+
+**D5 — Reflow snaps the row origin, then packs by gutter.** The origin (min child x/y) is grid-snapped; children then pack by `CLUSTER_HORIZONTAL_GUTTER` without per-child snapping. Alignment/distribution guides are suppressed during a reorder drag — the op is managed, so confirming-alignment guides would be noise.
+
+**D6 — Gap & alignment are defaulted in Milestone 1.** Milestone 1 uses the existing `CLUSTER_HORIZONTAL_GUTTER` constant and start-alignment. Persisted `layoutGap?: number` / `layoutAlign?` fields land with the toolbar (Milestone 2) — additive, no migration (absent → default), same pattern as `specular.textStyle`.
+
+**D-O2 — `reordering-child` is its own interaction mode**, not a `dragging-entities` payload flag. Commit semantics genuinely differ (reorder+reflow vs free move) and it owns its own drop-index preview and cancel path. The mode carries `{ groupId, childId, dropIndex }`; focus reconciles to `aboveView` like other gestures.
+
+**Undo batching.** A reorder is `entityOrder` move + reflow position writes. `writeEntityOrder` transacts directly while position writes reach the doc through the diff-sync — two transactions, hence two undo steps, under the UndoManager's `captureTimeout: 0`. `commitAsOneTransaction` (workspace-observers) wraps both in one Yjs transaction (nested transactions flatten) so a reorder is exactly one undo step. Same helper backs make-auto-layout.
+
+## Reachability (Milestone 1)
+
+The polished "wrap selection → auto-layout" toolbar button is Milestone 2. To make drag-reorder reachable on arbitrary content now, a headless command marks a selection (or an existing group) as a managed row: `makeAutoLayoutFromSelection()` (binding `make-auto-layout`, Shift+Cmd+A), the `specular auto-layout` CLI verb, and the `POST /groups/auto-layout` route. It seeds the layout sequence to the children's current left-to-right order so nothing jumps on conversion.
+
+## Consequences
+
+- `managedLayout` is now load-bearing: it gates reflow, the reorder hit layer, and dot painting.
+- Mixed-surface groups (ADR 0014 split rows) can be managed; reflow operates in canvas space on all children regardless of paint surface. The sidebar split-row representation reads `entityOrder`, which reorder mutates — rows stay paired.
+- Milestone 2 (deferred): draggable gap handles (`layoutGap`), direction toggle (column/grid via the existing `layout-math` paths), align (`layoutAlign`), distribute, and the floating multi-select toolbar.
+
+## Glossary additions
+
+- **Auto-layout group** — a group with `managedLayout: true`; children are reflowed, not freely positioned. Layout sequence = the group's `entityOrder` run (D2).
+- **Reorder handle (center dot)** — the per-child drag target that reorders a child within its auto-layout group. A `hit-test` layer above `body`, below `anchors`.

--- a/docs/plans/auto-layout-reorder.md
+++ b/docs/plans/auto-layout-reorder.md
@@ -1,0 +1,368 @@
+# Auto-layout & drag-reorder
+
+Build plan for the "auto-layout group + drag-to-reorder" feature: a selected
+auto-layout group shows a small **center dot** on each child; dragging a dot
+inserts that child at a new position and the siblings reflow to make room
+(Figma auto-layout reorder). The dot is small at rest and grows when the item
+or group is hovered.
+
+**Scope decisions (locked with the user):**
+
+1. **Group-backed.** Auto-layout is a property of a *group*, not an ephemeral
+   selection op. Order and (later) spacing/direction persist in the `.canvas`
+   file. This extends the existing `WorkspaceGroupLayoutMode` /
+   `managedLayout` fields rather than inventing a parallel concept.
+2. **Insert / reorder semantics.** Dragging a dot toward a gap inserts the
+   child there and shifts the others. Not pure swap. The child sequence is an
+   ordered list, reflowed left-to-right (row) on every change.
+3. **PR 1 = the core interaction only.** This doc lays out every phase, but the
+   first milestone ships drag-reorder + live reflow. The spacing handles,
+   direction toggle, align, distribute, and the floating multi-select toolbar
+   from the mockup are **Milestone 2 (deferred)**.
+
+> **Promote to ADR before Milestone 1 merges.** The canonical-decisions section
+> below is hard-to-reverse (it makes `managedLayout` load-bearing and couples
+> layout sequence to `entityOrder`). It should become **ADR 0015 — Auto-layout
+> groups** and be linked from `CONTEXT.md`. See "Canonical decisions" §.
+
+---
+
+## Status (2026-05-29, branch `feat/auto-layout`)
+
+**Milestone 1 is implemented and tested** (typecheck clean; 626 unit + 5 new
+managed-layout smoke tests pass; the only failing smoke is the pre-existing
+environmental `pages > takes a screenshot` capture test). Not yet committed.
+ADR 0015 written and linked from `CONTEXT.md`.
+
+| Phase | State | Landed as |
+|---|---|---|
+| Phase 1 — reflow engine | ✅ done | `computeRowReflow` (`layout-math.ts`); `reflowManagedGroup` / `reflowManagedGroupForChild` (`src/main/managed-layout.ts`); `reflowGroupRow` deleted, `addPageFromSource` re-pointed; resize-commit reflow hook in `register-canvas-drag-ipc.ts`. |
+| Phase 2 — reorder model | ✅ done | `managedChildOrder` / `writeManagedChildOrder` (`entity-order-state.ts`); `reorderManagedChild` + `computeReorderDropIndex` (`managed-layout.ts`); `commitAsOneTransaction` (`workspace-observers.ts`) → one undo step. |
+| O1 — reachability | ✅ done | `makeAutoLayoutGroup` / `makeAutoLayoutFromSelection`; `POST /groups/auto-layout`; `specular auto-layout` CLI verb; `make-auto-layout` binding (**Shift+Cmd+A**). |
+| Phase 3 — gesture | ✅ done | `reorder-handle` hit layer + priority; `begin-reorder-drag` action; `reordering-child` interaction mode; `register-canvas-reorder-ipc.ts`; `reorder-gesture.ts`; `runReorderDrag` in `useCanvasPointerRouter.ts`; preload bridge. Full begin/commit/cancel-{escape,blur,undo} smoke matrix. |
+| Phase 4 — dots | ✅ done | `ReorderDotsLayer.tsx` — geometric center dots (small at rest, grow on hover), insertion line during drag, suppressed off-`select`/mid-gesture. Visually verified in-app (dots render on a packed managed row). |
+
+**Open questions — resolved.** O1 → yes (headless command shipped). O2 → new
+`reordering-child` mode (D-O2 in ADR 0015). O3 → body drag moves the whole group.
+
+### Dogfooding finding (the reachability wall)
+
+First real use surfaced the friction the plan predicted: a plain selection — or
+even a `Cmd+G` freeform group — shows **no affordance**. Reorder is only reachable
+after an explicit "make auto-layout" step (`Shift+Cmd+A` / CLI), because dots are
+gated on `managedLayout: true`. The user's expectation is blunter than either the
+headless command or the deferred wrap-in-frame button:
+
+> **"I don't want a button. I want any multi-selection to have drag-to-reorder."**
+
+This reframes the next step (see "Next" below) and partially pushes back toward
+the lightweight selection-op model that scope decision #1 set aside.
+
+---
+
+## What already exists (do not rebuild)
+
+| Seed | Where | Note |
+|---|---|---|
+| `WorkspaceGroupLayoutMode = 'freeform' \| 'row' \| 'grid'` + `managedLayout: boolean` | `src/shared/types.ts`, `group-entity-state.ts` | Already persisted + JSON-Canvas round-tripped (`json-canvas-serializer.ts`, `workspace-restore.ts`). |
+| `reflowGroupRow(group)` | `src/main/workspace-pages.ts:115` | Working row-packer — but **pages-only** (reads the `pages` array, orders by `canvasX`), and only fires on `addPageFromSource`. The kernel to generalize. |
+| `computeLayoutMetrics` / `computeLayoutPositions(items, kind, colGap, rowGap, origin)` | `src/main/layout-math.ts` | Pure row/column/grid math. Used by design-system cluster tasks. |
+| `tidySelectedPages()` | `src/main/workspace-pages.ts:314` | One-shot row pack of a selection — reference for the math, not the live path. |
+| Group contiguity in `entityOrder` | ADR 0014, `entity-order-state.ts`, `src/shared/entity-order-math.ts` (`moveBlockBefore`, …) | A group's children are already a contiguous run in `entityOrder`. We reuse this run as the layout sequence (see Phase 2). |
+| Drag stack | `useCanvasPointerRouter.ts` → `register-canvas-drag-ipc.ts` → `applyDragDelta` / `interaction-controller.ts` | Per-action renderer handlers + begin/update/commit/cancel IPC + batched undo. The pattern every new gesture follows. |
+| Hit-test priority layers | `src/shared/hit-test.ts` (`resize-handle > chrome > anchor > body > background`) | We add a `reorder-handle` layer for the center dots. |
+| Guides overlay | `GuidesLayer` in `above-view/App.tsx`, `canvas-guides.ts` | Reuse its line style for the drop-insertion indicator. |
+
+**The floating multi-select toolbar in the mockup does not exist yet.** Per-kind
+popups (`ShapePopup`, `GroupPopup`, `FilePopup`) carry no align/distribute/arrange
+controls. That toolbar is Milestone 2.
+
+---
+
+## Canonical decisions (→ ADR 0015)
+
+**D1 — An "auto-layout group" is a group with `managedLayout: true`.** Its
+children's positions are *derived* (managed), not free. `layoutMode` selects the
+packing (`'row'` is the only live mode in Milestone 1; `'column'`/`'grid'`
+follow). `'freeform'` groups are unchanged — purely a selection/bbox container.
+
+**D2 — Layout sequence = the group's `entityOrder` run.** A managed group's
+children are already a contiguous run in `entityOrder` (ADR 0014 group
+contiguity). The order *within that run* is the left-to-right layout sequence.
+Reordering a child = `moveBlockBefore` within the run; reflow then reads the run,
+not `canvasX`. **No new per-group `childOrder` field.** Tradeoff: in a managed
+row, stack-order and layout-order are the same axis — acceptable because z-order
+is meaningless for non-overlapping row children; documented in the ADR.
+
+**D3 — Reflow is the single writer of managed children's positions.** Any change
+to a managed group — membership, child resize, child reorder, gap/align change —
+triggers `reflowManagedGroup(group)`. Managed children never hold authoritative
+`canvasX/canvasY`; those are outputs. (They are still persisted so other tools /
+freeform fallback render correctly.)
+
+**D4 — Two distinct drags on a managed child.** The **center dot** is the reorder
+handle (`reorder-handle` hit layer → `reordering-child` gesture). The child
+**body** keeps today's behavior (click to enter/select the child; drag the body
+moves the *whole group* as a unit, same as any group drag). You reorder with the
+dot, you move/position with the body. This keeps the managed invariant: you can't
+free-drag one child out of place.
+
+**D5 — Reflow bypasses grid-snap on the managed axis** (matches today's
+`reflowGroupRow`, which `snapToGrid`s the row origin then packs by gutter).
+Alignment/distribution guides are **suppressed** during a reorder drag — the
+op is managed, so confirming-alignment guides would be noise.
+
+**D6 — Gap & alignment are group fields, defaulted in Milestone 1.** Milestone 1
+uses the existing `CLUSTER_HORIZONTAL_GUTTER` constant and start-alignment. The
+persisted `layoutGap?: number` and `layoutAlign?` fields land with the toolbar
+(Milestone 2) — additive, no migration (absent → default).
+
+**Glossary additions (apply to `CONTEXT.md` when Milestone 1 lands):**
+- **Auto-layout group** — a group with `managedLayout: true`; children are
+  reflowed, not freely positioned.
+- **Reorder handle (center dot)** — the per-child drag target that reorders a
+  child within its auto-layout group. A new `hit-test` layer above `body`.
+
+---
+
+## Phase ladder
+
+### Milestone 1 — Drag-reorder (ships the core interaction)
+
+#### Phase 1 — Generalized reflow engine *(main; pure + runtime)*
+
+Lift row-packing out of the pages-only path so any entity kind can be a managed
+child.
+
+- Add pure `computeRowReflow(children: {width,height}[], gap, originX, originY)`
+  → positions, building on `layout-math.ts`. Unit-tested in isolation.
+- Add `reflowManagedGroup(groupId)` in a new `src/main/runtime/managed-layout.ts`
+  (or fold into `group-entity-state.ts`): resolve the group's direct children
+  *in `entityOrder` run order* across all entity arrays (text/file/shape/
+  drawing/page/sub-group), apply `computeRowReflow`, write each child's
+  `canvasX/canvasY` via its per-kind mutator, recompute the group bbox.
+- Re-point `reflowGroupRow`'s callers (`addPageFromSource`) at the generalized
+  function; delete the pages-only version once parity is confirmed.
+- Trigger `reflowManagedGroup` on: child resize commit, membership change, and
+  (Phase 3) reorder commit.
+- **Tests:** unit for `computeRowReflow` (1, 2, N children; zero-width edge);
+  smoke for managed-row round-trip (create managed group of mixed kinds →
+  reflow → persist → reload → positions stable) and "resize a child → siblings
+  reflow, one undo step." (Test contract: new runtime mutator ⇒ forward/reverse
+  sync coverage.)
+
+#### Phase 2 — Reorder model *(main; pure)*
+
+- Confirm D2: a helper `managedChildOrder(groupId)` returns child ids in
+  `entityOrder`-run order; `reorderManagedChild(groupId, childId, toIndex)` is a
+  thin wrapper over `entity-order-math.moveBlockBefore` constrained to the run,
+  then `reflowManagedGroup`. Single batched undo step.
+- **Tests:** unit on `reorderManagedChild` (move first→last, middle→middle,
+  no-op); smoke "reorder persists across reload" + "reorder is one undo step,
+  undo restores both order and positions."
+
+#### Phase 3 — Reorder gesture *(shared + renderer + IPC)*
+
+- **Hit-test:** add a `reorder-handle` layer (`src/shared/hit-test.ts`) above
+  `body`. A child contributes a center-dot target only when its managed group is
+  selected (or the child is selected within it). Dot geometry is a runtime-
+  derived slot (centre of the child rect), broadcast on the scene entity like
+  chrome slots — not persisted.
+- **Action:** new `CanvasPointerAction` `begin-reorder-drag { childId, groupId }`
+  in `src/shared/canvas-pointer-actions.ts`.
+- **Interaction mode:** new `reordering-child { groupId, childId }` in
+  `interaction-types.ts` / `interaction-controller.ts`. (We add a mode rather
+  than a `dragging-entities` payload per §5.6: commit semantics genuinely differ
+  — reorder+reflow vs free move — and it needs its own drop-index preview and
+  cancel path. Flag for ADR review.)
+- **IPC:** `canvas-reorder-child-{start,move,commit,cancel}` in a new
+  `register-canvas-reorder-ipc.ts`. `start` calls `tryEnter` **before** any
+  mutation (gesture-begin ordering gotcha — see `runtime/CLAUDE.md`). `move`
+  carries the cursor → main computes the target index and broadcasts a drop
+  preview. `commit` calls `reorderManagedChild` inside a batch. `cancel` →
+  `cancelActive`.
+- **Renderer:** `runReorderDrag` in `useCanvasPointerRouter.ts`, following the
+  per-handler conventions (pointer capture, window `blur`→cancel, threshold).
+  During the drag: lift the dragged child visually, render a gap insertion
+  indicator (reuse `GuidesLayer` line style) at the live target index.
+- **Tests:** smoke for the full gesture (begin/commit/cancel-on-escape/
+  cancel-on-blur/cancel-on-undo) mirroring the existing drag gesture matrix.
+
+#### Phase 4 — Dot affordance & hover polish *(renderer)*
+
+- Paint the center dots in aboveView (geometric hit target, like anchors —
+  *not* `data-overlay-ui` DOM buttons). Small at rest; grow when the item or
+  group is hovered. Hover state is renderer-local ephemera (§5.2) — no IPC.
+- Suppress dots during any active interaction (drag/resize/marquee/edit) and
+  while a tool other than `select` is active, matching popup suppression rules.
+- **Tests:** none required beyond Phase 3 (pure visual); verify manually.
+
+### Next — Reorder on *any* multi-selection *(revised priority, from dogfooding)*
+
+This is now the priority ahead of the Milestone 2 toolbar. Direction from the
+user after first use:
+
+> "I don't want a button. I want any multi-selection to have drag-to-reorder."
+
+**Goal.** Select 2+ entities → a center dot appears on each → drag a dot to
+reorder them; siblings shift to make room. No `Cmd+G`, no "make auto-layout"
+step, no toolbar button. Reorder becomes a property of *having a selection*, not
+of *being a managed group*.
+
+**Tension with the Milestone 1 canonical decisions — must be resolved first.**
+M1 made auto-layout deliberately group-backed and persisted (D1), with the
+layout sequence living in the group's `entityOrder` run (D2) and reflow as the
+sole writer of managed positions (D3). A loose multi-selection has none of that:
+no group, no contiguous run, no "managed" positions. So this step is *not* just
+loosening the dot-gating — it needs its own commit semantics. The two paths
+would share the gesture + dot rendering and diverge at commit.
+
+**Design options (pick before building):**
+
+- **A — Pure positional permute (no group, nothing persisted but positions).**
+  Dots show on any 2+ selection. The selection's current spatial order (sort by
+  position along the dominant axis) defines the sequence; dragging permutes the
+  items among the slots they already occupy, preserving the selection's outer
+  bounds and gaps. One undo step, position writes only; `entityOrder` untouched.
+  Closest to "just let me drag to reorder." *Open*: how to define slots for a
+  not-quite-a-row selection (even-distribute within bbox? keep existing gaps?),
+  and whether to show dots at all for clearly-scattered (non-collinear)
+  selections.
+- **B — Ephemeral managed row for the gesture's duration.** Same as A but
+  expressed through the existing reflow engine: treat the selection as a
+  transient row while dragging, reflow on each tick, leave items ungrouped on
+  release. Reuses `computeRowReflow`; still persists nothing but positions.
+- **C — Silent auto-group into a managed row.** Rejected for now: the user
+  explicitly doesn't want a button *or* a surprise group; silently mutating the
+  data model on a drag is the wrong feel.
+
+**Recommended:** A (or A-via-B internally). It honors "no button, it just
+works," keeps loose selections loose, and leaves the persisted managed-group
+feature (M1) intact for explicit auto-layout rows.
+
+**Work implied (sketch, not committed):**
+- Hit-test: gate the `reorder-handle` layer on *being in the current
+  multi-selection* (2+), in addition to the existing managed-group rule. Likely
+  an eligibility predicate (collinear-enough selection) so dots don't appear on
+  arbitrary scatter.
+- A pure slot/permute helper (selected boxes + target order → new positions
+  within current bounds), unit-tested like `computeRowReflow`.
+- A selection-reorder commit path distinct from `reorderManagedChild` (no group,
+  no `entityOrder` write) — one undo step.
+- Dots + insertion indicator already exist (`ReorderDotsLayer`); extend their
+  gating to the selection case.
+
+**Open questions for the user:**
+- **N1 — Slot model.** For a selection that isn't a clean row, do we (a) only
+  show dots when items are roughly collinear, (b) always allow reorder and
+  even-distribute within the bounding box, or (c) snap into a row on first
+  reorder? 
+- **N2 — Persistence.** Should selection-reorder ever persist anything beyond
+  the new positions (e.g. remember the row so re-selecting keeps the dots), or
+  stay purely ephemeral until the user explicitly makes an auto-layout group?
+- **N3 — Axis.** Row-only first, or detect vertical/grid selections and reorder
+  along the dominant axis?
+
+### Milestone 2 — Auto-layout toolbar *(deferred; documented for continuity)*
+
+Not in PR 1. Each is a later phase/PR:
+
+- **Wrap selection → auto-layout** (the frame icon): convert a freeform
+  multi-selection into a managed row group (or mark an existing group managed).
+  This is the entry point that makes auto-layout reachable on arbitrary content.
+- **Draggable gap handles** (the vertical bars between items) → persisted
+  `layoutGap`.
+- **Direction toggle** row/column/grid (live `layoutMode` reflow; generalize
+  `computeRowReflow` to the existing `layout-math` column/grid paths).
+- **Align** within the layout (start/center/end on the cross axis) → `layoutAlign`.
+- **Distribute** (one-shot) — already have `tidySelectedPages` math to lift.
+- **The floating multi-select toolbar shell** itself (a multi-select variant of
+  `CanvasItemPopup` anchored to the selection bbox via `useMultiAnchoredPosition`).
+
+> **Reachability note — resolved, then superseded.** Milestone 1 shipped the
+> headless "make auto-layout from selection" command (O1), so reorder is reachable
+> beyond page rows. Dogfooding showed even that is too hidden — the live priority
+> is now **reorder on any multi-selection** (see "Next" above), which makes the
+> wrap-in-frame button mostly redundant for reachability. This floating toolbar
+> remains the home for *spacing / direction / align / distribute*, not the entry
+> point for basic reorder.
+
+---
+
+## Build order
+
+```
+Phase 1 ──► Phase 2 ──► Phase 3 ──► Phase 4      (Milestone 1 ✅ done)
+   (reflow)   (order)    (gesture)   (polish)
+                                        │
+                                        ▼
+                        Next: reorder on any multi-selection
+                        (resolve N1–N3, then build the
+                         selection-reorder commit path)
+                                        │
+                                        ▼
+                              Milestone 2 — toolbar
+```
+
+Milestone 1 was strictly sequential — each phase the substrate for the next —
+and is complete. The next slice (selection-reorder) reuses Phases 3–4's gesture
+and dots and adds a non-group commit path; it now leads Milestone 2.
+
+Per the team's AFK-fast-route convention, each phase is one PR even if sizeable;
+don't pre-split on LOC. Block only on the real dependency edges above.
+
+---
+
+## Risks & invariants to respect
+
+- **I1 / layout pass.** All view-stack/visibility/bounds mutation stays in
+  `layoutAllViews`. Reflow writes entity data → `markDirty` → layout pass; never
+  `setBounds` directly.
+- **I2/I3 token discipline.** `canvas-reorder-child-start` must `tryEnter`
+  before mutating; commit/cancel must pair. Reorder is mutually exclusive with
+  every other gesture.
+- **Gesture-begin ordering** (`runtime/CLAUDE.md`). The `start` IPC enters
+  `reordering-child` before any `requestLayout`-triggering mutation, or focus
+  reconciliation cancels the gesture mid-drag (pages are the canary).
+- **Undo batching.** Reorder = `entityOrder` move + reflow position writes →
+  one `beginBatch`/`endBatch` + `markUndoBoundary`. One user action, one undo.
+- **Group contiguity (ADR 0014).** `reorderManagedChild` must keep the child
+  inside the group's run; reuse `enforceGroupContiguity`. Never let a reorder
+  leak a child out of its run.
+- **JSON Canvas round-trip.** `managedLayout`/`layoutMode` already serialize;
+  new `layoutGap`/`layoutAlign` (Milestone 2) are additive Specular extensions
+  (absent → default), same pattern as `specular.textStyle`.
+- **Mixed-surface groups (ADR 0014 split rows).** A managed group can contain
+  both notes and pages. Reflow operates in canvas space on all children
+  regardless of paint surface; verify the sidebar split-row representation is
+  unaffected (it reads `entityOrder`, which we mutate — confirm rows stay paired).
+
+---
+
+## Open questions for the user
+
+**All Milestone 1 open questions are resolved** (see Status §). Kept here for the
+record; live questions now live under "Next" (N1–N3).
+
+- **O1 — Reachability in Milestone 1.** ✅ Resolved: shipped the headless
+  command (`Shift+Cmd+A` / `specular auto-layout` / `POST /groups/auto-layout`).
+  Dogfooding then showed even this is too hidden → see "Next".
+- **O2 — New mode vs payload.** ✅ Resolved: new `reordering-child`
+  `InteractionController` mode (ADR 0015 D-O2).
+- **O3 — Body drag of a managed child** (D4). ✅ Resolved: body drag moves the
+  whole group; only the dot reorders.
+
+---
+
+## Test contract for this feature
+
+- New entity behavior on the **group** kind ⇒ smoke coverage of managed-row
+  persistence + undo round-trip (Phase 1).
+- New runtime mutators (`reflowManagedGroup`, `reorderManagedChild`) ⇒
+  forward/reverse sync coverage: one Y.Doc transaction per op, undo round-trips
+  cleanly (Phases 1–2).
+- New gesture ⇒ full begin/commit/cancel-on-{escape,blur,undo,tab-switch} smoke
+  matrix, mirroring the entity-drag gesture tests (Phase 3).
+- Touches `src/main/workspace-*.ts` (`workspace-pages.ts` reflow re-point) ⇒
+  smoke update required (not a pure refactor — behavior generalizes).
+- Re-read `tests/README.md` and clear the four-criterion bar before each test.

--- a/docs/plans/selection-reorder.md
+++ b/docs/plans/selection-reorder.md
@@ -1,0 +1,353 @@
+# Selection reorder — drag-to-reorder any aligned multi-selection
+
+> **Refactor of the auto-layout WIP.** Supersedes the "Next — Reorder on *any*
+> multi-selection" section of [`auto-layout-reorder.md`](./auto-layout-reorder.md)
+> and reframes [ADR 0015](../adr/0015-auto-layout-groups.md). Milestone 1 (the
+> persisted, group-backed auto-layout row) stays — it is *demoted* from "the
+> entry point for reorder" to "the opt-in way to make a reorder permanent."
+
+## Goal
+
+Select 2+ entities that form an evenly-spaced row → a **center dot** appears on
+each → drag a dot to reorder; siblings reflow to keep the row even. No `Cmd+G`,
+no "make auto-layout" step, no toolbar button. Reorder is a property of *having
+an aligned selection*, not of *being a managed group*. Nothing persists but the
+new positions.
+
+**The eligibility rule is FigJam's, and it is the spec:**
+
+- Multi-selection with **equal gaps** between consecutive items along the
+  dominant axis → dots show. (FigJam screenshot: four squares, equal spacing,
+  dot on each + gap bars between.)
+- The moment spacing becomes **unequal** → dots disappear. (Same four squares,
+  uneven spacing, no dots.)
+
+Equal-gap detection does double duty: it gates the affordance *and* it defines
+the slots/gap the reflow packs into. A selection that isn't already a clean row
+has no well-defined slots, so it gets no dots — the ambiguity never arises.
+
+## The inversion — why this is a refactor, not an add-on
+
+Milestone 1 and this goal point opposite directions on the source of truth:
+
+| | Source of truth | Derived |
+|---|---|---|
+| **M1 (managed group)** | stored order (the group's `entityOrder` run) | child positions (reflow output) |
+| **This goal** | positions (geometry) | order (read from geometry per gesture) |
+
+M1 is Figma's *persistent container* model: a stored child order, positions
+recomputed from it. This goal has **no container** — so there is nowhere for a
+stored order to live, and geometry *must* be the truth. Reorder becomes
+position→position; the "sequence" is an ephemeral read of the boxes at
+gesture-start.
+
+Geometry-is-truth is also the **simpler** implementation, because positions are
+already persisted, already undoable, already drag-writable. We add **zero new
+persisted state**. Concretely, it deletes a complication M1 had to invent:
+`commitAsOneTransaction` (`workspace-observers.ts:132`) exists *only* to merge
+`writeEntityOrder`'s own transaction with reflow's diff-synced position writes
+into one undo step. With no stored order to write, a reorder is just a batched
+multi-entity position write — one transaction through the normal drag batch. The
+ADR's "Undo batching" section and the "reorder is one Y.Doc transaction" smoke
+assertion both defend a problem D2 *created*; this model removes it instead.
+
+## Eligibility: the "reorderable row" (pure, the heart of the feature)
+
+A new pure module `src/shared/reorder-row.ts`. No Electron, no DOM — unit-tested
+in isolation like `computeRowReflow`. Shared so the hit-tester, the renderer
+painter, and the main-side commit all use *one* definition (the M1 duplication
+between `hit-test.ts` and `ReorderDotsLayer.tsx` is exactly what we must not
+repeat).
+
+```ts
+interface Box { id: string; x: number; y: number; width: number; height: number }
+
+interface ReorderableRow {
+  axis: 'x' | 'y'                  // dominant axis (larger center spread)
+  order: string[]                  // ids sorted along axis
+  gap: number                      // the common gap (avg of equal gaps)
+  origin: { x: number; y: number } // min corner — packing start
+  boxesById: Map<string, Box>      // frozen sizes/cross-axis at detect time
+}
+
+/** Equal-gap row detector + eligibility gate. Returns null when the selection
+ *  is not a clean, evenly-spaced, non-overlapping line. */
+function detectReorderableRow(
+  boxes: readonly Box[],
+  opts?: { gapTolerance?: number }, // default ~1px (snapped content is exact)
+): ReorderableRow | null
+
+/** Drop index for a cursor position along the row's axis: how many *other*
+ *  items have their center before the cursor. (Generalizes M1's
+ *  computeReorderDropIndex off a groupId onto a box list.) */
+function dropIndexForCursor(row: ReorderableRow, cursorAlongAxis: number, movingId: string): number
+
+/** Repack the row with `movingId` moved to `dropIndex`. Packs along `axis`
+ *  from `origin` by `gap`; each item KEEPS its own cross-axis coordinate
+ *  (a box that sat lower stays lower — see open question Q1). Returns only
+ *  the positions that changed. */
+function reorderRowPositions(row: ReorderableRow, movingId: string, dropIndex: number): Map<string, { x: number; y: number }>
+```
+
+`detectReorderableRow`, sketch:
+
+```
+if boxes.length < 2 → null
+axis = spread(centers.x) >= spread(centers.y) ? 'x' : 'y'
+sort by leading edge along axis
+gaps[i] = next.leadingEdge - cur.trailingEdge      // along axis
+if any gap < 0 → null                              // overlap = not a row
+if max(gaps) - min(gaps) > gapTolerance → null     // unequal = no dots
+return { axis, order, gap: avg(gaps), origin: minCorner, boxesById }
+```
+
+That's the whole eligibility brain. Dumb, total, testable.
+
+## Architecture — keep / generalize / demote
+
+### Keep wholesale (already group-agnostic in spirit)
+
+- **`computeRowReflow`** (`layout-math.ts:59`) — stays the *managed-group* packer
+  (shared top/start-alignment). The selection path uses `reorderRowPositions`
+  instead because it preserves per-item cross-axis; both are tiny pure packers.
+- **The gesture** — `runReorderDrag` (`useCanvasPointerRouter.ts:1083`), the IPC
+  family (`register-canvas-reorder-ipc.ts`), the `reorder-gesture.ts`
+  coordinator, pointer capture + blur/escape/undo cancel matrix. Group-free
+  already; only the *begin payload* and *commit target* change.
+- **Dot + insertion-line visuals** (`ReorderDotsLayer.tsx`) — keep the SVG; swap
+  the gating source (see below).
+- **The `reorder-handle` hit layer + priority slot** (`hit-test.ts`,
+  `interaction-priority.ts`) — keep; swap the eligibility source.
+
+### Generalize (the new spine)
+
+1. **`src/shared/reorder-row.ts`** — the pure module above.
+2. **One shared dot selector** — `reorderableDots(layout) → { id, center }[]`,
+   the single source for *both* the hit-tester (`collectReorderHandleTargets`)
+   and the painter (`ReorderDotsLayer`). Eligibility = the union of two doors
+   (next section). Kills the copy-pasted predicate.
+3. **`reorderSelection(orderedIds, movingId, dropIndex)`** (main runtime) — the
+   position-only commit. Computes positions via `reorderRowPositions`, writes
+   each through its per-kind mutator inside one `beginBatch`/`endBatch` +
+   `markUndoBoundary` (the same batched-multi-write shape `resizeMultiSelection`
+   already uses). No `entityOrder`, no `managedLayout`, no
+   `commitAsOneTransaction`.
+4. **Rename the mode** `reordering-child { groupId, childId, dropIndex }` →
+   `reordering-row { ids, movingId, dropIndex, axis }` in
+   `interaction-types.ts` (+ controller/state/snapshot). The shared interaction
+   type is the most expensive-to-reverse surface (§5.6); "child" bakes in the
+   group assumption, and the renderer needs `ids` to draw the insertion line
+   door-agnostically.
+
+### Two doors, one gesture (managed group demoted, not deleted)
+
+The gesture + dots + mode are shared; only **eligibility** and **commit**
+branch. Exactly the "share the gesture, diverge at commit" split the old plan's
+"Next" predicted — now made concrete:
+
+| Door | Eligibility | Commit |
+|---|---|---|
+| **Selection** (new, primary) | `detectReorderableRow(selectedBoxes)` ≠ null | `reorderSelection` — positions only, ephemeral |
+| **Managed group** (M1, persisted) | a managed-row group is selected → its children | `reorderManagedChild` — rewrites `entityOrder` run, persists |
+
+`reorderableDots(layout)` returns the union; `reorder-gesture.ts` records which
+door armed the gesture and dispatches the matching commit. M1's persisted row
+keeps working unchanged; it's just no longer the *only* way to see a dot.
+
+This preserves the reframe: **the default is ephemeral and free; `make-auto-layout`
+(`Shift+Cmd+A` / CLI / HTTP) becomes purely "crystallize this arrangement into a
+managed row so future inserts auto-reflow" — a deliberate later act, not a
+precondition.** It also keeps `reflowManagedGroup` earning its keep as the
+engine behind multi-breakpoint page rows (`addPageFromSource`).
+
+### Unchanged (managed door internals)
+
+`reflowManagedGroup`, `reorderManagedChild`, `makeAutoLayoutGroup`,
+`managedChildOrder` / `writeManagedChildOrder`, the `entityOrder` coupling, the
+`make-auto-layout` binding/CLI/HTTP, `commitAsOneTransaction`. All scoped to the
+managed door now.
+
+### No longer the story (but not deleted)
+
+The reachability narrative "make-auto-layout is how you get reorder." Dots now
+come from eligible selections; the headless command only adds persistence.
+
+## Gesture freeze (stability)
+
+Freeze the `ReorderableRow` at gesture start (slots, gap, order, box sizes,
+cross-axis). `dropIndexForCursor` runs against the frozen non-moving slots; the
+live preview and commit repack the frozen order. Freezing avoids a feedback loop
+between the live-preview reflow and re-detection mid-drag.
+
+## Prerequisites — do these before `/afk-local`
+
+*Not a worker task — human setup.* This refactor builds **on Milestone 1** (the
+persisted managed-group auto-layout), which currently sits **uncommitted** on
+`feat/auto-layout`. Phase C references M1 code directly (`reorderManagedChild`,
+the renamed `reordering-child` mode, the `reorder-handle` hit layer,
+`ReorderDotsLayer`), so M1 must exist in the branch the loop builds from.
+
+`/afk-local` creates `claude/feat-selection-reorder` from `origin/main`, and every
+worker fire runs `git reset --hard origin/<branch>` — so uncommitted M1 would be
+**wiped**, and a main-based branch wouldn't contain M1 at all. Before kicking off,
+pick one:
+
+- **(a) Land M1 first (recommended).** Commit the M1 WIP on `feat/auto-layout` and
+  merge it to `main` (it typechecks and passes its managed-layout smoke per the M1
+  plan). Then `/afk-local docs/plans/selection-reorder.md` branches cleanly from
+  main with M1 present.
+- **(b) Branch off M1 manually.** Commit + push `feat/auto-layout`, create
+  `claude/feat-selection-reorder` from it, commit the plan + the `dex` epic, and
+  run `scripts/afk-loop.sh <epic-id>` directly (bypassing the main-based branch
+  creation).
+
+Either way the working tree must be clean and pushed before the loop starts.
+
+## Working agreement — applies to every phase
+
+- **Read this plan top-to-bottom first.** The design is locked in §Goal, §The
+  inversion, §Eligibility, and §Architecture — don't re-open it. Block only on a
+  real dependency gap or a decision genuinely outside this plan; otherwise proceed
+  on the documented default (see §Open questions).
+- One PR per phase; don't pre-split on LOC (AFK fast-route).
+- Honor the interaction-layer invariants (`docs/interaction-layer.md` §6) and the
+  gesture-begin ordering rule (`src/main/runtime/CLAUDE.md`): a begin-IPC must
+  `tryEnter` before any layout-triggering mutation. Pointer events only; canvas
+  coord math from `src/shared/coords.ts`; no `setTimeout(0)` — `markDirty` + return.
+- `src/renderer` must not import from `src/main`; `src/shared` stays side-effect-free.
+- Verify before opening the PR: `pnpm typecheck && pnpm test:unit` (always) +
+  `pnpm test:smoke` (Phases B, C). The pre-existing `pages > takes a screenshot`
+  smoke is environmental — ignore it; everything else must be green.
+- Semantic commits, no emojis; `Co-Authored-By` trailer on commits, the Claude
+  Code line on PR bodies. UI-facing copy in sentence case. The `reordering-child →
+  reordering-row` rename is internal — keep it out of any changelog headline. If a
+  step must merge a PR, `gh auth switch --user lklyne` first.
+
+## Build order
+
+```
+Phase 0 ──► A ──────► B ──────────► C ───────────────► D
+ (docs)    (kernel)  (commit path)  (gating+gesture)   (live preview)
+```
+
+Phase 0 first — lock the inversion in ADR 0015 before code builds on it. A→B→C is
+the dependency spine. D is independent polish after C, and its visual check needs
+a human (the headless loop can't eyeball the canvas).
+
+## Phase 0 — Lock the model in docs (ADR 0015 + CONTEXT.md)
+
+Before starting: see §Working agreement. No source changes — encode the inversion
+in the canonical docs so the code phases build on a settled model.
+
+- **ADR 0015** (`docs/adr/0015-auto-layout-groups.md`) — add **D7 — Selection
+  reorder:** geometry-is-truth, position-only, ephemeral; eligibility = equal-gap
+  row (FigJam parity); the gesture + dots are shared with the managed door,
+  diverging only at commit (`reorderSelection` vs `reorderManagedChild`). Reframe
+  **D1**: a managed group is the opt-in *persistent crystallization* of a
+  reorderable arrangement, not the entry point for reorder.
+- **CONTEXT.md** (Auto-layout section) — add **Reorderable row:** an evenly-spaced
+  multi-selection (equal gaps along the dominant axis) that exposes reorder dots;
+  ephemeral, no group, nothing persisted but positions. Clarify dots now appear on
+  eligible selections, and `make-auto-layout` is the persist-it upgrade.
+- **Done when:** both docs updated; `pnpm typecheck` still clean.
+
+## Phase A — Pure kernel: `src/shared/reorder-row.ts`
+
+Before starting: see §Working agreement; the signatures live in §Eligibility —
+implement them, don't redesign them. Depends on nothing.
+
+Build the pure module — `detectReorderableRow`, `dropIndexForCursor`,
+`reorderRowPositions` — exactly as specced in §Eligibility. No Electron, no DOM;
+`src/shared` stays side-effect-free.
+
+- **Done when (unit tests):** equal-gap row → eligible; one unequal gap → null;
+  overlapping items → null; 2 items; vertical column; gap-tolerance boundary;
+  mixed-width repack moves the correct edges; cross-axis preserved (Q1);
+  drop-index at both ends. `pnpm typecheck && pnpm test:unit` green.
+
+## Phase B — Selection commit path: `reorderSelection` (main runtime)
+
+Before starting: see §Working agreement. Depends on Phase A.
+
+Add `reorderSelection(orderedIds, movingId, dropIndex)` in the main runtime:
+compute target positions via `reorderRowPositions`, write each entity through its
+per-kind mutator inside one `beginBatch`/`endBatch` + `markUndoBoundary` (mirror
+`resizeMultiSelection`'s batched multi-write). **No** `entityOrder` write, **no**
+`managedLayout`, **no** `commitAsOneTransaction`. Add a test-only route + an
+`AppClient` helper so smoke can drive it.
+
+- **Done when (smoke):** reordering a loose equal-gap selection permutes positions
+  to the new sequence; **one undo step** restores them; `entityOrder` is unchanged
+  and **no `managedLayout` group appears on disk** (mutation-verify: assert the
+  disk snapshot has no group). Forward/reverse sync per `runtime/CLAUDE.md`.
+  `pnpm test:smoke` green.
+
+## Phase C — Gating + gesture rewire (two doors)
+
+Before starting: see §Working agreement and §Architecture ("Two doors" +
+"Gesture freeze"). Depends on A + B. This phase edits the shared interaction type
+— the costliest surface to reverse — so get the rename right.
+
+- One shared `reorderableDots(layout) → { id, center }[]` selector returning the
+  **union** of the two doors (eligible selection via `detectReorderableRow`, plus
+  a selected managed-row group's children). Consume it in **both** `hit-test.ts`
+  `collectReorderHandleTargets` and `ReorderDotsLayer` — delete the duplicated
+  predicate.
+- Rename the mode `reordering-child { groupId, childId, dropIndex }` →
+  `reordering-row { ids, movingId, dropIndex, axis }` across `interaction-types.ts`,
+  the controller, `interaction-state.ts`, and the snapshot.
+- `begin-reorder-drag` drops the required `groupId` (carry `movingId`; main
+  resolves which door armed it). `reorder-gesture.ts` freezes the row at start and
+  branches commit: selection → `reorderSelection`; managed group →
+  `reorderManagedChild`.
+- **Done when (smoke):** full begin/move/commit/cancel-{escape,blur,undo,tab-switch}
+  matrix for the **selection** door (mirror the M1 matrix in
+  `managed-layout.test.ts`); regression that the **managed** door still commits via
+  `reorderManagedChild`; an **unequal-gap** selection exposes **no** reorder hit
+  target. `pnpm typecheck && pnpm test:unit && pnpm test:smoke` green.
+
+## Phase D — Live reflow preview (renderer)
+
+Before starting: see §Working agreement. Depends on C; independent polish.
+
+During the drag, reflow siblings visibly via renderer-side `reorderRowPositions`
+against the frozen row, instead of only painting an insertion line — the
+difference between "elegant" and "mechanical." Pure renderer ephemera: no IPC, no
+data change.
+
+- **Done when:** siblings shift to make room as the dragged dot crosses slot
+  boundaries; release commits to the previewed arrangement. **Verify in-app** — the
+  headless loop can't eyeball this, so a human (or an attended `/verify` pass)
+  confirms the acceptance feel: dots on an equal-gap selection, dots vanish when
+  spacing is uneven, drag reorders with live reflow, one undo restores, and reload
+  shows only moved positions (no group, no `managedLayout`). `pnpm typecheck` green.
+
+## Open questions (with dumb defaults)
+
+- **Q1 — Cross-axis on reorder.** *Default: each item keeps its own cross-axis
+  coordinate* (a box that sat lower stays lower; we only permute along the
+  dominant axis). Matches the FigJam screenshot (the offset 4th box keeps its
+  offset). Alternative: snap all to a shared baseline — defer to Milestone 2
+  align.
+- **Q2 — Column support.** The predicate is axis-generic; ship **row** first,
+  flip on column in the same module once row is solid (near-free).
+- **Q3 — Staircase edge case.** Equal x-gaps + monotonically rising y would
+  currently qualify as a row. Acceptable for v1 (rare; reorder still does
+  something sane). Add a cross-axis-overlap guard only if it bites.
+- **Q4 — Gap tolerance.** Start ~1px (snapped/distributed content has exact
+  gaps). Widen only if dogfooding shows near-even rows frustratingly excluded.
+- **Q5 — Mode vs payload (§5.6).** Kept as a mode (`reordering-row`) because the
+  preview + cancel path differ; but note it's now a close cousin of
+  `dragging-entities` (commit is also a position write). Revisit collapsing to a
+  payload if the two converge further.
+
+## Test contract for this feature
+
+- New pure module ⇒ unit coverage of every predicate branch (Phase A).
+- New runtime mutator (`reorderSelection`) ⇒ forward/reverse sync: one Y.Doc
+  transaction, undo round-trips, nothing persisted but positions (Phase B).
+- New/renamed gesture ⇒ full begin/commit/cancel-{escape,blur,undo,tab-switch}
+  smoke matrix (Phase C).
+- Re-read `tests/README.md`; clear the four-criterion bar before each test.
+
+*(The ADR 0015 / CONTEXT.md amendments are Phase 0 above — they land first.)*

--- a/resources/skills/specular/SKILL.md
+++ b/resources/skills/specular/SKILL.md
@@ -32,6 +32,7 @@ canvas and page operations go through the `specular` command.
 | `specular find-placement` | Find open canvas space for new entities |
 | `specular link <a> <b>` | Connect two pages with an edge |
 | `specular group <id…>` | Group entities together |
+| `specular auto-layout <id…>` | Make a managed auto-layout row from a selection (or convert a single group); children pack left-to-right and can be drag-reordered |
 | `specular breakpoints <id>` | Cycle through device breakpoints for a page |
 | `specular annotate "<text>"` | Leave a comment on the canvas (anchor type from context — viewport by default; `--page-id` for a page anchor) |
 | `specular annotations` | List unresolved annotations (pending + acknowledged) |

--- a/src/main/cli-commands.ts
+++ b/src/main/cli-commands.ts
@@ -260,6 +260,29 @@ const ungroup: VerbHandler = async (args) => {
   return 0
 }
 
+// Mark a group (or a fresh group made from 2+ entities) as an auto-layout row:
+// children reflow left-to-right and can be drag-reordered. A single group id
+// converts that group in place. (ADR 0015)
+const autoLayout: VerbHandler = async (args) => {
+  if (args.positional.length === 0) {
+    printError('usage: specular auto-layout <entityId> [entityId...]  (or a single groupId)')
+    return 1
+  }
+  const onlyGroup =
+    args.positional.length === 1 && args.positional[0].startsWith('group_')
+      ? args.positional[0]
+      : undefined
+  printJson(await callApp('/groups/auto-layout', {
+    method: 'POST',
+    body: JSON.stringify(
+      onlyGroup
+        ? { groupId: onlyGroup, label: args.flags.label }
+        : { entityIds: args.positional, label: args.flags.label },
+    ),
+  }))
+  return 0
+}
+
 // --- Annotation verbs ---
 
 const annotations: VerbHandler = async (args) => {
@@ -527,6 +550,7 @@ const VERBS: Record<string, VerbHandler> = {
   unlink,
   group,
   ungroup,
+  'auto-layout': autoLayout,
   annotations,
   annotation,
   annotate,

--- a/src/main/ipc/register-canvas-drag-ipc.ts
+++ b/src/main/ipc/register-canvas-drag-ipc.ts
@@ -51,8 +51,13 @@ import {
 } from '../workspace-clipboard'
 import { descendantEntityIdsForGroup } from '../runtime/group-descendants'
 import { duplicateGroup } from '../workspace-groups'
+import { reflowManagedGroupForChild } from '../managed-layout'
 
 const VIEWPORT_EVENT_FRAME_MS = 16
+
+// The entity currently being resized, captured at resize-begin so resize-end can
+// reflow its managed group (if any) before committing the gesture's undo step.
+let resizingEntityId: string | null = null
 
 let pendingViewportDelta = {
   zoomDeltaY: 0,
@@ -364,6 +369,7 @@ export function registerCanvasDragIpc(): void {
       // listener cancels the gesture after one pixel. Same gotcha as the
       // drag-start ordering — see runtime/CLAUDE.md.
       tryEnter({ kind: 'resizing-entity', target: { id: entityId, kind: entityKind } })
+      resizingEntityId = entityId
       initializeResizeGuides(entityId, handle)
       // Coalesce the gesture's per-tick bounds mutations into one Y.Doc
       // transaction / one undo step — mirrors drag (initializeDrag/finalizeDrag).
@@ -373,6 +379,10 @@ export function registerCanvasDragIpc(): void {
 
   ipcMain.on('canvas-resize-end', () => {
     finalizeResizeGuides()
+    // A managed child changing size reflows its siblings within the same batch,
+    // so the row re-packs in one undo step (ADR 0015 D3).
+    if (resizingEntityId) reflowManagedGroupForChild(resizingEntityId)
+    resizingEntityId = null
     endBatch()
     markUndoBoundary()
     commitActive()

--- a/src/main/ipc/register-canvas-ipc.ts
+++ b/src/main/ipc/register-canvas-ipc.ts
@@ -76,11 +76,13 @@ import {
 import { consumeDragId } from '../runtime/drop-owner'
 import { registerCanvasDragIpc } from './register-canvas-drag-ipc'
 import { registerCanvasEntityIpc } from './register-canvas-entity-ipc'
+import { registerCanvasReorderIpc } from './register-canvas-reorder-ipc'
 import { reorderSidebarStackOrder } from '../runtime/entity-order-state'
 
 export function registerCanvasIpc(): void {
   registerCanvasDragIpc()
   registerCanvasEntityIpc()
+  registerCanvasReorderIpc()
 
   // --- Selection ---
 

--- a/src/main/ipc/register-canvas-reorder-ipc.ts
+++ b/src/main/ipc/register-canvas-reorder-ipc.ts
@@ -1,0 +1,41 @@
+import { ipcMain } from 'electron'
+import type { CancelReason } from '../../shared/interaction-types'
+import {
+  cancelReorderGesture,
+  commitReorderGesture,
+  moveReorderGesture,
+  startReorderGesture,
+} from '../reorder-gesture'
+
+/**
+ * IPC for the auto-layout reorder gesture (ADR 0015 Phase 3). Thin wrappers over
+ * the reorder-gesture coordinator; the renderer's `runReorderDrag` dispatches
+ * start → move* → commit | cancel.
+ *
+ * `start` enters the interaction mode before any mutation (gesture-begin
+ * ordering — see runtime/CLAUDE.md), so the first `requestLayout` reconciles
+ * focus against `reordering-child` rather than `idle`.
+ */
+export function registerCanvasReorderIpc(): void {
+  ipcMain.on(
+    'canvas-reorder-child-start',
+    (_event, { childId, groupId }: { childId: string; groupId: string }) => {
+      startReorderGesture(childId, groupId)
+    },
+  )
+
+  ipcMain.on(
+    'canvas-reorder-child-move',
+    (_event, { canvasX }: { canvasX: number; canvasY: number }) => {
+      moveReorderGesture(canvasX)
+    },
+  )
+
+  ipcMain.on('canvas-reorder-child-commit', () => {
+    commitReorderGesture()
+  })
+
+  ipcMain.on('canvas-reorder-child-cancel', (_event, { reason }: { reason?: CancelReason } = {}) => {
+    cancelReorderGesture(reason ?? 'external')
+  })
+}

--- a/src/main/layout-math.ts
+++ b/src/main/layout-math.ts
@@ -50,6 +50,28 @@ export function computeLayoutMetrics(
 }
 
 /**
+ * Pack boxes left-to-right into a single row from an explicit origin, separated
+ * by a fixed gap. The managed-layout kernel: each child keeps its own size, the
+ * cursor advances by width + gap. All children share the row's top (`originY`);
+ * cross-axis alignment is a Milestone 2 concern. Pure — no grid-snap (the caller
+ * snaps the origin; see managed-layout reflow, ADR 0015 D5).
+ */
+export function computeRowReflow(
+  children: LayoutBox[],
+  gap: number,
+  originX: number,
+  originY: number,
+): Array<{ canvasX: number; canvasY: number }> {
+  const positions: Array<{ canvasX: number; canvasY: number }> = []
+  let cursorX = originX
+  for (const child of children) {
+    positions.push({ canvasX: cursorX, canvasY: originY })
+    cursorX += child.width + gap
+  }
+  return positions
+}
+
+/**
  * Place items at an explicit origin in row/column/grid. Grid uses uniform
  * tracks (each cell sized to the largest item's dim) so heterogeneous content
  * still aligns to a clean grid.

--- a/src/main/managed-layout.ts
+++ b/src/main/managed-layout.ts
@@ -1,0 +1,295 @@
+import type { WorkspaceGroup } from '../shared/types'
+import { CLUSTER_HORIZONTAL_GUTTER, USER_GROUP_PADDING } from '../shared/constants'
+import { computeRowReflow, type LayoutBox } from './layout-math'
+import { pages } from './runtime/page-runtime'
+import { textEntities } from './runtime/text-entity-state'
+import { fileEntities } from './runtime/file-entity-state'
+import { shapeEntities } from './runtime/shape-entity-state'
+import { drawingEntities } from './runtime/drawing-entity-state'
+import { workspaceGroups } from './runtime/workspace-model'
+import { pageContentSize, requestLayout, snapToGrid } from './runtime/surface-layout'
+import { markDirty } from './runtime/layout-dirty'
+import { managedChildOrder, writeManagedChildOrder } from './runtime/entity-order-state'
+import { commitAsOneTransaction } from './runtime/workspace-observers'
+import { scheduleWorkspaceAutosave } from './runtime/workspace-session'
+import { createUserGroup } from './workspace-groups'
+import {
+  entityBoundsById,
+  groupById,
+  groupDescendantIds,
+  pageSelectableBounds,
+  unionBounds,
+} from './workspace-entities'
+
+/**
+ * A managed group's child as the reflow engine sees it: a sized box plus a way
+ * to write its new canvas origin. Pages report their content size (chrome is
+ * excluded from the packing axis); sub-groups translate their whole subtree.
+ */
+interface ManagedChild extends LayoutBox {
+  id: string
+  /** Current top-left used as the packing origin source (min across children). */
+  canvasX: number
+  canvasY: number
+  setOrigin: (x: number, y: number) => void
+}
+
+function resolveManagedChild(id: string): ManagedChild | null {
+  const page = pages.find((p) => p.id === id)
+  if (page) {
+    const size = pageContentSize(page)
+    return {
+      id,
+      width: size.width,
+      height: size.height,
+      canvasX: page.canvasX,
+      canvasY: page.canvasY,
+      setOrigin: (x, y) => {
+        page.canvasX = x
+        page.canvasY = y
+      },
+    }
+  }
+  for (const arr of [textEntities, fileEntities, shapeEntities, drawingEntities]) {
+    const entity = (arr as Array<{ id: string; canvasX: number; canvasY: number; width: number; height: number }>).find(
+      (e) => e.id === id,
+    )
+    if (entity) {
+      return {
+        id,
+        width: entity.width,
+        height: entity.height,
+        canvasX: entity.canvasX,
+        canvasY: entity.canvasY,
+        setOrigin: (x, y) => {
+          entity.canvasX = x
+          entity.canvasY = y
+        },
+      }
+    }
+  }
+  const group = workspaceGroups.find((g) => g.id === id)
+  if (group) {
+    return {
+      id,
+      width: group.width,
+      height: group.height,
+      canvasX: group.canvasX,
+      canvasY: group.canvasY,
+      // Translate the whole subtree so a nested group moves as a unit.
+      setOrigin: (x, y) => translateGroupSubtree(group, x - group.canvasX, y - group.canvasY),
+    }
+  }
+  return null
+}
+
+function translateGroupSubtree(group: WorkspaceGroup, dx: number, dy: number): void {
+  if (dx === 0 && dy === 0) return
+  group.canvasX += dx
+  group.canvasY += dy
+  for (const descendantId of groupDescendantIds(group.id)) {
+    const child = resolveLeafForTranslate(descendantId)
+    if (child) {
+      child.canvasX += dx
+      child.canvasY += dy
+    }
+  }
+}
+
+function resolveLeafForTranslate(
+  id: string,
+): { canvasX: number; canvasY: number } | null {
+  return (
+    pages.find((p) => p.id === id) ??
+    textEntities.find((e) => e.id === id) ??
+    fileEntities.find((e) => e.id === id) ??
+    shapeEntities.find((e) => e.id === id) ??
+    drawingEntities.find((e) => e.id === id) ??
+    workspaceGroups.find((g) => g.id === id) ??
+    null
+  )
+}
+
+function recomputeGroupBounds(group: WorkspaceGroup, childIds: string[]): void {
+  const bounds = unionBounds(
+    childIds
+      .map((id) => {
+        const page = pages.find((p) => p.id === id)
+        return page ? pageSelectableBounds(page) : entityBoundsById(id)
+      })
+      .filter((b): b is NonNullable<typeof b> => b !== null),
+  )
+  if (!bounds) return
+  group.canvasX = bounds.x - USER_GROUP_PADDING
+  group.canvasY = bounds.y - USER_GROUP_PADDING
+  group.width = bounds.width + USER_GROUP_PADDING * 2
+  group.height = bounds.height + USER_GROUP_PADDING * 2
+}
+
+/**
+ * The single writer of a managed group's child positions (ADR 0015 D3). Resolves
+ * the group's direct children in `entityOrder` run order, packs them as a row,
+ * writes each origin, and recomputes the group bbox. Any change to a managed
+ * group — membership, child resize, reorder — funnels through here. Children
+ * never hold authoritative positions; these are outputs.
+ *
+ * No-op for `freeform` / unmanaged groups. Does not call `requestLayout` — the
+ * caller owns the layout pass and undo batching.
+ */
+export function reflowManagedGroup(groupId: string): boolean {
+  const group = groupById(groupId)
+  if (!group || !group.managedLayout) return false
+  if (group.layoutMode !== 'row') return false // only row is live in Milestone 1
+
+  const orderedIds = managedChildOrder(groupId)
+  if (!orderedIds.length) return false
+
+  const children = orderedIds
+    .map(resolveManagedChild)
+    .filter((c): c is ManagedChild => c !== null)
+  if (!children.length) return false
+
+  const originX = snapToGrid(Math.min(...children.map((c) => c.canvasX)))
+  const originY = snapToGrid(Math.min(...children.map((c) => c.canvasY)))
+
+  const positions = computeRowReflow(children, CLUSTER_HORIZONTAL_GUTTER, originX, originY)
+  children.forEach((child, index) => {
+    const pos = positions[index]
+    child.setOrigin(pos.canvasX, pos.canvasY)
+  })
+
+  recomputeGroupBounds(group, orderedIds)
+  markDirty('canvas', 'sidebar')
+  return true
+}
+
+/**
+ * Reflow the managed group that directly contains `childId`, if any. Used by
+ * gesture commits (resize) that know the child but not whether its group is
+ * managed.
+ */
+export function reflowManagedGroupForChild(childId: string): boolean {
+  const parentId = resolveLeafParentGroupId(childId)
+  if (!parentId) return false
+  return reflowManagedGroup(parentId)
+}
+
+function resolveLeafParentGroupId(id: string): string | null {
+  const page = pages.find((p) => p.id === id)
+  if (page) return page.parentGroupId ?? null
+  const entity =
+    textEntities.find((e) => e.id === id) ??
+    fileEntities.find((e) => e.id === id) ??
+    shapeEntities.find((e) => e.id === id) ??
+    drawingEntities.find((e) => e.id === id)
+  if (entity) return entity.parentGroupId ?? null
+  const group = workspaceGroups.find((g) => g.id === id)
+  if (group) return group.parentGroupId ?? null
+  return null
+}
+
+/**
+ * Drop index for a reorder-in-progress: where `childId` would land if released
+ * with the cursor at `cursorCanvasX`. Counts how many *other* children have their
+ * center left of the cursor. Returns an index into the without-dragged sequence
+ * (0..n-1), directly consumable by `reorderManagedChild`.
+ */
+export function computeReorderDropIndex(
+  groupId: string,
+  childId: string,
+  cursorCanvasX: number,
+): number {
+  const others = managedChildOrder(groupId).filter((id) => id !== childId)
+  let index = 0
+  for (const id of others) {
+    const child = resolveManagedChild(id)
+    if (!child) continue
+    if (cursorCanvasX > child.canvasX + child.width / 2) index++
+  }
+  return index
+}
+
+function clampIndex(index: number, length: number): number {
+  if (length <= 0) return 0
+  return Math.max(0, Math.min(index, length - 1))
+}
+
+/**
+ * Move `childId` to `toIndex` within its managed group's layout sequence, then
+ * reflow. The order rewrite and the position reflow run inside one transaction
+ * so the whole reorder is a single undo step (ADR 0015 undo batching). Returns
+ * true if the order changed. No-op when the group is unmanaged, the child isn't
+ * a direct child, or the move is a no-op.
+ */
+export function reorderManagedChild(
+  groupId: string,
+  childId: string,
+  toIndex: number,
+): boolean {
+  const group = groupById(groupId)
+  if (!group || !group.managedLayout) return false
+
+  const order = managedChildOrder(groupId)
+  const from = order.indexOf(childId)
+  if (from === -1) return false
+
+  const clampedTo = clampIndex(toIndex, order.length)
+  if (from === clampedTo) return false
+
+  const next = order.filter((id) => id !== childId)
+  next.splice(clampedTo, 0, childId)
+
+  let changed = false
+  commitAsOneTransaction(() => {
+    changed = writeManagedChildOrder(groupId, next)
+    if (changed) reflowManagedGroup(groupId)
+  })
+  if (changed) requestLayout()
+  return changed
+}
+
+/**
+ * Headless entry point for "make auto-layout from selection" (plan O1). Marks a
+ * group as a managed row — creating one from `entityIds` if no `groupId` is
+ * given — seeds the layout sequence to the children's current left-to-right
+ * order so nothing jumps, and reflows. One undo step.
+ *
+ * Returns the managed group, or null if there's nothing to manage.
+ */
+export function makeAutoLayoutGroup(input: {
+  groupId?: string
+  entityIds?: string[]
+  label?: string
+}): WorkspaceGroup | null {
+  let result: WorkspaceGroup | null = null
+  commitAsOneTransaction(() => {
+    let group: WorkspaceGroup | undefined
+    if (input.groupId) {
+      group = groupById(input.groupId)
+    } else if (input.entityIds && input.entityIds.length === 1 && groupById(input.entityIds[0])) {
+      group = groupById(input.entityIds[0])
+    } else if (input.entityIds && input.entityIds.length >= 2) {
+      group = createUserGroup(input.entityIds, input.label ?? 'Auto-layout')
+    }
+    if (!group) return
+
+    group.layoutMode = 'row'
+    group.managedLayout = true
+    markDirty('canvas', 'sidebar')
+
+    // Seed layout order = current visual left-to-right so the row doesn't
+    // scramble on conversion.
+    const seeded = managedChildOrder(group.id)
+      .map((id) => ({ id, x: resolveManagedChild(id)?.canvasX ?? 0 }))
+      .sort((a, b) => a.x - b.x)
+      .map((c) => c.id)
+    writeManagedChildOrder(group.id, seeded)
+    reflowManagedGroup(group.id)
+    result = group
+  })
+  if (result) {
+    scheduleWorkspaceAutosave()
+    requestLayout()
+  }
+  return result
+}

--- a/src/main/reorder-gesture.ts
+++ b/src/main/reorder-gesture.ts
@@ -1,0 +1,79 @@
+/**
+ * Reorder-gesture coordinator (ADR 0015 Phase 3).
+ *
+ * Drives the `reordering-child` interaction mode: a drag of a managed child's
+ * center dot. The renderer's `runReorderDrag` calls start → move* → commit |
+ * cancel through IPC; both the IPC handlers and the smoke test routes funnel
+ * here so there's one state machine.
+ *
+ * Invariants (plan I2/I3, gesture-begin ordering):
+ *   - `start` enters the interaction mode BEFORE any mutation, so the focus
+ *     reconciler sees `reordering-child` (→ aboveView) and the renderer's
+ *     window-blur cancel doesn't fire on the first tick.
+ *   - `move` only updates the broadcast drop-index preview — no doc mutation.
+ *   - `commit` applies the reorder as one undo step (`reorderManagedChild`).
+ *   - start pairs with exactly one commit or cancel.
+ */
+
+import { tryEnter, commitActive, cancelActive } from './runtime/interaction-controller'
+import { currentInteractionState, updateReorderingDropIndex } from './runtime/interaction-state'
+import { markUndoBoundary } from './runtime/workspace-undo'
+import type { CancelReason } from '../shared/interaction-types'
+import { groupById } from './workspace-entities'
+import { managedChildOrder } from './runtime/entity-order-state'
+import { computeReorderDropIndex, reorderManagedChild } from './managed-layout'
+
+let activeChildId: string | null = null
+let activeGroupId: string | null = null
+
+function clearActive(): void {
+  activeChildId = null
+  activeGroupId = null
+}
+
+/** Begin a reorder drag. Returns false (and enters nothing) when the child is
+ *  not a member of a managed group. */
+export function startReorderGesture(childId: string, groupId: string): boolean {
+  const group = groupById(groupId)
+  if (!group || !group.managedLayout) return false
+  const dropIndex = managedChildOrder(groupId).indexOf(childId)
+  if (dropIndex === -1) return false
+
+  const token = tryEnter({ kind: 'reordering-child', groupId, childId, dropIndex })
+  if ('refused' in token) return false
+  activeChildId = childId
+  activeGroupId = groupId
+  return true
+}
+
+/** Update the live drop-index preview from the cursor's canvas-space X. */
+export function moveReorderGesture(cursorCanvasX: number): void {
+  if (!activeChildId || !activeGroupId) return
+  const dropIndex = computeReorderDropIndex(activeGroupId, activeChildId, cursorCanvasX)
+  updateReorderingDropIndex(dropIndex)
+}
+
+/** Commit the reorder at the current drop index. Returns true if the order
+ *  changed. A drag that didn't move (drop index unchanged) is a clean no-op. */
+export function commitReorderGesture(): boolean {
+  const childId = activeChildId
+  const groupId = activeGroupId
+  clearActive()
+  if (!childId || !groupId) {
+    commitActive()
+    return false
+  }
+  const state = currentInteractionState()
+  const dropIndex = state.kind === 'reordering-child' ? state.dropIndex : -1
+  let changed = false
+  if (dropIndex >= 0) changed = reorderManagedChild(groupId, childId, dropIndex)
+  commitActive()
+  markUndoBoundary()
+  return changed
+}
+
+/** Abort the reorder without mutating order or positions. */
+export function cancelReorderGesture(reason: CancelReason): void {
+  clearActive()
+  cancelActive(reason)
+}

--- a/src/main/routes/edges-groups.ts
+++ b/src/main/routes/edges-groups.ts
@@ -2,6 +2,7 @@ import type { Route } from './types'
 import type { CreateEdgesRequest, DeleteGroupsRequest } from '../../shared/types'
 import { createEdges, deleteEdges } from '../workspace-edges'
 import { createUserGroup, deleteGroups, focusTargets } from '../workspace-groups'
+import { makeAutoLayoutGroup, reorderManagedChild } from '../managed-layout'
 import { ungroupSelectedGroup } from '../runtime/document-commands'
 import { selectGroup as selectSelectionGroup } from '../runtime/selection-controller'
 import { workspaceEdges, workspaceGroups } from '../runtime/workspace-model'
@@ -65,6 +66,36 @@ export const edgesGroupsRoutes: Route[] = [
         .find((g): g is NonNullable<typeof g> => Boolean(g))
       if (firstGroup) movePresenceCursorTo(request, firstGroup.canvasX, firstGroup.canvasY, null)
       writeJson(response, 200, deleteGroups(payload))
+    },
+  },
+  {
+    method: 'POST',
+    pattern: '/groups/auto-layout',
+    async handler({ response, body }) {
+      const payload = body as { entityIds?: string[]; groupId?: string; label?: string }
+      if (!payload.groupId && !(payload.entityIds && payload.entityIds.length)) {
+        writeJson(response, 400, { error: 'groupId or entityIds is required' })
+        return
+      }
+      const group = makeAutoLayoutGroup(payload)
+      if (!group) {
+        writeJson(response, 404, { error: 'Nothing to manage' })
+        return
+      }
+      writeJson(response, 200, group)
+    },
+  },
+  {
+    method: 'POST',
+    pattern: '/groups/reorder-child',
+    async handler({ response, body }) {
+      const payload = body as { groupId?: string; childId?: string; toIndex?: number }
+      if (!payload.groupId || !payload.childId || typeof payload.toIndex !== 'number') {
+        writeJson(response, 400, { error: 'groupId, childId and toIndex are required' })
+        return
+      }
+      const changed = reorderManagedChild(payload.groupId, payload.childId, payload.toIndex)
+      writeJson(response, 200, { changed })
     },
   },
   {

--- a/src/main/routes/test.ts
+++ b/src/main/routes/test.ts
@@ -53,6 +53,12 @@ import { restorePersistedWorkspace } from '../runtime/workspace-restore'
 import { getActiveDoc } from '../runtime/workspace-doc'
 import { workspaceTabs, activeWorkspaceTabId } from '../runtime/workspace-model'
 import { applyDragDelta, finalizeDrag, initializeDrag, resizeMultiSelection } from '../runtime/document-commands'
+import {
+  cancelReorderGesture,
+  commitReorderGesture,
+  moveReorderGesture,
+  startReorderGesture,
+} from '../reorder-gesture'
 import type { MultiResizeEntry } from '../runtime/document-commands'
 import { currentCanvasGuides } from '../runtime/canvas-guides'
 import { currentEntityOrder, reorderSidebarStackOrder } from '../runtime/entity-order-state'
@@ -265,6 +271,43 @@ export const testRoutes: Route[] = [
     pattern: '/test/canvas-guides/current',
     async handler({ response }) {
       writeJson(response, 200, currentCanvasGuides())
+    },
+  },
+
+  // --- Auto-layout reorder gesture simulation (ADR 0015) ---
+  {
+    method: 'POST',
+    pattern: '/test/canvas-reorder/start',
+    async handler({ response, body }) {
+      const { childId, groupId } = body as { childId: string; groupId: string }
+      const ok = startReorderGesture(childId, groupId)
+      writeJson(response, 200, { ok, mode: peekInteractionMode() })
+    },
+  },
+  {
+    method: 'POST',
+    pattern: '/test/canvas-reorder/move',
+    async handler({ response, body }) {
+      const { canvasX } = body as { canvasX: number }
+      moveReorderGesture(canvasX)
+      writeJson(response, 200, { ok: true, mode: peekInteractionMode() })
+    },
+  },
+  {
+    method: 'POST',
+    pattern: '/test/canvas-reorder/commit',
+    async handler({ response }) {
+      const changed = commitReorderGesture()
+      writeJson(response, 200, { changed, mode: peekInteractionMode() })
+    },
+  },
+  {
+    method: 'POST',
+    pattern: '/test/canvas-reorder/cancel',
+    async handler({ response, body }) {
+      const { reason } = (body as { reason?: CancelReason }) ?? {}
+      cancelReorderGesture(reason ?? 'external')
+      writeJson(response, 200, { ok: true, mode: peekInteractionMode() })
     },
   },
 

--- a/src/main/runtime/binding-handlers.ts
+++ b/src/main/runtime/binding-handlers.ts
@@ -4,7 +4,7 @@ import { setActiveTool } from './tool-mode'
 import { applyToolDefaultPatch } from './tool-defaults'
 import { undo, redo } from './workspace-undo'
 import { setZoom, setPan, focusSelection } from './viewport-control'
-import { groupSelectedEntities, ungroupSelectedGroup } from './document-commands'
+import { groupSelectedEntities, makeAutoLayoutFromSelection, ungroupSelectedGroup } from './document-commands'
 import { selectAdjacentPage } from './selection-state'
 import { selectEntities, selectNone } from './selection-controller'
 import { markDirty } from './layout-dirty'
@@ -81,6 +81,10 @@ export const mainHandlers: Record<MainBindingId, (ctx: BindingContext) => void> 
   },
   'ungroup': () => {
     ungroupSelectedGroup()
+  },
+  'make-auto-layout': (ctx) => {
+    if (ctx.viewMode !== 'canvas') return
+    makeAutoLayoutFromSelection()
   },
   'select-all': () => {
     selectAllEntities()

--- a/src/main/runtime/document-commands.ts
+++ b/src/main/runtime/document-commands.ts
@@ -34,6 +34,7 @@ import {
   createUserGroup as createUserGroupInEngine,
   ungroupUserGroup as ungroupUserGroupInEngine,
 } from '../workspace-groups'
+import { makeAutoLayoutGroup } from '../managed-layout'
 import {
   createDrawingEntity as createDrawingEntityInState,
   deleteDrawingEntity as deleteDrawingEntityInState,
@@ -556,6 +557,23 @@ export function groupSelectedEntities(): WorkspaceGroup | null {
   const group = createUserGroupInEngine(ids)
   selectGroup(group.id)
   requestLayout()
+  return group
+}
+
+/**
+ * Convert the current selection into an auto-layout (managed row) group: a
+ * selected group is converted in place; a multi-selection is wrapped into a new
+ * managed group. Reachability entry point for drag-reorder on arbitrary content
+ * (plan O1). Returns the managed group or null. (ADR 0015)
+ */
+export function makeAutoLayoutFromSelection(): WorkspaceGroup | null {
+  const groupId = uiSelectedGroupId()
+  if (groupId) return makeAutoLayoutGroup({ groupId })
+
+  const ids = uiSelectedEntityIds()
+  if (ids.length < 2) return null
+  const group = makeAutoLayoutGroup({ entityIds: ids })
+  if (group) selectGroup(group.id)
   return group
 }
 

--- a/src/main/runtime/entity-order-state.ts
+++ b/src/main/runtime/entity-order-state.ts
@@ -233,6 +233,51 @@ export function reorderStackOrderIds(action: StackOrderAction, ids: readonly str
   return true
 }
 
+/**
+ * Direct children of a group in their `entityOrder` run order — the layout
+ * sequence of a managed (auto-layout) group (ADR 0015 D2). The order *within the
+ * run* is the left-to-right packing order; `canvasX` is an output of reflow, not
+ * the key. Returns children regardless of contiguity (the relative order is
+ * still well-defined).
+ */
+export function managedChildOrder(groupId: string): string[] {
+  const childIds = new Set(directChildIds(groupId))
+  if (!childIds.size) return []
+  return currentEntityOrder().filter((id) => childIds.has(id))
+}
+
+/**
+ * Rewrite a group's run so its direct children follow `orderedChildIds`, then
+ * re-enforce group contiguity. `orderedChildIds` must be a permutation of the
+ * group's current direct children. Returns true if the order actually changed.
+ *
+ * This is the order half of a managed reorder; the caller pairs it with a reflow
+ * inside one transaction (see `commitAsOneTransaction`) so order + positions
+ * collapse to a single undo step.
+ */
+export function writeManagedChildOrder(
+  groupId: string,
+  orderedChildIds: readonly string[],
+): boolean {
+  const childIds = new Set(directChildIds(groupId))
+  if (!childIds.size) return false
+  const requested = orderedChildIds.filter((id) => childIds.has(id))
+  if (requested.length !== childIds.size) return false
+
+  const order = currentEntityOrder()
+  const eligible = (id: string) => childIds.has(id)
+  const nextOrder = enforceGroupContiguity(
+    replaceSubsequence(order, eligible, requested),
+    groupsForContiguity(),
+  )
+  if (JSON.stringify(order) === JSON.stringify(nextOrder)) return false
+
+  writeEntityOrder(nextOrder)
+  markDirty('canvas', 'sidebar')
+  scheduleWorkspaceAutosave()
+  return true
+}
+
 export function appendStackOrderIdsAtTop(ids: readonly string[]): boolean {
   if (!ids.length) return false
   let nextOrder = currentEntityOrder()

--- a/src/main/runtime/focus-reconciler-runtime.ts
+++ b/src/main/runtime/focus-reconciler-runtime.ts
@@ -31,6 +31,7 @@ function interactionModeKey(): FocusState['interactionMode'] {
     case 'resizing-multi-selection': return 'resizing-multi-selection'
     case 'dragging-edge': return 'dragging-edge'
     case 'editing-entity': return 'editing-entity'
+    case 'reordering-child': return 'reordering-child'
   }
 }
 

--- a/src/main/runtime/focus-reconciler.ts
+++ b/src/main/runtime/focus-reconciler.ts
@@ -21,7 +21,7 @@
 import type { FocusTarget } from '../../shared/interaction-types'
 
 export type FocusState = {
-  interactionMode: 'idle' | 'panning' | 'marquee' | 'dragging-entities' | 'resizing-entity' | 'resizing-multi-selection' | 'dragging-edge' | 'editing-entity'
+  interactionMode: 'idle' | 'panning' | 'marquee' | 'dragging-entities' | 'resizing-entity' | 'resizing-multi-selection' | 'dragging-edge' | 'editing-entity' | 'reordering-child'
   editingEntityId: string | null
   selectedPageId: string | null
   workspaceViewMode: 'canvas' | 'browser'
@@ -56,6 +56,7 @@ export function expectedFocus(state: FocusState): FocusTarget {
     case 'resizing-entity':
     case 'resizing-multi-selection':
     case 'dragging-edge':
+    case 'reordering-child':
       return { kind: 'aboveView' }
     case 'editing-entity':
       // Inline canvas editors (sticky notes, shapes, markdown files,

--- a/src/main/runtime/interaction-controller.ts
+++ b/src/main/runtime/interaction-controller.ts
@@ -29,6 +29,7 @@ import {
   beginEntityResize,
   beginMarqueeSelect,
   beginMultiSelectionResize,
+  beginReorderingChild,
   clearInteractionState,
 } from './interaction-state'
 import type { CanvasSelectableTarget, EdgeSide } from '../../shared/types'
@@ -71,6 +72,8 @@ function snapshotMode(): InteractionMode {
       return { kind: 'resizing-multi-selection' }
     case 'editing-entity':
       return { kind: 'editing-entity', id: s.entityId }
+    case 'reordering-child':
+      return { kind: 'reordering-child', groupId: s.groupId, childId: s.childId, dropIndex: s.dropIndex }
     case 'dragging-edge':
       return {
         kind: 'dragging-edge',
@@ -103,6 +106,7 @@ export type TryEnterInput =
   | { kind: 'resizing-multi-selection' }
   | { kind: 'editing-entity'; entityId: string }
   | { kind: 'dragging-edge'; from: CanvasSelectableTarget; fromSide: EdgeSide }
+  | { kind: 'reordering-child'; groupId: string; childId: string; dropIndex: number }
 
 export function peek(): InteractionMode {
   return snapshotMode()
@@ -120,6 +124,7 @@ export function tryEnter(input: TryEnterInput): Token | InteractionRefused {
     case 'resizing-multi-selection': beginMultiSelectionResize(); break
     case 'editing-entity': beginEntityEditing(input.entityId); break
     case 'dragging-edge': beginEdgeDrag(input.from, input.fromSide); break
+    case 'reordering-child': beginReorderingChild(input.groupId, input.childId, input.dropIndex); break
   }
   const token: InternalToken = {
     id: newTokenId(),

--- a/src/main/runtime/interaction-state.ts
+++ b/src/main/runtime/interaction-state.ts
@@ -93,6 +93,28 @@ export function updateEdgeDragTarget(
   return next
 }
 
+export function beginReorderingChild(
+  groupId: string,
+  childId: string,
+  dropIndex: number,
+): CanvasInteractionState {
+  const next: CanvasInteractionState = { kind: 'reordering-child', groupId, childId, dropIndex }
+  setInteractionState(next)
+  markDirty('canvas')
+  requestLayout()
+  return next
+}
+
+export function updateReorderingDropIndex(dropIndex: number): CanvasInteractionState {
+  if (interactionState.kind !== 'reordering-child') return interactionState
+  if (interactionState.dropIndex === dropIndex) return interactionState
+  const next: CanvasInteractionState = { ...interactionState, dropIndex }
+  setInteractionState(next)
+  markDirty('canvas')
+  requestLayout()
+  return next
+}
+
 export function interactionBlocksPageHover(state: CanvasInteractionState = interactionState): boolean {
   return (
     state.kind === 'dragging-edge' ||

--- a/src/main/runtime/selection-controller.ts
+++ b/src/main/runtime/selection-controller.ts
@@ -80,6 +80,7 @@ function predicateInteractionKind(
     case 'resizing-multi-selection': return 'resizing-multi-selection'
     case 'dragging-edge': return 'dragging-edge'
     case 'editing-entity': return 'editing-entity'
+    case 'reordering-child': return 'reordering-child'
   }
 }
 

--- a/src/main/runtime/workspace-observers.ts
+++ b/src/main/runtime/workspace-observers.ts
@@ -118,6 +118,38 @@ export function endBatch(): void {
 }
 
 /**
+ * Run `mutate` and flush the resulting runtime→Y.Doc sync inside a single Y.Doc
+ * transaction, so it collapses to exactly one undo step.
+ *
+ * Needed when an operation mixes a *direct* doc write (e.g. `writeEntityOrder`,
+ * which transacts on its own) with *runtime* mutations that reach the doc only
+ * through the diff-sync (e.g. reflow position writes). Left apart these are two
+ * transactions — two undo entries, since the UndoManager uses `captureTimeout:
+ * 0`. Yjs flattens nested transactions, so wrapping both in one outer transact
+ * merges them. Reorder + reflow is the canonical caller (ADR 0015 undo
+ * batching).
+ */
+export function commitAsOneTransaction(mutate: () => void): void {
+  if (!_refs) {
+    mutate()
+    return
+  }
+  // Suppress the microtask sync that `scheduleWorkspaceAutosave()` would queue
+  // from inside `mutate` — we sync once, synchronously, inside the transaction.
+  // Without this, that trailing (empty) sync fires a second transaction.
+  const wasBatching = _batchingActive
+  _batchingActive = true
+  try {
+    getActiveDoc().transact(() => {
+      mutate()
+      requestDocSyncImmediate()
+    }, 'user')
+  } finally {
+    _batchingActive = wasBatching
+  }
+}
+
+/**
  * Schedule a diff-sync from runtime state to Y.Doc.
  * Uses queueMicrotask so multiple mutations in the same tick become one sync.
  * Call this from scheduleWorkspaceAutosave().

--- a/src/main/workspace-pages.ts
+++ b/src/main/workspace-pages.ts
@@ -40,12 +40,11 @@ import { setCustomPageSizeMetadata, setDeviceIdMetadata } from './runtime/runtim
 import { makeId, cloneMetadata, pageCurrentUrl, createGroup } from './workspace-utils'
 import {
   entityBoundsById,
-  pageSelectableBounds,
   groupById,
   groupChildIds,
-  unionBounds,
 } from './workspace-entities'
 import { findDuplicatePlacement } from './workspace-placement'
+import { reflowManagedGroup } from './managed-layout'
 
 // --- Helpers ---
 
@@ -104,34 +103,6 @@ function ensureManualRowGroup(sourcePageId: string, url: string): WorkspaceGroup
   }
 
   return group
-}
-
-function orderedPagesForGroup(group: WorkspaceGroup) {
-  return pages
-    .filter((page) => page.parentGroupId === group.id)
-    .sort((a, b) => a.canvasX - b.canvasX)
-}
-
-function reflowGroupRow(group: WorkspaceGroup): void {
-  const rowPages = orderedPagesForGroup(group)
-  if (!rowPages.length) return
-
-  const rowY = snapToGrid(Math.min(...rowPages.map((page) => page.canvasY)))
-  let cursorX = snapToGrid(Math.min(...rowPages.map((page) => page.canvasX)))
-  for (const page of rowPages) {
-    const size = pageContentSize(page)
-    page.canvasX = cursorX
-    page.canvasY = rowY
-    page.parentGroupId = group.id
-    cursorX = snapToGrid(cursorX + size.width + CLUSTER_HORIZONTAL_GUTTER)
-  }
-  const bounds = unionBounds(rowPages.map((page) => pageSelectableBounds(page)))
-  if (bounds) {
-    group.canvasX = bounds.x - USER_GROUP_PADDING
-    group.canvasY = bounds.y - USER_GROUP_PADDING
-    group.width = bounds.width + USER_GROUP_PADDING * 2
-    group.height = bounds.height + USER_GROUP_PADDING * 2
-  }
 }
 
 // --- Exported page operations ---
@@ -204,7 +175,7 @@ export function addPageFromSource(input: {
     newPage.metadata = setCustomPageSizeMetadata(newPage.metadata, pageContentSize(newPage))
   }
   newPage.parentGroupId = group.id
-  reflowGroupRow(group)
+  reflowManagedGroup(group.id)
 
   if (input.focus ?? true) {
     setSelectedGroupId(group.id)

--- a/src/preload/canvas-bg.ts
+++ b/src/preload/canvas-bg.ts
@@ -10,6 +10,7 @@ import type {
   ToolDefaultPatch,
 } from '../shared/types'
 import type { BindingId } from '../shared/bindings'
+import type { CancelReason } from '../shared/interaction-types'
 import type { CanvasGuidesPayload } from '../shared/canvas-guides'
 
 function installSelectionOverlayBridge(): void {
@@ -212,6 +213,13 @@ const api: CanvasBgElectronAPI = {
   endResize: () => ipcRenderer.send('canvas-resize-end'),
   beginMultiResize: () => ipcRenderer.send('canvas-multi-resize-begin'),
   endMultiResize: () => ipcRenderer.send('canvas-multi-resize-end'),
+  beginReorderChild: (childId: string, groupId: string) =>
+    ipcRenderer.send('canvas-reorder-child-start', { childId, groupId }),
+  reorderChildMove: (canvasX: number, canvasY: number) =>
+    ipcRenderer.send('canvas-reorder-child-move', { canvasX, canvasY }),
+  reorderChildCommit: () => ipcRenderer.send('canvas-reorder-child-commit'),
+  reorderChildCancel: (reason?: CancelReason) =>
+    ipcRenderer.send('canvas-reorder-child-cancel', { reason }),
   commitRegionSelect: (canvasRect) => ipcRenderer.send('canvas-commit-region-select', canvasRect),
   commitCommentClickAt: (windowX, windowY) =>
     ipcRenderer.send('canvas-comment-click-at', { windowX, windowY }),

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -55,6 +55,7 @@ import {
 } from './useCanvasPointerRouter'
 import { EdgeDragLayer } from './EdgeDragLayer'
 import { EdgeLayer } from './EdgeLayer'
+import { ReorderDotsLayer } from './ReorderDotsLayer'
 import { PageChromeOverlay } from './PageChrome'
 import { PagePopup } from './PagePopup'
 import { FilePopup } from './FilePopup'
@@ -1324,6 +1325,10 @@ html:active, body:active, body *:active { cursor: grabbing !important; }`
           <EdgeDragLayer state={edgeDragState} layoutData={layoutData} isDark={isDark} />
           <DragCopyPreviewLayer previews={dragCopyPreview} isDark={isDark} />
           <GuideOverlayLayer guides={canvasGuides} layoutData={layoutData} isDark={isDark} />
+
+          {layoutData.viewMode === 'canvas' ? (
+            <ReorderDotsLayer layoutData={layoutData} isDark={isDark} />
+          ) : null}
 
           <PageChromeOverlay
             api={api}

--- a/src/renderer/above-view/ReorderDotsLayer.tsx
+++ b/src/renderer/above-view/ReorderDotsLayer.tsx
@@ -1,0 +1,124 @@
+import { useMemo } from 'react'
+import type { LayoutUpdateData } from '../../shared/types'
+import {
+  REORDER_DOT_HOVER_RADIUS_PX,
+  REORDER_DOT_VISUAL_RADIUS_PX,
+} from '../../shared/canvas-hit-geometry'
+import { CLUSTER_HORIZONTAL_GUTTER } from '../../shared/constants'
+import { selectionColor } from '../canvas-bg/canvasBgConstants'
+
+/**
+ * Auto-layout reorder dots (ADR 0015 Phase 4). Paints the per-child center dot
+ * that hosts the reorder gesture — a geometric overlay (like edge anchors), not
+ * DOM buttons. Small at rest, larger when the child or its group is hovered.
+ *
+ * Mirrors the `reorder-handle` hit-test gating exactly (managed-row child whose
+ * group or self is selected), so the visible dot and the grabbable target line
+ * up. Suppressed during any non-reorder interaction and while a non-select tool
+ * is active, matching popup suppression rules. During a reorder drag the dragged
+ * child's dot is hidden and an insertion line marks the live drop slot.
+ */
+export function ReorderDotsLayer({
+  layoutData,
+  isDark,
+}: {
+  layoutData: LayoutUpdateData
+  isDark: boolean
+}) {
+  const color = selectionColor(isDark)
+  const { zoom, pan, canvasOrigin, entities, interaction } = layoutData
+
+  const reordering = interaction.kind === 'reordering-child' ? interaction : null
+
+  const dots = useMemo(() => {
+    if (layoutData.viewMode !== 'canvas') return []
+    if (layoutData.activeTool.kind !== 'select') return []
+    // Show dots only at rest or while reordering; hide during drag/resize/
+    // marquee/edit so they don't clutter an in-progress gesture.
+    if (interaction.kind !== 'idle' && interaction.kind !== 'reordering-child') return []
+
+    const childToGroup = new Map<string, string>()
+    for (const e of entities) {
+      if (e.kind === 'group' && e.managedLayout && e.layoutMode === 'row') {
+        for (const childId of e.entityIds) childToGroup.set(childId, e.id)
+      }
+    }
+    if (!childToGroup.size) return []
+
+    const selected = new Set(layoutData.selectedEntityIds)
+    const hoverId = layoutData.hover?.id ?? null
+    const out: Array<{ id: string; cx: number; cy: number; r: number }> = []
+    for (const e of entities) {
+      if (e.kind === 'group') continue
+      const groupId = childToGroup.get(e.id)
+      if (!groupId) continue
+      if (layoutData.selectedGroupId !== groupId && !selected.has(e.id)) continue
+      // The dragged child is "lifted" — its dot is replaced by the drop line.
+      if (reordering && reordering.childId === e.id) continue
+      const grown = hoverId === e.id || hoverId === groupId
+      out.push({
+        id: e.id,
+        cx: e.screenX + e.screenWidth / 2,
+        cy: e.screenY - canvasOrigin.y + e.screenHeight / 2,
+        r: grown ? REORDER_DOT_HOVER_RADIUS_PX : REORDER_DOT_VISUAL_RADIUS_PX,
+      })
+    }
+    return out
+  }, [
+    entities,
+    interaction.kind,
+    layoutData.activeTool.kind,
+    layoutData.hover?.id,
+    layoutData.selectedEntityIds,
+    layoutData.selectedGroupId,
+    layoutData.viewMode,
+    canvasOrigin.y,
+    reordering,
+  ])
+
+  // Insertion line: vertical bar at the drop slot of the dragged child's row.
+  const insertionLine = useMemo(() => {
+    if (!reordering) return null
+    const group = entities.find((e) => e.kind === 'group' && e.id === reordering.groupId)
+    if (!group) return null
+    const childIds = new Set(group.kind === 'group' ? group.entityIds : [])
+    const others = entities
+      .filter((e) => e.kind !== 'group' && childIds.has(e.id) && e.id !== reordering.childId)
+      .sort((a, b) => a.screenX - b.screenX)
+    if (!others.length) return null
+
+    const top = Math.min(...others.map((e) => e.screenY - canvasOrigin.y))
+    const bottom = Math.max(...others.map((e) => e.screenY - canvasOrigin.y + e.screenHeight))
+    const gapHalf = (CLUSTER_HORIZONTAL_GUTTER * zoom) / 2
+    const index = Math.max(0, Math.min(reordering.dropIndex, others.length))
+    const x =
+      index < others.length
+        ? others[index].screenX - gapHalf
+        : others[others.length - 1].screenX + others[others.length - 1].screenWidth + gapHalf
+    return { x, top, bottom }
+  }, [reordering, entities, canvasOrigin.y, zoom])
+
+  if (!dots.length && !insertionLine) return null
+
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0 h-full w-full overflow-visible"
+      aria-hidden="true"
+    >
+      {dots.map((dot) => (
+        <circle key={dot.id} cx={dot.cx} cy={dot.cy} r={dot.r} fill={color} opacity={0.85} />
+      ))}
+      {insertionLine ? (
+        <line
+          x1={insertionLine.x}
+          y1={insertionLine.top}
+          x2={insertionLine.x}
+          y2={insertionLine.bottom}
+          stroke={color}
+          strokeWidth={2}
+          vectorEffect="non-scaling-stroke"
+        />
+      ) : null}
+    </svg>
+  )
+}

--- a/src/renderer/above-view/useCanvasPointerRouter.ts
+++ b/src/renderer/above-view/useCanvasPointerRouter.ts
@@ -56,6 +56,7 @@ import {
   isTypingTarget,
   middleDragDelta,
   normalizeRect,
+  screenPointToCanvasPoint,
   screenRectToCanvasRect,
 } from '../../shared/gesture-utils'
 import { aspectRatioResizeModeForCanvasFile } from '../canvas-bg/entityConstants'
@@ -120,6 +121,7 @@ const ALL_KINDS: ReadonlySet<CanvasPointerAction['kind']> = new Set<CanvasPointe
   'background-click',
   'begin-marquee',
   'begin-pan',
+  'begin-reorder-drag',
 ])
 
 /** All routable kinds — used by tests and any caller that wants full
@@ -370,6 +372,8 @@ function dispatchAction(ctx: DispatchContext): boolean {
       return runBackgroundSelectionGesture(api, event, layoutRef)
     case 'begin-pan':
       return runPan(api, event)
+    case 'begin-reorder-drag':
+      return runReorderDrag(action, api, event, layoutRef)
   }
 }
 
@@ -1069,6 +1073,50 @@ function runPan(api: CanvasBgElectronAPI, event: PointerEvent): boolean {
     cleanup()
   }
   const onCancel = () => cleanup()
+  window.addEventListener('pointermove', onMove)
+  window.addEventListener('pointerup', onUp)
+  window.addEventListener('pointercancel', onCancel)
+  window.addEventListener('blur', onCancel)
+  return true
+}
+
+function runReorderDrag(
+  action: Extract<CanvasPointerAction, { kind: 'begin-reorder-drag' }>,
+  api: CanvasBgElectronAPI,
+  event: PointerEvent,
+  layoutRef: React.MutableRefObject<LayoutUpdateData>,
+): boolean {
+  const pointerId = event.pointerId
+  const releasePointer = capturePointer(event)
+
+  // Enter reorder mode in main BEFORE any layout-triggering work — same
+  // gesture-begin ordering as resize/drag (see runtime/CLAUDE.md). With the
+  // mode set to 'reordering-child', the focus reconciler keeps aboveView
+  // focused, so the window-blur cancel below doesn't fire on the first tick.
+  api.beginReorderChild(action.childId, action.groupId)
+
+  const cleanup = () => {
+    releasePointer?.()
+    window.removeEventListener('pointermove', onMove)
+    window.removeEventListener('pointerup', onUp)
+    window.removeEventListener('pointercancel', onCancel)
+    window.removeEventListener('blur', onCancel)
+  }
+  const onMove = (ev: PointerEvent) => {
+    if (ev.pointerId !== pointerId) return
+    const layout = layoutRef.current
+    const point = screenPointToCanvasPoint(ev.clientX, ev.clientY + layout.canvasOrigin.y, layout)
+    api.reorderChildMove(point.x, point.y)
+  }
+  const onUp = (ev: PointerEvent) => {
+    if (ev.pointerId !== pointerId) return
+    cleanup()
+    api.reorderChildCommit()
+  }
+  const onCancel = () => {
+    cleanup()
+    api.reorderChildCancel('blur')
+  }
   window.addEventListener('pointermove', onMove)
   window.addEventListener('pointerup', onUp)
   window.addEventListener('pointercancel', onCancel)

--- a/src/shared/bindings.ts
+++ b/src/shared/bindings.ts
@@ -58,6 +58,7 @@ export type BindingId =
   | 'reset-viewport'
   | 'group'
   | 'ungroup'
+  | 'make-auto-layout'
   | 'select-all'
   | 'duplicate'
   | 'delete-selection'
@@ -139,6 +140,7 @@ export const BINDINGS: readonly Binding[] = [
   // Canvas-region modifier shortcuts
   { id: 'group', defaultKey: k('g', true), scope: CANVAS_REGION, target: 'main', label: 'Group' },
   { id: 'ungroup', defaultKey: k('g', true, true), scope: CANVAS_REGION, target: 'main', label: 'Ungroup' },
+  { id: 'make-auto-layout', defaultKey: k('a', true, true), scope: CANVAS_REGION, target: 'main', label: 'Auto-layout' },
   { id: 'select-all', defaultKey: k('a', true), scope: CANVAS_REGION, target: 'main', label: 'Select all' },
   { id: 'duplicate', defaultKey: k('d', true), scope: CANVAS_REGION, target: 'main', label: 'Duplicate' },
   {

--- a/src/shared/canvas-hit-geometry.ts
+++ b/src/shared/canvas-hit-geometry.ts
@@ -12,6 +12,12 @@ export const EDGE_ANCHOR_HIT_MIN_SCALE = 0.35
 export const RESIZE_HANDLE_VISUAL_PX = 8
 export const RESIZE_HANDLE_HIT_PX = 12
 
+// Auto-layout reorder dot (ADR 0015). Visual radius is small at rest and grows
+// on hover (rendered in aboveView); the hit square stays comfortably grabbable.
+export const REORDER_DOT_VISUAL_RADIUS_PX = 4
+export const REORDER_DOT_HOVER_RADIUS_PX = 7
+export const REORDER_HANDLE_HIT_PX = 28
+
 export const MULTI_SELECTION_OUTLINE_PADDING_PX = 8
 
 export const EDGE_SIDES: readonly EdgeSide[] = ['top', 'right', 'bottom', 'left']

--- a/src/shared/canvas-pointer-actions.ts
+++ b/src/shared/canvas-pointer-actions.ts
@@ -60,6 +60,9 @@ export type CanvasPointerAction =
   | { kind: 'begin-multi-resize'; handle: ResizeHandle }
   /** Begin an edge-create drag from an anchor. */
   | { kind: 'begin-edge-drag'; entityId: string; entityKind: CanvasEntityKind; side: EdgeSide }
+  /** Begin dragging a managed child's center dot to reorder it within its
+   *  auto-layout group (ADR 0015). */
+  | { kind: 'begin-reorder-drag'; childId: string; groupId: string; entityKind: CanvasEntityKind }
   /** Modifier-additive selection toggle (no drag). */
   | { kind: 'toggle-select'; entityId: string; entityKind: CanvasEntityKind }
   /** Background click/drag candidate — clears on click, marquee-selects after threshold. */
@@ -141,6 +144,13 @@ function routeByPayload(
         entityId: payload.entityId,
         entityKind: payload.entityKind,
         side: payload.side,
+      }
+    case 'reorder-handle':
+      return {
+        kind: 'begin-reorder-drag',
+        childId: payload.entityId,
+        groupId: payload.groupId,
+        entityKind: payload.entityKind,
       }
     case 'page-body':
       // Additive modifier wins over the forward-into-page shortcut: shift/

--- a/src/shared/hit-test.ts
+++ b/src/shared/hit-test.ts
@@ -19,6 +19,7 @@ import {
   EDGE_SIDES,
   CHROME_HEADER_HEIGHT,
   MULTI_SELECTION_OUTLINE_PADDING_PX,
+  REORDER_HANDLE_HIT_PX,
   RESIZE_HANDLE_HIT_PX,
   scaleEdgeAnchorHitSize,
 } from './canvas-hit-geometry'
@@ -40,6 +41,7 @@ export type HitPayload =
   | { kind: 'multi-resize-handle'; handle: ResizeHandle }
   | { kind: 'chrome'; entityId: string; entityKind: CanvasEntityKind }
   | { kind: 'anchor'; entityId: string; entityKind: CanvasEntityKind; side: EdgeSide }
+  | { kind: 'reorder-handle'; entityId: string; entityKind: CanvasEntityKind; groupId: string }
   | { kind: 'page-body'; entityId: string }
   | {
       kind: 'entity-body'
@@ -127,6 +129,8 @@ function collectLayerTargets(layer: HitLayer, inputs: HitInputs): HitTarget[] {
       return collectChromeTargets(inputs)
     case 'anchors':
       return collectAnchorTargets(inputs)
+    case 'reorder-handle':
+      return collectReorderHandleTargets(inputs)
     case 'body':
       return collectBodyTargets(inputs)
     case 'background':
@@ -289,6 +293,37 @@ function collectAnchorTargets(inputs: HitInputs): HitTarget[] {
   return out
 }
 
+// Center-dot reorder handles for managed (auto-layout row) children. A child
+// contributes a dot only when its managed group is selected or the child itself
+// is selected — matches the dot-paint rule in aboveView (ADR 0015 D4).
+function collectReorderHandleTargets(inputs: HitInputs): HitTarget[] {
+  // Map each managed-row group's direct children → group id. Using the group's
+  // broadcast `entityIds` avoids needing a parentGroupId on every scene entity
+  // (pages don't carry one) and is exactly the direct-child set.
+  const childToGroup = new Map<string, string>()
+  for (const e of inputs.entities) {
+    if (e.kind !== 'group' || !e.managedLayout || e.layoutMode !== 'row') continue
+    for (const childId of e.entityIds) childToGroup.set(childId, e.id)
+  }
+  if (!childToGroup.size) return []
+
+  const selected = new Set(inputs.selectedEntityIds)
+  const out: HitTarget[] = []
+  for (const entity of inputs.entities) {
+    if (entity.kind === 'group') continue
+    const groupId = childToGroup.get(entity.id)
+    if (!groupId) continue
+    const groupSelected = inputs.selectedGroupId === groupId
+    if (!groupSelected && !selected.has(entity.id)) continue
+    out.push({
+      layer: 'reorder-handle',
+      region: { kind: 'rect', rect: reorderHandleRect(entity) },
+      payload: { kind: 'reorder-handle', entityId: entity.id, entityKind: entity.kind, groupId },
+    })
+  }
+  return out
+}
+
 function collectBodyTargets(inputs: HitInputs): HitTarget[] {
   // Front-to-back hit order. `inputs.entities` is back-to-front (paint order:
   // first item painted first, last item on top — matches JSON Canvas array
@@ -364,6 +399,13 @@ function handleRect(entity: CanvasSceneEntity, handle: ResizeHandle): Rect {
     case 'e':
       return { x: x + w + pad - half, y, width: RESIZE_HANDLE_HIT_PX, height: h }
   }
+}
+
+function reorderHandleRect(entity: CanvasSceneEntity): Rect {
+  const half = REORDER_HANDLE_HIT_PX / 2
+  const cx = entity.screenX + entity.screenWidth / 2
+  const cy = entity.screenY + entity.screenHeight / 2
+  return { x: cx - half, y: cy - half, width: REORDER_HANDLE_HIT_PX, height: REORDER_HANDLE_HIT_PX }
 }
 
 function chromeRect(entity: CanvasSceneEntity): Rect {

--- a/src/shared/interaction-priority.ts
+++ b/src/shared/interaction-priority.ts
@@ -12,6 +12,7 @@ export type HitLayer =
   | 'resize-handles'
   | 'chrome'
   | 'anchors'
+  | 'reorder-handle'
   | 'body'
   | 'background'
 
@@ -19,6 +20,10 @@ export const HIT_LAYER_ORDER: readonly HitLayer[] = [
   'resize-handles',
   'chrome',
   'anchors',
+  // Auto-layout reorder dots sit above the child body so dragging the dot
+  // reorders, while dragging the body still moves the whole group (ADR 0015 D4).
+  // Below anchors/chrome/handles, which own the entity's edges.
+  'reorder-handle',
   'body',
   'background',
 ] as const

--- a/src/shared/interaction-types.ts
+++ b/src/shared/interaction-types.ts
@@ -13,6 +13,11 @@ export type InteractionMode =
   | { kind: 'resizing-multi-selection' }
   | { kind: 'dragging-edge'; from: EdgeEndpoint; target: EdgeEndpoint | null }
   | { kind: 'editing-entity'; id: string }
+  // Dragging a managed child's center dot to reorder it within its auto-layout
+  // group. A distinct mode (not a `dragging-entities` payload) because commit
+  // semantics differ — reorder+reflow vs free move — and it owns its own
+  // drop-index preview and cancel path (ADR 0015 D-O2).
+  | { kind: 'reordering-child'; groupId: string; childId: string; dropIndex: number }
 
 export type CancelReason = 'blur' | 'escape' | 'undo' | 'tab-switch' | 'external'
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -12,6 +12,7 @@ import type { DrawingBrushType, Tool } from './tool'
 import type { BindingId } from './bindings'
 import type { CanvasGuidesPayload } from './canvas-guides'
 import type { ResizeHandle } from './resize-accumulator'
+import type { CancelReason } from './interaction-types'
 
 export type { DrawingBrushType, Tool } from './tool'
 export type { ToolDefaultPatch } from './tool-defaults'
@@ -110,6 +111,7 @@ export type CanvasInteractionState =
   | { kind: 'resizing-entity'; entity: CanvasSelectableTarget }
   | { kind: 'resizing-multi-selection' }
   | { kind: 'editing-entity'; entityId: string }
+  | { kind: 'reordering-child'; groupId: string; childId: string; dropIndex: number }
 
 export interface CanvasScenePageEntity {
   kind: 'page'
@@ -1789,6 +1791,11 @@ export interface CanvasBgElectronAPI {
   endResize: () => void
   beginMultiResize: () => void
   endMultiResize: () => void
+  /** Auto-layout reorder drag (ADR 0015). start → move* → commit | cancel. */
+  beginReorderChild: (childId: string, groupId: string) => void
+  reorderChildMove: (canvasX: number, canvasY: number) => void
+  reorderChildCommit: () => void
+  reorderChildCancel: (reason?: CancelReason) => void
   commitRegionSelect: (canvasRect: WorkspaceBounds) => void
   /** Comment tool click below the drag threshold. Main resolves the page +
    *  element under the window-coord point and either fires

--- a/tests/smoke/app-client.ts
+++ b/tests/smoke/app-client.ts
@@ -421,6 +421,40 @@ export function ungroup(groupId: string) {
   return post<{ entityIds: string[] }>('/groups/ungroup', { groupId })
 }
 
+export function makeAutoLayout(input: { entityIds?: string[]; groupId?: string; label?: string }) {
+  return post<{
+    id: string
+    layoutMode: string
+    managedLayout: boolean
+    canvasX: number
+    canvasY: number
+    width: number
+    height: number
+  }>('/groups/auto-layout', input)
+}
+
+export function reorderManagedChild(input: { groupId: string; childId: string; toIndex: number }) {
+  return post<{ changed: boolean }>('/groups/reorder-child', input)
+}
+
+// --- Auto-layout reorder gesture (test-only IPC simulation) ---
+
+export function reorderGestureStart(input: { childId: string; groupId: string }) {
+  return post<{ ok: boolean; mode: { kind: string } }>('/test/canvas-reorder/start', input)
+}
+
+export function reorderGestureMove(canvasX: number) {
+  return post<{ ok: true; mode: { kind: string } }>('/test/canvas-reorder/move', { canvasX })
+}
+
+export function reorderGestureCommit() {
+  return post<{ changed: boolean; mode: { kind: string } }>('/test/canvas-reorder/commit')
+}
+
+export function reorderGestureCancel(reason: CancelReason = 'external') {
+  return post<{ ok: true; mode: { kind: string } }>('/test/canvas-reorder/cancel', { reason })
+}
+
 export function deleteGroups(groupIds: string[]) {
   return post<{ deletedGroupIds: string[] }>('/groups/delete', { groupIds })
 }

--- a/tests/smoke/managed-layout.test.ts
+++ b/tests/smoke/managed-layout.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Auto-layout (managed group) smoke tests — ADR 0015.
+ *
+ * Covers the Milestone 1 runtime: make-auto-layout from a selection (O1),
+ * row reflow, drag-reorder, and the undo/persistence round-trips required by
+ * the test contract for new runtime mutators (reflowManagedGroup,
+ * reorderManagedChild).
+ *
+ * Mutation-verified by:
+ *   - changing `commitAsOneTransaction` to call `mutate()` then a separate
+ *     `requestDocSyncImmediate()` outside the transaction: the reorder
+ *     transaction-count assertion goes from 1 to 2.
+ *   - dropping the `reflowManagedGroup(groupId)` call inside `reorderManagedChild`:
+ *     positions stop following the reordered sequence and the "B,C,A after
+ *     reorder" assertion fails.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  createTextEntities,
+  deleteTextEntities,
+  flushWorkspaceAutosave,
+  getDiskSnapshot,
+  getEntityOrder,
+  getInteractionMode,
+  getTextEntities,
+  makeAutoLayout,
+  reorderGestureCancel,
+  reorderGestureCommit,
+  reorderGestureMove,
+  reorderGestureStart,
+  reorderManagedChild,
+  resetSmokeState,
+  undoWorkspace,
+} from './app-client'
+import { observeYDocTransactions, wait } from './test-utils'
+
+const GAP = 80
+
+async function cleanupTextEntities(): Promise<void> {
+  const { textEntities } = await getTextEntities()
+  if (textEntities.length) {
+    await deleteTextEntities(textEntities.map((t) => t.id))
+    await wait(50)
+  }
+}
+
+// Create one at a time: the multi-item create route staggers entity creation
+// asynchronously, which would race make-auto-layout. Single creates are sync.
+async function createText(input: {
+  canvasX: number
+  canvasY: number
+  text: string
+  width: number
+  height: number
+}): Promise<string> {
+  const { ids } = await createTextEntities([input])
+  return ids[0]
+}
+
+async function positionsById(): Promise<Record<string, { x: number; y: number; width: number }>> {
+  const { textEntities } = await getTextEntities()
+  return Object.fromEntries(
+    textEntities.map((t) => [t.id, { x: t.canvasX, y: t.canvasY, width: t.width }]),
+  )
+}
+
+describe('auto-layout managed groups', () => {
+  beforeEach(async () => {
+    await resetSmokeState()
+    await cleanupTextEntities()
+  })
+
+  afterEach(async () => {
+    await cleanupTextEntities()
+  })
+
+  it('packs a multi-selection into a row in visual order and persists positions', async () => {
+    // Scattered both ways: visual left-to-right is B(100), C(350), A(600).
+    const a = await createText({ canvasX: 600, canvasY: 200, text: 'A', width: 200, height: 100 })
+    const b = await createText({ canvasX: 100, canvasY: 260, text: 'B', width: 150, height: 100 })
+    const c = await createText({ canvasX: 350, canvasY: 220, text: 'C', width: 120, height: 100 })
+    const ids = [a, b, c]
+
+    const group = await makeAutoLayout({ entityIds: ids })
+    expect(group.managedLayout).toBe(true)
+    expect(group.layoutMode).toBe('row')
+    await wait(50)
+
+    const pos = await positionsById()
+    // All children share the row's top (start-alignment, Milestone 1).
+    expect(pos[b].y).toBe(pos[c].y)
+    expect(pos[c].y).toBe(pos[a].y)
+    // Packed in visual order, each after the previous by width + gap.
+    expect(pos[c].x).toBe(pos[b].x + pos[b].width + GAP)
+    expect(pos[a].x).toBe(pos[c].x + pos[c].width + GAP)
+
+    // Reflowed positions persist to disk.
+    await flushWorkspaceAutosave()
+    const snap = await getDiskSnapshot()
+    const diskB = snap.doc?.nodes.find((n) => n.id === b)
+    expect(diskB?.x).toBe(pos[b].x)
+    expect(diskB?.y).toBe(pos[b].y)
+  })
+
+  it('reorder is one Y.Doc transaction and one undo step restoring order + positions', async () => {
+    const a = await createText({ canvasX: 100, canvasY: 200, text: 'A', width: 200, height: 100 })
+    const b = await createText({ canvasX: 400, canvasY: 200, text: 'B', width: 200, height: 100 })
+    const c = await createText({ canvasX: 700, canvasY: 200, text: 'C', width: 200, height: 100 })
+
+    const group = await makeAutoLayout({ entityIds: [a, b, c] })
+    await wait(50)
+
+    const before = await positionsById()
+    const orderBefore = (await getEntityOrder()).entityOrder
+    expect(before[a].x).toBeLessThan(before[b].x)
+    expect(before[b].x).toBeLessThan(before[c].x)
+
+    // Move A from the front to the end. One mutation → one Y.Doc transaction.
+    const count = await observeYDocTransactions(async () => {
+      await reorderManagedChild({ groupId: group.id, childId: a, toIndex: 2 })
+    })
+    expect(count).toBe(1)
+    await wait(50)
+
+    const after = await positionsById()
+    // Sequence is now B, C, A.
+    expect(after[b].x).toBeLessThan(after[c].x)
+    expect(after[c].x).toBeLessThan(after[a].x)
+
+    // A single undo restores both the layout sequence and the positions.
+    await undoWorkspace()
+    await wait(50)
+    const undone = await positionsById()
+    expect(undone[a].x).toBe(before[a].x)
+    expect(undone[b].x).toBe(before[b].x)
+    expect(undone[c].x).toBe(before[c].x)
+    expect((await getEntityOrder()).entityOrder).toEqual(orderBefore)
+  })
+})
+
+describe('auto-layout reorder gesture', () => {
+  beforeEach(async () => {
+    await resetSmokeState()
+    await cleanupTextEntities()
+  })
+
+  afterEach(async () => {
+    await cleanupTextEntities()
+  })
+
+  async function makeRowOfThree() {
+    const a = await createText({ canvasX: 100, canvasY: 200, text: 'A', width: 200, height: 100 })
+    const b = await createText({ canvasX: 400, canvasY: 200, text: 'B', width: 200, height: 100 })
+    const c = await createText({ canvasX: 700, canvasY: 200, text: 'C', width: 200, height: 100 })
+    const group = await makeAutoLayout({ entityIds: [a, b, c] })
+    await wait(50)
+    return { a, b, c, group }
+  }
+
+  it('begin → move → commit reorders and returns to idle', async () => {
+    const { a, b, c, group } = await makeRowOfThree()
+    const before = await positionsById()
+
+    const started = await reorderGestureStart({ childId: a, groupId: group.id })
+    expect(started.ok).toBe(true)
+    expect(started.mode.kind).toBe('reordering-child')
+
+    // Drag A's dot far to the right, past C's center.
+    await reorderGestureMove(before[c].x + before[c].width + 500)
+    const committed = await reorderGestureCommit()
+    expect(committed.changed).toBe(true)
+    expect(committed.mode.kind).toBe('idle')
+    await wait(50)
+
+    const after = await positionsById()
+    // Sequence is now B, C, A.
+    expect(after[b].x).toBeLessThan(after[c].x)
+    expect(after[c].x).toBeLessThan(after[a].x)
+  })
+
+  it('begin → cancel leaves order and positions untouched', async () => {
+    const { a, b, c, group } = await makeRowOfThree()
+    const before = await positionsById()
+
+    await reorderGestureStart({ childId: a, groupId: group.id })
+    await reorderGestureMove(before[c].x + 500)
+    const cancelled = await reorderGestureCancel('escape')
+    expect(cancelled.mode.kind).toBe('idle')
+    await wait(50)
+
+    const after = await positionsById()
+    expect(after[a].x).toBe(before[a].x)
+    expect(after[b].x).toBe(before[b].x)
+    expect(after[c].x).toBe(before[c].x)
+  })
+
+  it('cancel-on-blur and cancel-on-undo abort without mutation', async () => {
+    for (const reason of ['blur', 'undo'] as const) {
+      const { a, b, c, group } = await makeRowOfThree()
+      const before = await positionsById()
+      await reorderGestureStart({ childId: a, groupId: group.id })
+      await reorderGestureMove(before[c].x + 500)
+      await reorderGestureCancel(reason)
+      await wait(20)
+      const after = await positionsById()
+      expect(after[a].x).toBe(before[a].x)
+      expect(after[b].x).toBe(before[b].x)
+      expect(after[c].x).toBe(before[c].x)
+      expect((await getInteractionMode()).mode.kind).toBe('idle')
+      await cleanupTextEntities()
+    }
+  })
+})

--- a/tests/unit/canvas-pointer-actions.test.ts
+++ b/tests/unit/canvas-pointer-actions.test.ts
@@ -416,3 +416,22 @@ describe('routePointerDown', () => {
     expect(action.kind).toBe('begin-entity-drag')
   })
 })
+
+describe('routePointerDown — auto-layout reorder dot (ADR 0015)', () => {
+  it('routes a reorder-handle hit to begin-reorder-drag', () => {
+    const action = routePointerDown(
+      {
+        layer: 'reorder-handle',
+        region: { kind: 'rect', rect: { x: 0, y: 0, width: 28, height: 28 } },
+        payload: { kind: 'reorder-handle', entityId: 'c1', entityKind: 'text', groupId: 'g1' },
+      },
+      baseCtx,
+    )
+    expect(action).toEqual({
+      kind: 'begin-reorder-drag',
+      childId: 'c1',
+      groupId: 'g1',
+      entityKind: 'text',
+    })
+  })
+})

--- a/tests/unit/hit-test.test.ts
+++ b/tests/unit/hit-test.test.ts
@@ -384,3 +384,55 @@ describe('hit-test — selected drawing beats page chrome and page body (issue #
     expect(result.payload).toMatchObject({ kind: 'page-body', entityId: 'p1' })
   })
 })
+
+describe('hit-test — auto-layout reorder dots (ADR 0015)', () => {
+  // Managed-row group g1 with two text children c1, c2. Child c1 at screen
+  // (220,220) 100×40 → center (270,240); reorder hit square is 28px centered →
+  // x ∈ [256,284], y ∈ [226,254].
+  const managedGroup = (entityIds: string[]): CanvasSceneGroupEntity => ({
+    ...group('g1', 200, 200, 600, 200),
+    layoutMode: 'row',
+    managedLayout: true,
+    entityIds,
+  })
+  const c1 = text('c1', 220, 220, 100, 40)
+  const c2 = text('c2', 400, 220, 100, 40)
+  const center = { x: 270, y: 240 }
+
+  it('emits a reorder handle at the child center when the group is selected', () => {
+    const result = hitTest(
+      { entities: [managedGroup(['c1', 'c2']), c1, c2], edges: [], selectedEntityIds: [], selectedGroupId: 'g1', zoom: 1 },
+      center,
+    )
+    expect(result.layer).toBe('reorder-handle')
+    expect(result.payload).toMatchObject({ kind: 'reorder-handle', entityId: 'c1', groupId: 'g1' })
+  })
+
+  it('emits a reorder handle when the child itself is selected', () => {
+    const result = hitTest(inputs([managedGroup(['c1', 'c2']), c1, c2], ['c1']), center)
+    expect(result.payload).toMatchObject({ kind: 'reorder-handle', entityId: 'c1' })
+  })
+
+  it('does not emit a reorder handle when neither group nor child is selected', () => {
+    const result = hitTest(inputs([managedGroup(['c1', 'c2']), c1, c2], []), center)
+    expect(result.payload.kind).not.toBe('reorder-handle')
+    expect(result.payload).toMatchObject({ kind: 'entity-body', entityId: 'c1' })
+  })
+
+  it('does not emit a reorder handle for an unmanaged group', () => {
+    const freeform: CanvasSceneGroupEntity = { ...group('g1', 200, 200, 600, 200), entityIds: ['c1', 'c2'] }
+    const result = hitTest(
+      { entities: [freeform, c1, c2], edges: [], selectedEntityIds: [], selectedGroupId: 'g1', zoom: 1 },
+      center,
+    )
+    expect(result.payload.kind).not.toBe('reorder-handle')
+  })
+
+  it('child resize handle still wins over the reorder dot at the corner', () => {
+    // c1 NE corner ≈ (320, 220) (2px outline pad). The reorder dot is below
+    // resize handles in priority, so a corner click resizes.
+    const result = hitTest(inputs([managedGroup(['c1', 'c2']), c1, c2], ['c1']), { x: 320, y: 220 })
+    expect(result.layer).toBe('resize-handles')
+    expect(result.payload).toMatchObject({ kind: 'resize-handle', entityId: 'c1' })
+  })
+})

--- a/tests/unit/layout-math.test.ts
+++ b/tests/unit/layout-math.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   computeLayoutMetrics,
   computeLayoutPositions,
+  computeRowReflow,
   type LayoutBox,
 } from '../../src/main/layout-math'
 import {
@@ -173,6 +174,48 @@ describe('computeLayoutPositions — grid', () => {
     const positions = computeLayoutPositions(items, 'grid', 10, 10, { x: 50, y: 50 }, 2)
     expect(positions[0]).toEqual({ canvasX: 50, canvasY: 50 })
     expect(positions[1]).toEqual({ canvasX: 160, canvasY: 50 })
+  })
+})
+
+describe('computeRowReflow', () => {
+  it('returns empty for no children', () => {
+    expect(computeRowReflow([], 80, 0, 0)).toEqual([])
+  })
+
+  it('places a single child at the origin', () => {
+    expect(computeRowReflow([{ width: 300, height: 200 }], 80, 10, 20)).toEqual([
+      { canvasX: 10, canvasY: 20 },
+    ])
+  })
+
+  it('packs two children left-to-right separated by gap', () => {
+    const children: LayoutBox[] = [
+      { width: 100, height: 80 },
+      { width: 150, height: 80 },
+    ]
+    expect(computeRowReflow(children, 80, 0, 0)).toEqual([
+      { canvasX: 0, canvasY: 0 },
+      { canvasX: 180, canvasY: 0 },
+    ])
+  })
+
+  it('flows N heterogeneous widths by own width, sharing originY', () => {
+    const children: LayoutBox[] = [
+      { width: 100, height: 80 },
+      { width: 200, height: 120 },
+      { width: 50, height: 60 },
+    ]
+    const positions = computeRowReflow(children, 10, 5, 50)
+    expect(positions.map((p) => p.canvasX)).toEqual([5, 115, 325])
+    expect(positions.every((p) => p.canvasY === 50)).toBe(true)
+  })
+
+  it('treats a zero-width child as occupying only the gap', () => {
+    const children: LayoutBox[] = [
+      { width: 0, height: 0 },
+      { width: 100, height: 80 },
+    ]
+    expect(computeRowReflow(children, 20, 0, 0).map((p) => p.canvasX)).toEqual([0, 20])
   })
 })
 


### PR DESCRIPTION
Implements **Milestone 1 of auto-layout** ([ADR 0015](docs/adr/0015-auto-layout-groups.md)).

A group with `managedLayout: true` derives its children's positions: children pack into a row, and dragging a child's center dot reorders it while siblings reflow to make room (Figma auto-layout reorder).

## What's in it
- **`managed-layout.ts`** — `reflowManagedGroup`, the single writer of managed child positions; supersedes the pages-only `reflowGroupRow`
- **`layout-math.ts`** — `computeRowReflow` pure kernel
- **`reorder-gesture.ts` + `register-canvas-reorder-ipc.ts`** — `reordering-child` interaction mode (begin/move/commit/cancel); one Y.Doc transaction, one undo step restoring order + positions
- **`ReorderDotsLayer.tsx`** — center-dot reorder affordance
- New `reorder-handle` hit-test layer; layout sequence = the group's `entityOrder` run (no new `childOrder` field)
- ADR 0015 + planning docs

## Verification
- `pnpm typecheck` ✓
- `pnpm test:unit` ✓ (626)
- `pnpm test:smoke` ✓ — 5 new `managed-layout` smoke tests pass (persistence + undo round-trip, gesture lifecycle, cancel paths). The one failing smoke test (`takes a screenshot of a page`) fails identically on clean `main` — environmental (display surface unavailable for capture in this session), not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)