### PR TITLE
Smart paste in markdown notes: auto-detect SVG/JSON/HTML and wrap in fenced code block

### DIFF
--- a/src/renderer/canvas-bg/entity-renderers/markdown-codemirror.ts
+++ b/src/renderer/canvas-bg/entity-renderers/markdown-codemirror.ts
@@ -4,6 +4,7 @@ import { defaultKeymap } from '@codemirror/commands'
 import { markdown } from '@codemirror/lang-markdown'
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language'
 import { tags as t } from '@lezer/highlight'
+import { smartPasteExtension } from './markdown-smart-paste'
 
 export const externalUpdate = Annotation.define<boolean>()
 
@@ -94,6 +95,7 @@ export function createMarkdownExtensions(
     keymap.of(defaultKeymap),
     markdown(),
     syntaxHighlighting(markdownHighlightStyle),
+    smartPasteExtension(),
   ]
   // When wrap is off (auto-width plain text), the editor's container shrinks
   // to fit each line's natural width instead of forcing single-character wrap.

--- a/src/renderer/canvas-bg/entity-renderers/markdown-smart-paste.ts
+++ b/src/renderer/canvas-bg/entity-renderers/markdown-smart-paste.ts
@@ -1,0 +1,95 @@
+import type { Extension } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+
+interface PasteData {
+  readonly types: readonly string[]
+  getData(type: string): string
+}
+
+export interface DetectedContent {
+  lang: string
+  text: string
+}
+
+/**
+ * Returns formatted content + language tag when clipboard carries a strong
+ * structural signal (MIME type identifies it, or it parses unambiguously).
+ * Returns null when uncertain — bias is hard toward doing nothing so
+ * mis-fires don't wrap prose in code fences.
+ */
+export function detectSmartPaste(data: PasteData): DetectedContent | null {
+  const types = Array.from(data.types)
+
+  // MIME hints: highest-confidence path
+  if (types.includes('image/svg+xml')) {
+    const text = (data.getData('image/svg+xml') || data.getData('text/plain')).trim()
+    if (text) return { lang: 'svg', text }
+  }
+
+  if (types.includes('application/json')) {
+    const raw = data.getData('application/json') || data.getData('text/plain')
+    if (raw) {
+      try {
+        return { lang: 'json', text: JSON.stringify(JSON.parse(raw), null, 2) }
+      } catch {
+        // malformed despite the MIME type — fall through to plain text sniffs
+      }
+    }
+  }
+
+  // Structural sniffs on plain text
+  const plain = data.getData('text/plain')
+  if (!plain) return null
+  const trimmed = plain.trim()
+  if (!trimmed) return null
+
+  // SVG: must open with <svg and close with </svg> (complete document)
+  if (/^<svg[\s>]/i.test(trimmed) && /<\/svg\s*>$/i.test(trimmed)) {
+    return { lang: 'svg', text: trimmed }
+  }
+
+  // JSON: objects and arrays only — not primitive values like "123" or "true"
+  if (
+    (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+    (trimmed.startsWith('[') && trimmed.endsWith(']'))
+  ) {
+    try {
+      return { lang: 'json', text: JSON.stringify(JSON.parse(trimmed), null, 2) }
+    } catch {
+      // not valid JSON
+    }
+  }
+
+  // Full HTML document — not generic HTML snippets
+  if (/^<!doctype\s+html/i.test(trimmed) || /^<html[\s>]/i.test(trimmed)) {
+    return { lang: 'html', text: trimmed }
+  }
+
+  return null
+}
+
+/**
+ * CodeMirror extension: intercepts paste and wraps detected structured content
+ * in a fenced code block. Falls through to normal paste when detection is
+ * uncertain so plain paste is always available.
+ */
+export function smartPasteExtension(): Extension {
+  return EditorView.domEventHandlers({
+    paste(event, view) {
+      const { clipboardData } = event
+      if (!clipboardData) return false
+
+      const detected = detectSmartPaste(clipboardData)
+      if (!detected) return false
+
+      event.preventDefault()
+      const fenced = `\`\`\`${detected.lang}\n${detected.text}\n\`\`\``
+      const { from, to } = view.state.selection.main
+      view.dispatch({
+        changes: { from, to, insert: fenced },
+        selection: { anchor: from + fenced.length },
+      })
+      return true
+    },
+  })
+}

--- a/tests/unit/markdown-smart-paste.test.ts
+++ b/tests/unit/markdown-smart-paste.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import { detectSmartPaste } from '../../src/renderer/canvas-bg/entity-renderers/markdown-smart-paste'
+
+function mockPasteData(types: string[], data: Record<string, string>) {
+  return {
+    types,
+    getData: (type: string) => data[type] ?? '',
+  }
+}
+
+const MINIMAL_SVG = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>'
+
+describe('detectSmartPaste', () => {
+  describe('SVG detection', () => {
+    it('detects SVG via image/svg+xml MIME type', () => {
+      const result = detectSmartPaste(
+        mockPasteData(['image/svg+xml', 'text/plain'], {
+          'image/svg+xml': MINIMAL_SVG,
+          'text/plain': MINIMAL_SVG,
+        }),
+      )
+      expect(result).toEqual({ lang: 'svg', text: MINIMAL_SVG })
+    })
+
+    it('falls back to text/plain when image/svg+xml slot is empty', () => {
+      const result = detectSmartPaste(
+        mockPasteData(['image/svg+xml', 'text/plain'], {
+          'image/svg+xml': '',
+          'text/plain': MINIMAL_SVG,
+        }),
+      )
+      expect(result).toEqual({ lang: 'svg', text: MINIMAL_SVG })
+    })
+
+    it('detects SVG from plain text structural sniff', () => {
+      const result = detectSmartPaste(
+        mockPasteData(['text/plain'], { 'text/plain': MINIMAL_SVG }),
+      )
+      expect(result).toEqual({ lang: 'svg', text: MINIMAL_SVG })
+    })
+
+    it('does not detect partial SVG missing closing tag', () => {
+      const result = detectSmartPaste(
+        mockPasteData(['text/plain'], {
+          'text/plain': '<svg xmlns="http://www.w3.org/2000/svg"><rect/>',
+        }),
+      )
+      expect(result).toBeNull()
+    })
+
+    it('does not detect SVG-like prose (no opening <svg tag)', () => {
+      const result = detectSmartPaste(
+        mockPasteData(['text/plain'], { 'text/plain': '<div>hello</div>' }),
+      )
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('JSON detection', () => {
+    it('detects JSON object and pretty-prints it', () => {
+      const result = detectSmartPaste(
+        mockPasteData(['text/plain'], { 'text/plain': '{"foo":"bar","n":1}' }),
+      )
+      expect(result).toEqual({
+        lang: 'json',
+        text: JSON.stringify({ foo: 'bar', n: 1 }, null, 2),
+      })
+    })
+
+    it('detects JSON array', () => {
+      const result = detectSmartPaste(
+        mockPasteData(['text/plain'], { 'text/plain': '[1,2,3]' }),
+      )
+      expect(result).toEqual({ lang: 'json', text: JSON.stringify([1, 2, 3], null, 2) })
+    })
+
+    it('detects JSON via application/json MIME type', () => {
+      const result = detectSmartPaste(
+        mockPasteData(['application/json'], {
+          'application/json': '{"key":"value"}',
+        }),
+      )
+      expect(result).toEqual({
+        lang: 'json',
+        text: JSON.stringify({ key: 'value' }, null, 2),
+      })
+    })
+
+    it('does not detect invalid JSON even when braces match', () => {
+      const result = detectSmartPaste(
+        mockPasteData(['text/plain'], { 'text/plain': '{not: valid json}' }),
+      )
+      expect(result).toBeNull()
+    })
+
+    it('does not detect bare JSON primitive (not object or array)', () => {
+      const result = detectSmartPaste(
+        mockPasteData(['text/plain'], { 'text/plain': '"just a string"' }),
+      )
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('HTML detection', () => {
+    it('detects full HTML document starting with DOCTYPE', () => {
+      const html = '<!DOCTYPE html><html><head></head><body>hello</body></html>'
+      const result = detectSmartPaste(
+        mockPasteData(['text/plain'], { 'text/plain': html }),
+      )
+      expect(result).toEqual({ lang: 'html', text: html })
+    })
+
+    it('detects full HTML document starting with <html', () => {
+      const html = '<html><body>hello</body></html>'
+      const result = detectSmartPaste(
+        mockPasteData(['text/plain'], { 'text/plain': html }),
+      )
+      expect(result).toEqual({ lang: 'html', text: html })
+    })
+
+    it('does not detect HTML snippet (generic element, not full document)', () => {
+      const result = detectSmartPaste(
+        mockPasteData(['text/plain'], {
+          'text/plain': '<div class="foo"><p>paragraph</p></div>',
+        }),
+      )
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('prose and no-match cases', () => {
+    it('returns null for plain prose', () => {
+      const result = detectSmartPaste(
+        mockPasteData(['text/plain'], { 'text/plain': 'This is just some plain text.' }),
+      )
+      expect(result).toBeNull()
+    })
+
+    it('returns null for empty clipboard', () => {
+      const result = detectSmartPaste(
+        mockPasteData(['text/plain'], { 'text/plain': '' }),
+      )
+      expect(result).toBeNull()
+    })
+
+    it('returns null when no text/plain is available', () => {
+      const result = detectSmartPaste(mockPasteData([], {}))
+      expect(result).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
Closes #122

## What

Adds smart paste detection to the CodeMirror markdown note editor. When pasting content with a strong structural signal, it's automatically inserted as a fenced code block with the detected language tag.

## Detection logic

Two layers, cheapest first:

1. **MIME type hints** — `image/svg+xml` → `svg`, `application/json` → `json`
2. **Structural sniffs** on `text/plain`:
   - Opens with `<svg` and closes with `</svg>` → `svg`
   - Parses as a valid JSON object or array → `json` (pretty-printed)
   - Starts with `<!DOCTYPE html>` or `<html` → `html`

Uncertain content always falls through to normal paste — bias is hard toward doing nothing so mis-fires can't wrap prose in code fences.

## Undo

The formatted insert is a single CodeMirror dispatch transaction, captured by the Yjs UndoManager as one operation. One Cmd+Z reverses it.

## Files changed

- `src/renderer/canvas-bg/entity-renderers/markdown-smart-paste.ts` — detection function (`detectSmartPaste`) + CodeMirror extension (`smartPasteExtension`)
- `src/renderer/canvas-bg/entity-renderers/markdown-codemirror.ts` — adds `smartPasteExtension()` to the editor extensions
- `tests/unit/markdown-smart-paste.test.ts` — 16 unit tests covering all detection paths and no-match cases

---
_Generated by [Claude Code](https://claude.ai/code/session_01QimxGbNH9tVirc5fJDPcGA)_