### PR TITLE
Fix plain-text placement preview to match selected text size and zoom

### DIFF
--- a/src/main/runtime/canvas-layout-data.ts
+++ b/src/main/runtime/canvas-layout-data.ts
@@ -306,6 +306,8 @@ function buildPlacementPreview(tool: ReturnType<typeof uiActiveTool>): PendingPl
         : undefined
   const color =
     tool.kind === 'add-sticky' ? getToolDefaults()['add-sticky'].color : undefined
+  const textSize =
+    tool.kind === 'add-text' ? getToolDefaults()['add-text'].textSize : undefined
   const customSize = tool.kind === 'add-page' ? tool.customSize === true : false
   const sourcePageId = tool.kind === 'add-page' ? tool.sourcePageId : undefined
   // shapeKind moved to tool defaults per ADR 0009 — preview reads the persisted
@@ -324,6 +326,7 @@ function buildPlacementPreview(tool: ReturnType<typeof uiActiveTool>): PendingPl
     shapeKind,
     textStyle,
     color,
+    textSize,
     width: isText
       ? DEFAULT_TEXT_WIDTH
       : isFile

--- a/src/renderer/canvas-bg/CanvasGridSurface.tsx
+++ b/src/renderer/canvas-bg/CanvasGridSurface.tsx
@@ -116,6 +116,8 @@ export function PlacementPreviewLayer({
     shapeKind?: string
     textStyle?: TextEntityStyle
     color?: string
+    textSize?: number
+    zoom?: number
     left: number
     top: number
     width: number
@@ -128,12 +130,16 @@ export function PlacementPreviewLayer({
   const isShape = preview.entityKind === 'shape'
   const isStickyPreview = isTextEntity && preview.textStyle === 'sticky'
   if (isTextEntity && preview.textStyle === 'plain') {
+    const scaledFontSize = (preview.textSize ?? 14) * (preview.zoom ?? 1)
+    const scaledLineHeight = scaledFontSize * 1.5
     return (
       <div
-        className="pointer-events-none absolute select-none text-[12px] leading-[18px] font-normal"
+        className="pointer-events-none absolute select-none font-normal"
         style={{
           left: preview.left,
           top: preview.top,
+          fontSize: scaledFontSize,
+          lineHeight: `${scaledLineHeight}px`,
           color: isDark ? 'rgba(231, 229, 228, 0.58)' : 'rgba(28, 25, 23, 0.48)',
           fontFamily: 'system-ui, sans-serif',
         }}

--- a/src/renderer/canvas-bg/canvasBgSelectors.ts
+++ b/src/renderer/canvas-bg/canvasBgSelectors.ts
@@ -30,6 +30,8 @@ export function buildPendingPlacementPreview(
     shapeKind: layoutData.pendingPlacement.shapeKind,
     textStyle: layoutData.pendingPlacement.textStyle,
     color: layoutData.pendingPlacement.color,
+    textSize: layoutData.pendingPlacement.textSize,
+    zoom: layoutData.zoom,
     left: layoutData.canvasOrigin.x + layoutData.pan.x + snappedX * layoutData.zoom,
     top: layoutData.canvasOrigin.y + layoutData.pan.y + snappedY * layoutData.zoom,
     width: layoutData.pendingPlacement.width * layoutData.zoom,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -313,6 +313,8 @@ export interface PendingPlacement {
   textStyle?: TextEntityStyle
   /** Stored color of the in-flight placement (sticky fill, etc.) so the preview can match the picker. */
   color?: string
+  /** Text size in canvas units for plain-text placement preview. */
+  textSize?: number
   width: number
   height: number
 }


### PR DESCRIPTION
Closes #146

## What changed

The ghost-text preview shown when hovering with the add-text tool was hardcoded to `12px` and ignored canvas zoom. This fix makes the preview reflect both the configured text size and the current zoom level.

### Changes

- **`src/shared/types.ts`** — added optional `textSize?: number` field to `PendingPlacement`
- **`src/main/runtime/canvas-layout-data.ts`** — `buildPlacementPreview` now reads `getToolDefaults()['add-text'].textSize` and includes it in the placement for `add-text` tools
- **`src/renderer/canvas-bg/canvasBgSelectors.ts`** — `buildPendingPlacementPreview` passes `textSize` and `zoom` through to the preview object
- **`src/renderer/canvas-bg/CanvasGridSurface.tsx`** — `PlacementPreviewLayer` now computes `scaledFontSize = textSize * zoom` for the plain-text case instead of using the hardcoded `text-[12px]` Tailwind class

## Acceptance criteria check

- [x] Preview renders at the currently selected text size (default 14px or user-configured)
- [x] Changing the text size updates the preview
- [x] Preview font scales with canvas zoom
- [x] Preview size and created text size agree across zoom levels and configured sizes
- [x] No regression to sticky-note, shape, or file placement previews (those code paths are unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_013KdAUApa9UExU6LhjCt6Vr)_