### PR TITLE
fix: isolate test discovery files and re-assert the canonical one

### DIFF
--- a/src/main/app-control-server.ts
+++ b/src/main/app-control-server.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto'
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'http'
 import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs'
-import { join } from 'path'
+import { isAbsolute, join } from 'path'
 import { tmpdir } from 'os'
 import type { Duplex } from 'stream'
 import { WebSocket, WebSocketServer, type RawData } from 'ws'
@@ -78,8 +78,49 @@ let cdpProxyServer: WebSocketServer | null = null
 let secret = ''
 const PROBE_TIMEOUT_MS = 1_000
 
+// The discovery payload this instance owns once it has successfully bound, plus
+// a timer that re-asserts it. See ensureDiscoveryFile.
+let currentDiscovery: DiscoveryPayload | null = null
+let discoveryReassertTimer: NodeJS.Timeout | null = null
+const DISCOVERY_REASSERT_INTERVAL_MS = 4_000
+
+// Test instances (smoke/agent) set SPECULAR_DISCOVERY_FILE to a private path so
+// they never read or clobber the canonical file the dev/production app and the
+// CLI share. Mirror this in src/main/shared/app-client.ts.
 function discoveryFilePath(): string {
+  const override = process.env.SPECULAR_DISCOVERY_FILE
+  if (override) return isAbsolute(override) ? override : join(tmpdir(), override)
   return join(tmpdir(), APP_CONTROL_DISCOVERY_FILE)
+}
+
+function writeDiscoveryFile(payload: DiscoveryPayload): void {
+  writeFileSync(discoveryFilePath(), JSON.stringify(payload, null, 2), 'utf8')
+}
+
+// Re-write the discovery file if it has gone missing or drifted while our
+// server is still listening. Guards against another instance (e.g. a smoke
+// test tearing down, or a crash leaving a stale file) deleting or overwriting
+// the canonical file and orphaning this still-running app from the CLI.
+function ensureDiscoveryFile(): void {
+  if (!server || !currentDiscovery) return
+  try {
+    const onDisk = JSON.parse(readFileSync(discoveryFilePath(), 'utf8')) as Partial<DiscoveryPayload>
+    if (
+      onDisk.port === currentDiscovery.port &&
+      onDisk.secret === currentDiscovery.secret &&
+      onDisk.version === currentDiscovery.version
+    ) {
+      return
+    }
+  } catch {
+    // Missing or unreadable — fall through and rewrite.
+  }
+  try {
+    writeDiscoveryFile(currentDiscovery)
+    console.warn('[app-control] re-asserted discovery file (was missing or drifted)')
+  } catch (error) {
+    console.warn('[app-control] failed to re-assert discovery file:', error)
+  }
 }
 
 function removeDiscoveryFile(): void {
@@ -817,13 +858,21 @@ export async function startAppControlServer(): Promise<void> {
     secret,
     version: APP_CONTROL_VERSION,
   }
-  writeFileSync(discoveryFilePath(), JSON.stringify(payload, null, 2), 'utf8')
+  currentDiscovery = payload
+  writeDiscoveryFile(payload)
+  discoveryReassertTimer = setInterval(ensureDiscoveryFile, DISCOVERY_REASSERT_INTERVAL_MS)
+  discoveryReassertTimer.unref?.()
   console.log(`[app-control] listening on http://${APP_CONTROL_HOST}:${effectivePort}`)
   notifyStatusListeners()
 }
 
 export function stopAppControlServer(): void {
   if (!server) return
+  if (discoveryReassertTimer) {
+    clearInterval(discoveryReassertTimer)
+    discoveryReassertTimer = null
+  }
+  currentDiscovery = null
   cdpProxyServer?.close()
   cdpProxyServer = null
   server.close()

--- a/src/main/shared/app-client.ts
+++ b/src/main/shared/app-client.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
 import { readFileSync, writeFileSync } from 'fs'
-import { join } from 'path'
+import { isAbsolute, join } from 'path'
 import { tmpdir } from 'os'
 import {
   APP_CONTROL_DISCOVERY_FILE,
@@ -17,7 +17,12 @@ interface DiscoveryPayload {
   version: string
 }
 
+// Mirror the resolver in src/main/app-control-server.ts: SPECULAR_DISCOVERY_FILE
+// lets test instances talk to a private discovery file instead of the canonical
+// one shared by the dev/production app.
 function discoveryFilePath(): string {
+  const override = process.env.SPECULAR_DISCOVERY_FILE
+  if (override) return isAbsolute(override) ? override : join(tmpdir(), override)
   return join(tmpdir(), APP_CONTROL_DISCOVERY_FILE)
 }
 
@@ -98,6 +103,14 @@ export async function callApp<T>(path: string, init?: RequestInit): Promise<T> {
   })
   const payload = (await response.json()) as T & { error?: string }
   if (!response.ok) {
+    if (response.status === 401) {
+      // The discovery file's secret no longer matches the server answering on
+      // its port — typically a stale file left by a restarted app or a test
+      // instance. Relaunching the app rewrites the file with a fresh secret.
+      throw new Error(
+        'Specular rejected the request (stale credentials). The discovery file points at a server with a different secret — quit any extra Specular instances and relaunch the app, then retry.',
+      )
+    }
     throw new Error(payload.error ?? `Request failed with ${response.status}`)
   }
   return payload

--- a/tests/agent/run-scenarios.sh
+++ b/tests/agent/run-scenarios.sh
@@ -41,12 +41,15 @@ cleanup() {
   if [[ -n "$SANDBOX_DIR" && -d "$SANDBOX_DIR" ]]; then
     rm -rf "$SANDBOX_DIR"
   fi
+  rm -f "$DISCOVERY_FILE" 2>/dev/null || true
   agent-browser close 2>/dev/null || true
 }
 trap cleanup EXIT
 
-# Locate the discovery file (macOS tmpdir is not always /tmp)
-DISCOVERY_FILE="$(python3 -c "import tempfile, os; print(os.path.join(tempfile.gettempdir(), 'specular-mcp.json'))")"
+# Private discovery file (macOS tmpdir is not always /tmp) so this run never
+# reads or clobbers the canonical specular-mcp.json a dev app + CLI share.
+DISCOVERY_FILE="$(python3 -c "import tempfile, os; print(os.path.join(tempfile.gettempdir(), 'specular-mcp-agent-$SMOKE_PORT.json'))")"
+export SPECULAR_DISCOVERY_FILE="$DISCOVERY_FILE"
 
 # Read secret once (populated after server is ready)
 API_SECRET=""

--- a/tests/smoke/global-setup.ts
+++ b/tests/smoke/global-setup.ts
@@ -3,7 +3,6 @@ import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync } from 'fs
 import { join } from 'path'
 import { tmpdir } from 'os'
 
-const DISCOVERY_FILE = join(tmpdir(), 'specular-mcp.json')
 const SMOKE_ENV_FILE = join(tmpdir(), 'specular-smoke-env.json')
 const POLL_INTERVAL_MS = 500
 const POLL_TIMEOUT_MS = 15_000
@@ -11,6 +10,11 @@ const POLL_TIMEOUT_MS = 15_000
 // Use a random high port to avoid colliding with a running Specular instance
 const SMOKE_PORT = 29900 + Math.floor(Math.random() * 99)
 const SMOKE_CDP_PORT = 39000 + Math.floor(Math.random() * 1000)
+
+// Private discovery file so smoke instances never read or clobber the canonical
+// specular-mcp.json that a developer's running app and the CLI share. Namespaced
+// by port so concurrent smoke runs stay isolated too.
+const DISCOVERY_FILE = join(tmpdir(), `specular-mcp-smoke-${SMOKE_PORT}.json`)
 
 let electronProcess: ChildProcess | null = null
 let sandboxDir: string | null = null
@@ -49,6 +53,7 @@ export async function setup() {
       ...process.env,
       NODE_ENV: 'production',
       SPECULAR_PORT: String(SMOKE_PORT),
+      SPECULAR_DISCOVERY_FILE: DISCOVERY_FILE,
       SPECULAR_REMOTE_DEBUGGING_PORT: String(SMOKE_CDP_PORT),
       SPECULAR_SKIP_ONBOARDING: '1',
       SPECULAR_BACKGROUND: '1',
@@ -88,14 +93,8 @@ export async function teardown() {
     rmSync(sandboxDir, { recursive: true, force: true })
   }
 
-  // Only remove the discovery file if it belongs to our smoke test instance
-  if (existsSync(DISCOVERY_FILE)) {
-    try {
-      const payload = JSON.parse(readFileSync(DISCOVERY_FILE, 'utf8'))
-      if (payload.port === SMOKE_PORT) rmSync(DISCOVERY_FILE)
-    } catch {
-      // File may have been removed by another process
-    }
-  }
+  // DISCOVERY_FILE is private to this run, so removing it can't affect the
+  // canonical specular-mcp.json a developer's app relies on.
+  if (existsSync(DISCOVERY_FILE)) rmSync(DISCOVERY_FILE, { force: true })
   if (existsSync(SMOKE_ENV_FILE)) rmSync(SMOKE_ENV_FILE)
 }


### PR DESCRIPTION
## Problem

The `specular` CLI returned `error: Unauthorized` when run against a running app. Root cause: smoke and agent test instances share the single global `$TMPDIR/specular-mcp.json` discovery file with the dev/production app, **last-writer-wins**.

- A test run binds a random port and **overwrites** the canonical file with its own port + secret.
- On teardown it removes the file — orphaning a still-running dev app from the CLI (`app not available`).
- If a test crashed or a port was later reused, the file pointed at a live server with a **different secret** → genuine `401 Unauthorized`.

Confirmed live: a leaked canonical file was found pointing at port `29965` (a smoke random port) with a dead server.

## Changes

- **Isolation** — add a `SPECULAR_DISCOVERY_FILE` env override to the discovery-path resolver in both the control server (`app-control-server.ts`) and the CLI client (`app-client.ts`). Production/dev never set it, so they keep using the canonical `specular-mcp.json`.
- **Tests** — smoke (`global-setup.ts`) and agent (`run-scenarios.sh`) runs now write to private, port-namespaced discovery files (`specular-mcp-smoke-<port>.json` / `specular-mcp-agent-<port>.json`) and clean up only their own file. They can no longer read, overwrite, or delete the canonical file.
- **Re-assert** — the instance that successfully binds re-checks its discovery file every 4s and rewrites it if it has gone missing or drifted while still listening (defense against crashes/external deletes).
- **Clear error** — a CLI 401 now throws a "stale credentials — quit extra instances and relaunch" message instead of a bare `Unauthorized`.

## Verification

- `pnpm typecheck` ✓ · `pnpm test:unit` ✓ (650) · `pnpm test:smoke` → 154 passed, 1 todo.
- The one smoke failure (`takes a screenshot of a page` → "display surface not available") is an environment limit of headless `SPECULAR_BACKGROUND=1`, unrelated to this change.
- The smoke run exercised the new override end-to-end: the server came up via the private discovery file and self-cleaned, leaving the canonical file untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)