### PR TITLE
Resume Claude sessions across annotation replies

### DIFF
--- a/src/main/agent-fix/claude-spawner.ts
+++ b/src/main/agent-fix/claude-spawner.ts
@@ -8,11 +8,15 @@ export interface FixResult {
   summary: string
   shouldResolve: boolean
   rawOutput: string
+  /** Session id reported by this run, for resuming the thread on the next reply. */
+  sessionId?: string
 }
 
 export interface InvokeOptions {
   onEvent?: (event: FixProgressEvent) => void
   timeout?: number
+  /** Resume an existing Claude session instead of starting a fresh one. */
+  resumeSessionId?: string
 }
 
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000
@@ -44,6 +48,9 @@ export function invokeClaude(
       '--output-format', 'stream-json',
       '--verbose',
     ]
+    if (options.resumeSessionId) {
+      args.push('--resume', options.resumeSessionId)
+    }
     if (config.model !== 'opus') {
       args.push('--model', `claude-${config.model}-4-6`)
     }
@@ -63,6 +70,7 @@ export function invokeClaude(
     let stdoutBuffer = ''
     let rawOutput = ''
     let finalText = ''
+    let sessionId: string | undefined
 
     const timer = setTimeout(() => {
       child.kill('SIGKILL')
@@ -73,6 +81,7 @@ export function invokeClaude(
       const parsed = parseStreamLine(line)
       if (!parsed) return
       if (parsed.finalText != null) finalText = parsed.finalText
+      if (parsed.sessionId) sessionId = parsed.sessionId
       if (options.onEvent) options.onEvent(parsed.event)
     }
 
@@ -114,7 +123,7 @@ export function invokeClaude(
         return
       }
       const parsed = parseOutput(finalText || rawOutput)
-      resolve({ ...parsed, rawOutput })
+      resolve({ ...parsed, rawOutput, sessionId })
     })
 
     child.stdin.end()

--- a/src/main/agent-fix/fix-orchestrator.ts
+++ b/src/main/agent-fix/fix-orchestrator.ts
@@ -1,15 +1,16 @@
-import type { Annotation } from '../../shared/types'
+import type { Annotation, FixProgressEvent } from '../../shared/types'
 import { annotationOrigin, truncate } from '../../shared/annotation-utils'
 import {
   addAnnotationReply,
   getAnnotationById,
   getAnnotations,
+  setAnnotationFixSession,
   setOnAnnotationCreated,
   setOnAnnotationReply,
   updateAnnotationStatus,
 } from '../workspace-annotations'
 import { getOriginBindingView as getOriginBinding } from '../runtime/dev-server-manager'
-import { buildFixPrompt } from './prompt-builder'
+import { buildFixPrompt, buildFollowUpPrompt } from './prompt-builder'
 import { invokeClaude, type FixResult } from './claude-spawner'
 import {
   isAnnotationInFlight,
@@ -40,7 +41,7 @@ export function initFixOrchestrator(): void {
     if (!origin) return
     const binding = getOriginBinding(origin)
     if (!binding || !binding.autoFix) return
-    fixAnnotation(annotation.id)
+    fixAnnotationCore(annotation, { followUpText: reply.text })
   })
 }
 
@@ -64,7 +65,10 @@ export function fixPendingAnnotationsForOrigin(origin: string): number {
   return queued
 }
 
-function fixAnnotationCore(annotation: Annotation): boolean {
+function fixAnnotationCore(
+  annotation: Annotation,
+  opts?: { followUpText?: string },
+): boolean {
   if (isAnnotationInFlight(annotation.id)) return false
 
   const origin = annotationOrigin(annotation)
@@ -83,31 +87,58 @@ function fixAnnotationCore(annotation: Annotation): boolean {
     return false
   }
 
-  const prompt = buildFixPrompt(annotation)
+  // A thread that has been fixed before carries its Claude session id; resume it
+  // so the agent keeps its prior context. The first fix (or a stale session)
+  // falls back to the full-context prompt.
+  const resumeSessionId = annotation.metadata?.fixSessionId
+  const fullPrompt = buildFixPrompt(annotation)
+  const prompt = resumeSessionId
+    ? buildFollowUpPrompt(opts?.followUpText ?? latestUserReplyText(annotation))
+    : fullPrompt
+
   updateAnnotationStatus(annotation.id, 'acknowledged')
   startFixProgress(annotation.id, origin)
   markFixStarted(annotation.id, origin)
-  void runFix(annotation.id, origin, prompt, binding.repoPath)
+  void runFix(annotation.id, origin, binding.repoPath, { prompt, resumeSessionId, fullPrompt })
   return true
+}
+
+function latestUserReplyText(annotation: Annotation): string {
+  for (let i = annotation.replies.length - 1; i >= 0; i--) {
+    if (annotation.replies[i].author === 'user') return annotation.replies[i].text
+  }
+  return ''
 }
 
 async function runFix(
   annotationId: string,
   origin: string,
-  prompt: string,
   repoPath: string,
+  plan: { prompt: string; resumeSessionId?: string; fullPrompt: string },
 ): Promise<void> {
   let result: FixResult | null = null
   let error: Error | null = null
+  const onEvent = (event: FixProgressEvent) =>
+    appendFixEvent(annotationId, event.kind, event.text)
   try {
-    result = await invokeClaude(prompt, repoPath, {
-      onEvent: (event) => appendFixEvent(annotationId, event.kind, event.text),
-    })
+    result = await invokeClaude(plan.prompt, repoPath, { resumeSessionId: plan.resumeSessionId, onEvent })
   } catch (err) {
     error = err instanceof Error ? err : new Error(String(err))
+    // A stale/missing session can't be resumed (cleaned up, or the .canvas
+    // moved to another machine). Retry once from scratch with full context.
+    if (plan.resumeSessionId) {
+      appendFixEvent(annotationId, 'system', 'Could not resume prior session — starting fresh.')
+      error = null
+      try {
+        result = await invokeClaude(plan.fullPrompt, repoPath, { onEvent })
+      } catch (retryErr) {
+        error = retryErr instanceof Error ? retryErr : new Error(String(retryErr))
+      }
+    }
   } finally {
     markFixFinished(annotationId, origin)
   }
+  if (result?.sessionId) setAnnotationFixSession(annotationId, result.sessionId)
   handleCompletion(annotationId, result, error)
 }
 

--- a/src/main/agent-fix/prompt-builder.ts
+++ b/src/main/agent-fix/prompt-builder.ts
@@ -103,6 +103,26 @@ export function buildFixPrompt(annotation: Annotation): string {
   return lines.join('\n')
 }
 
+/**
+ * Prompt for a resumed session. The session already holds the page context and
+ * prior thread, so we only send the new user message plus the reply contract.
+ */
+export function buildFollowUpPrompt(replyText: string): string {
+  const message = replyText.trim() || 'Continue addressing the latest feedback in this thread.'
+  return [
+    'The user replied on the same comment thread:',
+    `[User] ${message}`,
+    '',
+    'Continue the fix. Use the specular skill to inspect the live page as before.',
+    '',
+    'Reply format — REQUIRED:',
+    '- End with one short IM-style summary line (under 280 chars), then a newline, then one of:',
+    '  <<RESOLVE>>   if you believe the issue is now fixed',
+    '  <<WAITING>>   if you need more information from the user',
+    'Do not write anything after the marker.',
+  ].join('\n')
+}
+
 function labelForAuthor(author: 'user' | 'agent'): string {
   return author === 'agent' ? 'Agent' : 'User'
 }

--- a/src/main/agent-fix/stream-json-parser.ts
+++ b/src/main/agent-fix/stream-json-parser.ts
@@ -13,6 +13,8 @@ import { truncate } from '../../shared/annotation-utils'
 export interface ParsedStreamEvent {
   event: FixProgressEvent
   finalText?: string
+  /** Claude Code session id, carried on the init event so a thread can resume. */
+  sessionId?: string
 }
 
 export function parseStreamLine(line: string): ParsedStreamEvent | null {
@@ -29,8 +31,13 @@ export function parseStreamLine(line: string): ParsedStreamEvent | null {
   const type = payload.type as string | undefined
 
   if (type === 'system') {
-    const model = payload.model ?? payload.session_id ?? payload.subtype ?? 'system'
-    return makeEvent('system', `init ${String(model)}`)
+    // The stream emits many `system` messages per run (init, status, hooks …),
+    // all carrying the same session_id. Only the real init is worth surfacing;
+    // the rest would render as a flood of identical "init <session_id>" lines.
+    if (payload.subtype !== 'init') return null
+    const model = typeof payload.model === 'string' ? payload.model : 'session'
+    const sessionId = typeof payload.session_id === 'string' ? payload.session_id : undefined
+    return { ...makeEvent('system', `init ${model}`), sessionId }
   }
 
   if (type === 'assistant') {
@@ -66,8 +73,11 @@ export function parseStreamLine(line: string): ParsedStreamEvent | null {
     return { ...makeEvent('result', summary), finalText }
   }
 
-  // Unknown event — fall through with a short marker so we still see movement.
-  return makeEvent('system', String(type ?? 'event'))
+  // Allowlist: only the types handled above are surfaced. Anything else
+  // (rate_limit_event, status pings, future control messages) is dropped so
+  // new CLI message types can't flood the panel. Movement is already visible
+  // through assistant/tool_use/tool_result events.
+  return null
 }
 
 function describeContentBlock(block: any): { kind: FixProgressEventKind; text: string } | null {

--- a/src/main/app-control-server.ts
+++ b/src/main/app-control-server.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'crypto'
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'http'
-import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs'
-import { isAbsolute, join } from 'path'
-import { tmpdir } from 'os'
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'fs'
+import { dirname, isAbsolute, join } from 'path'
+import { homedir, tmpdir } from 'os'
 import type { Duplex } from 'stream'
 import { WebSocket, WebSocketServer, type RawData } from 'ws'
 
@@ -87,13 +87,19 @@ const DISCOVERY_REASSERT_INTERVAL_MS = 4_000
 // Test instances (smoke/agent) set SPECULAR_DISCOVERY_FILE to a private path so
 // they never read or clobber the canonical file the dev/production app and the
 // CLI share. Mirror this in src/main/shared/app-client.ts.
+//
+// The default lives under the home dir, NOT tmpdir(): a CLI run inside a tool
+// sandbox (e.g. Claude Code sets TMPDIR=/tmp/claude-<uid>) resolves tmpdir() to
+// a different directory than the app, so writer and reader would never meet.
+// A home-relative path is stable across processes regardless of TMPDIR.
 function discoveryFilePath(): string {
   const override = process.env.SPECULAR_DISCOVERY_FILE
   if (override) return isAbsolute(override) ? override : join(tmpdir(), override)
-  return join(tmpdir(), APP_CONTROL_DISCOVERY_FILE)
+  return join(homedir(), '.specular', APP_CONTROL_DISCOVERY_FILE)
 }
 
 function writeDiscoveryFile(payload: DiscoveryPayload): void {
+  mkdirSync(dirname(discoveryFilePath()), { recursive: true })
   writeFileSync(discoveryFilePath(), JSON.stringify(payload, null, 2), 'utf8')
 }
 

--- a/src/main/shared/app-client.ts
+++ b/src/main/shared/app-client.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto'
 import { readFileSync, writeFileSync } from 'fs'
 import { isAbsolute, join } from 'path'
-import { tmpdir } from 'os'
+import { homedir, tmpdir } from 'os'
 import {
   APP_CONTROL_DISCOVERY_FILE,
   APP_CONTROL_VERSION,
@@ -19,11 +19,13 @@ interface DiscoveryPayload {
 
 // Mirror the resolver in src/main/app-control-server.ts: SPECULAR_DISCOVERY_FILE
 // lets test instances talk to a private discovery file instead of the canonical
-// one shared by the dev/production app.
+// one shared by the dev/production app. The default is home-relative (not
+// tmpdir()) so the CLI finds the app even when run inside a tool sandbox that
+// overrides TMPDIR (e.g. Claude Code's /tmp/claude-<uid>).
 function discoveryFilePath(): string {
   const override = process.env.SPECULAR_DISCOVERY_FILE
   if (override) return isAbsolute(override) ? override : join(tmpdir(), override)
-  return join(tmpdir(), APP_CONTROL_DISCOVERY_FILE)
+  return join(homedir(), '.specular', APP_CONTROL_DISCOVERY_FILE)
 }
 
 function loadDiscovery(): DiscoveryPayload {

--- a/src/main/workspace-annotations.ts
+++ b/src/main/workspace-annotations.ts
@@ -223,6 +223,15 @@ export function updateAnnotationStatus(
   return annotation
 }
 
+export function setAnnotationFixSession(id: string, sessionId: string): void {
+  const annotation = workspaceAnnotations.find((a) => a.id === id)
+  if (!annotation) return
+  if (annotation.metadata?.fixSessionId === sessionId) return
+  annotation.metadata = { ...annotation.metadata, fixSessionId: sessionId }
+  markDirty('canvas')
+  scheduleWorkspaceAutosave()
+}
+
 export function addAnnotationReply(
   id: string,
   author: 'user' | 'agent',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2196,6 +2196,12 @@ export interface AnnotationMetadata extends Record<string, unknown> {
   regionElements?: RegionElementGroup[]
   /** Who resolved this annotation, when status === 'resolved'. */
   resolvedBy?: 'user' | 'agent'
+  /**
+   * Claude Code session id for this thread's fix conversation. Set after the
+   * first fix; subsequent replies resume the same session (`claude --resume`)
+   * so the agent keeps its prior context instead of starting cold.
+   */
+  fixSessionId?: string
 }
 
 // --- Origin bindings (derived view from ConnectedRepo.boundOrigins) ---


### PR DESCRIPTION
## Summary

Improves the annotation-driven agent fix loop so a follow-up reply continues the same Claude conversation instead of restarting from scratch.

- **Resumable sessions** — the Claude Code session id is captured from the stream `init` event and persisted on the thread's annotation metadata (`fixSessionId`) after the first fix. A reply on that thread resumes the session (`claude --resume`) with a follow-up prompt carrying only the new user message, so the agent keeps its prior page context. If the session can't be resumed (cleaned up, or the `.canvas` moved to another machine), it retries once from scratch with the full-context prompt.
- **Quieter stream parsing** — only the real `init` system event (which carries `session_id`) is surfaced; other `system` messages and unknown event types are dropped via allowlist so new CLI message types can't flood the progress panel. Movement stays visible through assistant/tool_use/tool_result events.
- **Sandbox-safe discovery** — the app-control discovery file now resolves under `~/.specular` instead of `tmpdir()`. A CLI run inside a tool sandbox that overrides `TMPDIR` (e.g. Claude Code's `/tmp/claude-<uid>`) resolves `tmpdir()` differently from the app, so writer and reader never met; a home-relative path is stable across processes.

## Changes
- `agent-fix/claude-spawner.ts` — capture `sessionId`; accept `resumeSessionId` and pass `--resume`.
- `agent-fix/stream-json-parser.ts` — surface only `init` (with `session_id`); allowlist event types.
- `agent-fix/prompt-builder.ts` — `buildFollowUpPrompt` for resumed sessions.
- `agent-fix/fix-orchestrator.ts` — resume on reply, fall back to full context once on failure, persist the returned session id.
- `workspace-annotations.ts` + `shared/types.ts` — `setAnnotationFixSession` / `fixSessionId` metadata.
- `app-control-server.ts` + `shared/app-client.ts` — home-relative discovery file path.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:unit` (686 passed)
- [ ] Manual: create an annotation → auto-fix runs → reply on the thread → agent resumes the same session (no cold re-read of page context)
- [ ] Manual: delete/expire the session, then reply → falls back to a fresh full-context run
- [ ] Manual: run the `specular` CLI from inside Claude Code (TMPDIR overridden) → it discovers the running app

> Note: this branch contains pre-existing local work; opened as its own PR per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)