### PR TITLE
fix: auto-focus sidebar rename inputs (#167)

### DIFF
--- a/src/main/ipc/register-canvas-ipc.ts
+++ b/src/main/ipc/register-canvas-ipc.ts
@@ -38,6 +38,7 @@ import {
   commitEditingEntity,
 } from '../runtime/editing-entity-runtime'
 import { setTextEditingActive, setAnnotationState } from '../runtime/binding-dispatcher'
+import { leftSidebarView } from '../runtime/view-refs'
 import {
   forwardPointerToPage,
   forwardWheelToPage,
@@ -275,6 +276,12 @@ export function registerCanvasIpc(): void {
   // IPC pair — this handler stays focus-tracking-only.
   ipcMain.on('canvas-set-text-editing', (event, { active }: { active: boolean }) => {
     setTextEditingActive(event.sender, active)
+    // When the sidebar reports a text input becoming active, request a layout
+    // pass so reconcileFocus() immediately gives focus to the sidebar —
+    // preventing any in-flight layout pass from stealing it back to aboveView.
+    if (event.sender === leftSidebarView?.webContents) {
+      requestLayout()
+    }
   })
 
   ipcMain.on(

--- a/src/main/runtime/focus-reconciler-runtime.ts
+++ b/src/main/runtime/focus-reconciler-runtime.ts
@@ -18,6 +18,7 @@ import {
   pendingFocus,
   setPendingFocus,
 } from './runtime-context'
+import { isTextEditingFor } from './binding-dispatcher'
 import { isCommentOverlayVisible, selectedPageIndex, workspaceViewMode } from '../ui-state'
 import { currentKeyboardTargetPageId } from './selection-controller'
 
@@ -46,6 +47,7 @@ function currentFocusState(): FocusState {
     commentOverlayActive: isCommentOverlayVisible(),
     pendingFocus,
     focusedPageId: currentKeyboardTargetPageId(),
+    sidebarTextInputActive: leftSidebarView ? isTextEditingFor(leftSidebarView.webContents) : false,
   }
 }
 

--- a/src/main/runtime/focus-reconciler.ts
+++ b/src/main/runtime/focus-reconciler.ts
@@ -32,10 +32,17 @@ export type FocusState = {
    *  forwarded input, or null. Filled from `currentKeyboardTargetPageId`
    *  at the runtime binding layer. */
   focusedPageId: string | null
+  /** True while a sidebar rename input is active. Forces sidebar focus so
+   *  layout passes don't steal focus back to the canvas. */
+  sidebarTextInputActive: boolean
 }
 
 export function expectedFocus(state: FocusState): FocusTarget {
   if (state.pendingFocus) return state.pendingFocus
+
+  // Sidebar rename input is open — keep focus in the sidebar so keystrokes
+  // reach the input rather than firing canvas shortcuts.
+  if (state.sidebarTextInputActive) return { kind: 'sidebar' }
 
   // Selection-driven page focus (the predicate already gates on idle
   // interaction + commentOverlayActive). Gesture modes still win below

--- a/tests/unit/focus-reconciler.test.ts
+++ b/tests/unit/focus-reconciler.test.ts
@@ -10,6 +10,7 @@ function state(overrides: Partial<FocusState> = {}): FocusState {
     commentOverlayActive: false,
     pendingFocus: null,
     focusedPageId: null,
+    sidebarTextInputActive: false,
     ...overrides,
   }
 }
@@ -61,6 +62,20 @@ describe('expectedFocus', () => {
       expect(expectedFocus(state({ focusedPageId: 'f1', pendingFocus: { kind: 'toolbar' } })))
         .toEqual({ kind: 'toolbar' })
     })
+  })
+
+  it('routes to sidebar when sidebarTextInputActive', () => {
+    expect(expectedFocus(state({ sidebarTextInputActive: true }))).toEqual({ kind: 'sidebar' })
+  })
+
+  it('sidebarTextInputActive overrides page focus', () => {
+    expect(expectedFocus(state({ sidebarTextInputActive: true, focusedPageId: 'p1' })))
+      .toEqual({ kind: 'sidebar' })
+  })
+
+  it('sidebarTextInputActive yields to explicit pendingFocus', () => {
+    expect(expectedFocus(state({ sidebarTextInputActive: true, pendingFocus: { kind: 'toolbar' } })))
+      .toEqual({ kind: 'toolbar' })
   })
 
   it('pendingFocus overrides derivation', () => {


### PR DESCRIPTION
Closes #167

## Root cause

The focus reconciler (`expectedFocus`) never returned `{ kind: 'sidebar' }`, so every layout pass routed focus back to `aboveView` or a page view — stealing focus from the sidebar's rename input as soon as it appeared. The user's next keystroke went to the canvas rather than the input.

## Fix

- Add `sidebarTextInputActive: boolean` to `FocusState`. When true, `expectedFocus` returns `{ kind: 'sidebar' }`, preventing any layout pass from stealing focus.
- Populate the flag from `isTextEditingFor(leftSidebarView.webContents)` in `currentFocusState()`. The sidebar already reports text-input state via the existing `canvas-set-text-editing` IPC (wired up through `useReportTextEditing`), so no new renderer-side changes are needed.
- Request a layout pass when the sidebar signals `active: true` so `reconcileFocus()` restores sidebar focus immediately if it was grabbed between the double-click and the IPC arriving.
- Add unit tests for the new routing rules (sidebar focus, override of page focus, yield to `pendingFocus`).

No changes to `InlineEditLabel.tsx` or the sidebar renderers — the existing `inputRef.current?.focus()` call was correct; the bug was entirely in the main-process focus reconciler.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMLwDN1wZyuo4K7WmVEHLr)_