### PR TITLE
fix(toolbar): let draw/comment/inspect activate with no pages

### DIFF
--- a/src/main/runtime/inspect-session.ts
+++ b/src/main/runtime/inspect-session.ts
@@ -433,7 +433,9 @@ export function notifyDevtoolsPanelData(): void {
     panelMode,
     activeTool: uiActiveTool(),
     annotateEnabled: uiActiveTool().kind === 'comment',
-    annotateAvailable: pages.length > 0,
+    // Comment activates on an empty canvas (matching the always-on toolbar), so
+    // the right-panel toggle must stay available with zero pages too.
+    annotateAvailable: true,
     focusedAnnotationId: uiFocusedAnnotationId(),
     selection: selectedPageSummary(),
     inspect,

--- a/src/main/runtime/tool-mode.ts
+++ b/src/main/runtime/tool-mode.ts
@@ -57,17 +57,10 @@ function sanitizeForFeatureFlags(tool: Tool): Tool {
   return tool
 }
 
-function sanitizeForPages(tool: Tool): Tool {
-  if (pages.length > 0) return tool
-  // Annotation/inspect tools need at least one page; collapse to select otherwise.
-  if (isAnnotationTool(tool) || tool.kind === 'inspect') {
-    return { kind: 'select' }
-  }
-  return tool
-}
-
 export function setActiveTool(tool: Tool): Tool {
-  const sanitized = sanitizeForPages(sanitizeForFeatureFlags(tool))
+  // Draw, comment, and inspect activate on an empty canvas — they don't
+  // require a page. Only the drawing feature flag can veto a tool here.
+  const sanitized = sanitizeForFeatureFlags(tool)
   const prev = uiActiveTool()
   if (toolsEqual(prev, sanitized)) {
     return prev


### PR DESCRIPTION
## Summary

Follow-up to #181. That PR removed the `hasPages`-gated `disabled` on the Draw/Comment/Inspect toolbar buttons, but a **second, main-side gate** remained: `sanitizeForPages()` in `src/main/runtime/tool-mode.ts` silently collapsed annotation/inspect tools back to `select` whenever the canvas had zero pages.

The result: with no frame on the canvas, the Draw (pen/marker) button *looked* clickable but the activation died in main — `activeTool` never became `'draw'`, so the tool didn't select and its `DrawToolPopup` (gated on `activeTool.kind === 'draw'`) never appeared. Same for Comment and Inspect.

This removes the page collapse entirely, so draw, comment, and inspect activate on an empty canvas — matching the always-enabled buttons. Only the drawing feature flag can veto a tool now.

It also closes a parallel gate: the right panel's "Add comments" button used `annotateAvailable: pages.length > 0`, which stayed disabled on an empty canvas even though the toolbar comment tool now activates there. That flag is now always `true` so both surfaces agree.

## Why it's safe with zero pages

The inspect path (the only one that touches page content) is already defensive:
- `syncInspectionState()` iterates an empty `pages` list → no-op
- panel data reports `available` = `pages.length > 0`
- inspection-enabled is forced `false` when there are no pages
- hover-target handlers guard `if (!page || …isDestroyed()) return`

`syncAnnotationState()` (draw/comment) also just iterates the empty `pages` list. No tool crashes; inspect simply has nothing to target until a page exists.

## Test plan

- [ ] Empty canvas (no pages): click Draw → tool activates and the brush/color popup appears in the top toolbar.
- [ ] Empty canvas: click Comment → comment tool activates.
- [ ] Empty canvas: open right panel → Comments → "Add comments" button is enabled and toggles comment mode.
- [ ] Empty canvas: click Inspect → inspect tool activates (panel shows nothing to inspect, no error).
- [ ] With pages present, all three tools behave exactly as before.
- [ ] `pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
