### PR TITLE
Rename ResizeEdge → ResizeDirection in interaction-types.ts

### DIFF
--- a/src/shared/interaction-types.ts
+++ b/src/shared/interaction-types.ts
@@ -1,6 +1,6 @@
 import type { CanvasPoint } from './coords'
 
-export type ResizeEdge = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw'
+export type ResizeDirection = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw'
 
 export type EdgeEndpoint = { entityId: string; side: 'top' | 'right' | 'bottom' | 'left' }
 
@@ -9,7 +9,7 @@ export type InteractionMode =
   | { kind: 'panning' }
   | { kind: 'marquee'; origin: CanvasPoint; current: CanvasPoint }
   | { kind: 'dragging-entities'; ids: string[]; anchor: CanvasPoint }
-  | { kind: 'resizing-entity'; id: string; edge: ResizeEdge }
+  | { kind: 'resizing-entity'; id: string; edge: ResizeDirection }
   | { kind: 'resizing-multi-selection' }
   | { kind: 'dragging-edge'; from: EdgeEndpoint; target: EdgeEndpoint | null }
   | { kind: 'editing-entity'; id: string }


### PR DESCRIPTION
Closes #183

Renames `ResizeEdge` → `ResizeDirection` in `src/shared/interaction-types.ts` (definition + its single consumer on line 12). This eliminates the duplicate exported name between `interaction-types.ts` and `resize-accumulator.ts`, clearing the `fallow check` warning.

The `resize-accumulator.ts` variant and its re-export chain through `entityConstants.ts` and `ResizeHandles.tsx` are untouched.

**Verified:** `pnpm typecheck` (no new errors), `pnpm test:unit` (650/650 pass).

---
_Generated by [Claude Code](https://claude.ai/code/session_019LAxfFgMnYxzsscY8qbnZL)_