### PR TITLE
Add self-healing CLI loop: general engine + CLI pack + probe harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,9 +146,11 @@ primitives and tools, not dedicated workflow features:
 
 ## Agent integration
 
-Agent interaction is moving to a CLI for better context management.
-Agents can also read and write .canvas files directly — they are just JSON.
-The HTTP API (src/main/routes/) remains available for runtime interaction.
+The `specular` CLI is the primary agent surface — see the specular skill
+(`.claude/skills/specular/SKILL.md`) for the full command reference and
+`## Specular CLI` below for invocation rules. Agents can also read and write
+.canvas files directly — they are just JSON. The HTTP API (`src/main/routes/`)
+backs the CLI and remains available for direct runtime interaction.
 
 ## Testing patterns
 
@@ -171,7 +173,19 @@ The suite stays small on purpose. To prevent drift back to a pile of low-value t
 
 ## Specular CLI
 
-- Always pass full URLs (including scheme and host) to `specular create page`. The canvas can contain pages from different origins, so bare paths like `/garden` are ambiguous. Use `http://localhost:4321/garden`, not `/garden`.
+The `specular` CLI drives the canvas (`src/main/cli.ts`, `src/main/cli-commands.ts`).
+It talks to the running app over the HTTP API, discovered via
+`~/.specular/specular-mcp.json`. The full command reference lives in the specular
+skill; `specular --help` lists the verbs.
+
+- The app must be running (`pnpm dev`) for any command to work — otherwise the CLI
+  reports "Specular app is not available. Launch the app first."
+- After editing CLI source, rebuild with `pnpm build:cli`, or the command keeps the
+  old behavior (`pnpm dev` rebuilds it on start).
+- Always pass full URLs (including scheme and host) to `specular create page` and
+  `specular breakpoints`. The canvas can contain pages from different origins, so
+  bare paths like `/garden` are ambiguous. Use `http://localhost:4321/garden`, not
+  `/garden`.
 
 ## Skill files
 

--- a/docs/plans/self-heal-cli-loop.md
+++ b/docs/plans/self-heal-cli-loop.md
@@ -1,0 +1,100 @@
+# Self-healing CLI loop
+
+A local loop that continuously improves the `specular` CLI: a fresh-context agent
+uses the CLI to edit the canvas, measures how awkward that was against concrete
+friction signals, fixes a bug or smooths the surface, and records the outcome in
+git. Built to generalize to other domains (wireframing, design) by swapping a pack
+of docs.
+
+## Shape: a general engine + a domain pack
+
+Two layers. The **engine knows nothing about the CLI**; a **pack of docs aims it.**
+
+```
+harness/                 # general purpose — never mentions the CLI
+  loop.sh                # while-loop; takes a pack dir; one fresh `claude -p` per round
+  fire.md                # generic prompt template (only substitution: the pack path)
+
+packs/cli/               # aims the engine at the CLI
+  charter.md             # what "better" means; mechanical friction signals; workflows
+  guardrails.md          # branch-only, don't game probes, flag deletions, skill sync
+  backlog.md             # the memory: ## Todo / ## Done (git history = the record)
+  probes.md              # how to run the probes + coverage map + gaps
+
+tests/smoke/cli/         # the runnable probes (reuse the existing smoke harness)
+  cli-probe-utils.ts     # runCli(): built CLI → ephemeral smoke app, returns code/stdout/stderr/json
+  *.probe.test.ts        # assert agent-friendliness as fact
+```
+
+Run it: `./harness/loop.sh packs/cli`. A second domain is a second pack
+(`packs/wireframe/…`) + its probe glob — the engine is unchanged.
+
+## The loop (one fire = one unit of work)
+
+Each round is a fresh `claude -p` (no `-c`): no context accumulates, cost per round
+is flat, and the only durable state is git. A fire:
+
+1. Reads the pack (charter → guardrails → backlog → probes) + CLAUDE.md.
+2. **Heal preempts improve.** Runs the probe command + `typecheck`/`test:unit`. If
+   red, the only job is making it green.
+3. Else takes the single top `## Todo` item. Smallest change; prefer deletion.
+4. Verifies (typecheck + unit + probes all green; never weaken a probe to pass).
+5. Records: moves the item to `## Done` (date + sha), appends new friction as
+   `## Todo`, commits code + backlog together.
+
+## The probes: agent-friendliness as assertions
+
+Probes exercise the **real CLI binary** (not the HTTP client) against the
+**ephemeral smoke app** (`tests/smoke/global-setup.ts` already boots an isolated,
+throwaway instance — temp user-data, private discovery file, random port). The real
+app is never touched, so the flaky-reboot problem is sidestepped entirely.
+
+`runCli()` points the CLI at the smoke instance via `SPECULAR_DISCOVERY_FILE` and
+returns `{ code, stdout, stderr, json }`. Assertions encode the charter's
+**mechanical friction signals** — parseable stdout, actionable stderr, non-zero
+exit on misuse, edits observable on read-back, call count per intent. "Looking for
+improvements" is concrete: a friction note becomes a probe asserting the better
+behavior, the probe goes red, the fire fixes the CLI, the probe goes green.
+
+## Guardrails (the dumb safety model)
+
+- **Branch only, never main.** The loop refuses to run on `main`/`master`. Commits
+  land on a review branch; no auto-merge. That review gate *is* the safety rail.
+- **Can't game the metric.** Weakening/deleting a probe or deleting a feature is a
+  `REVIEW:` note for a human, never something a fire does.
+- **Skill stays in sync.** CLI behavior changes update both skill copies (per
+  CLAUDE.md); a skill edit must keep probes green.
+
+## Tokens
+
+Bash loop = 0 tokens. Default fire = Sonnet (most fixes). Run the same script with
+`MODEL=opus` occasionally for a deeper simplification pass. No per-task routing to
+build.
+
+## Scope: v1 vs v2
+
+**v1 (this commit).** Engine + CLI pack + probe harness + two starter probes +
+seeded backlog. History of record = git (backlog.md diffs + commits). Verification
+runs against the throwaway smoke app.
+
+**v2 — artifacts in the real Specular.** Because probes run against the ephemeral
+smoke app, the canvas they build is discarded, so the loop's progress isn't visible
+in the user's live app. v2 adds a read-only projection step that points the CLI at
+the *canonical* discovery file (the running app) and renders `backlog.md` Done/Todo
+entries as canvas notes — dogfooding the CLI to display its own history. Deferred so
+v1 stays simple; it's additive and changes nothing above.
+
+## First real iterations (seeded in packs/cli/backlog.md)
+
+1. Reliable `specular dev restart` (idempotent, cross-platform) — the highest-
+   leverage agent-friendliness fix and the cause of "the agent can't reboot the app."
+2. `create page` should reject bare paths with a full-URL message.
+3. `snapshot` output should be parseable without a flag (or document it).
+
+## How to run
+
+```
+git switch claude/self-healing-cli-loop-FmZXa   # a review branch, not main
+pnpm build:cli && pnpm test:smoke -- cli         # sanity-check the probes
+./harness/loop.sh packs/cli                      # MODEL=opus / MAX_ROUNDS=N / SLEEP=N to tune
+```

--- a/harness/fire.md
+++ b/harness/fire.md
@@ -1,0 +1,44 @@
+You are one fire of a self-improvement loop. You have a fresh context and will do
+exactly one unit of work, then exit. Nothing carries over to the next fire except
+what you write to git — so the durable record is the pack's backlog.md and your
+commit.
+
+The pack that aims this loop is at: __PACK__
+
+Read these first, in order:
+1. __PACK__/charter.md      — what "better" means here, the friction signals, the
+                              prescribed workflows, and the probe command.
+2. __PACK__/guardrails.md   — hard limits. Obey them over anything below.
+3. __PACK__/backlog.md      — the memory: ## Todo (work to do) and ## Done (history).
+4. __PACK__/probes.md       — how to run this pack's probes and what they cover.
+Also read CLAUDE.md for repo conventions.
+
+Then do ONE of the following, in priority order:
+
+A. HEAL (preempts everything). Run the probe command from probes.md, plus
+   `pnpm typecheck && pnpm test:unit`. If anything is RED, your only job this fire
+   is to make it green. Do not start new work while the suite is red.
+
+B. IMPROVE. If the suite is green, take the single top item under ## Todo in
+   backlog.md. Prefer the smallest change that satisfies the charter. Prefer
+   deleting code over adding it.
+
+   If the item is "write a probe for <friction>": add a probe under tests/smoke/cli/
+   that asserts the *desired* behavior, watch it fail, then make the CLI satisfy it.
+   A friction you can't yet encode as an assertion stays a ## Todo note — do not
+   silently drop it.
+
+Verify before you commit: `pnpm typecheck && pnpm test:unit` and the pack's probe
+command must all pass. Never weaken or delete a probe or test to go green — if a
+probe is wrong, leave a "REVIEW:" note in ## Todo instead.
+
+Record the outcome in the same fire:
+- Move the finished item to ## Done with today's date and the commit short-sha.
+- Append any new friction you hit (while using the CLI for real) as ## Todo items.
+  These become future probes.
+- Commit everything (code + backlog.md) together with a clear message.
+
+If there is genuinely nothing to do (suite green, ## Todo empty), make no commit
+and exit. Obey guardrails.md at all times — especially: branch only, never main;
+no auto-merge; flag feature deletions and probe changes for human REVIEW rather
+than doing them.

--- a/harness/loop.sh
+++ b/harness/loop.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Self-improvement engine — general purpose.
+#
+# Knows nothing about the CLI (or any domain). It points a fresh-context agent at
+# a "pack" of docs and loops. The pack decides what "better" means, what to probe,
+# and what the guardrails are. To self-heal the CLI:   ./harness/loop.sh packs/cli
+#
+# Each iteration is a fresh `claude -p` (no -c): no context accumulates in the
+# loop, so cost per round is flat. Durable state lives in git — the pack's
+# backlog.md (the memory) and the commits the fire makes.
+#
+# Env overrides:
+#   MODEL=sonnet|opus|haiku   model for the fire (default: sonnet)
+#   MAX_ROUNDS=N              stop after N rounds (default: unbounded)
+#   SLEEP=N                   seconds between rounds (default: 5)
+#
+set -euo pipefail
+
+PACK="${1:-packs/cli}"
+MODEL="${MODEL:-sonnet}"
+MAX_ROUNDS="${MAX_ROUNDS:-0}"
+SLEEP="${SLEEP:-5}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if [[ ! -d "$PACK" ]]; then
+  echo "pack not found: $PACK" >&2
+  exit 1
+fi
+for doc in charter.md guardrails.md backlog.md probes.md; do
+  if [[ ! -f "$PACK/$doc" ]]; then
+    echo "pack is missing $PACK/$doc" >&2
+    exit 1
+  fi
+done
+
+# Safety rail (the dumb version of CI gating): never run the loop on a primary
+# branch. The fire commits straight to whatever branch is checked out; that
+# branch is meant to be reviewed before it reaches main.
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+case "$BRANCH" in
+  main|master)
+    echo "refuse to run the self-heal loop on '$BRANCH'. Check out a self-heal branch first." >&2
+    exit 1
+    ;;
+esac
+
+render_prompt() {
+  # The prompt template is domain-agnostic; the only substitution is the pack path.
+  sed "s|__PACK__|$PACK|g" "$REPO_ROOT/harness/fire.md"
+}
+
+echo "self-heal: pack=$PACK model=$MODEL branch=$BRANCH"
+
+round=0
+while true; do
+  round=$((round + 1))
+  if [[ "$MAX_ROUNDS" -gt 0 && "$round" -gt "$MAX_ROUNDS" ]]; then
+    echo "self-heal: reached MAX_ROUNDS=$MAX_ROUNDS, stopping."
+    break
+  fi
+
+  echo "── round $round ($(date '+%H:%M:%S')) ────────────────────────────────"
+
+  # Refresh truth from the branch (picks up anything merged out of band).
+  git pull --rebase --autostash origin "$BRANCH" 2>/dev/null || true
+
+  # One fresh-context fire. It reads the pack, does one unit of work, runs the
+  # probes, and commits + records the outcome in the pack's backlog.md itself.
+  claude -p "$(render_prompt)" \
+    --model "$MODEL" \
+    --allowedTools "Bash,Read,Write,Edit,Glob,Grep" \
+    --dangerously-skip-permissions || echo "self-heal: fire exited non-zero (round $round)"
+
+  # Push whatever the fire committed (no-op if it committed nothing).
+  git push -u origin "$BRANCH" 2>/dev/null || echo "self-heal: nothing to push (round $round)"
+
+  sleep "$SLEEP"
+done

--- a/packs/cli/backlog.md
+++ b/packs/cli/backlog.md
@@ -22,7 +22,27 @@ Top of `## Todo` = next up. Keep items small and concrete.
       always pass full URLs (a bare `/garden` is ambiguous across origins), but
       `src/main/cli-commands.ts` passes the value straight through. Write a probe
       asserting `specular create page /garden` exits non-zero with a message
-      pointing at full-URL usage, then make it pass.
+      pointing at full-URL usage, then make it pass. The same applies to
+      `specular breakpoints <url>` (also takes a URL).
+
+- [ ] **Skill drift: `breakpoints` argument.** `.claude/skills/specular/SKILL.md`
+      documents `specular breakpoints <id>` / "cycle through device breakpoints,"
+      but the CLI takes a URL and applies a breakpoint *map*
+      (`cli-commands.ts` `breakpoints` handler: `usage: specular breakpoints <url>`).
+      Fix the skill (both copies) to match; verify against the actual handler.
+
+- [ ] **Audit the CLI docs against the command surface.** Diff CLAUDE.md
+      `## Specular CLI` + `## Agent integration` and both `SKILL.md` copies against
+      the `VERBS` map and per-verb usage strings in `cli-commands.ts`. File each
+      drift (missing/renamed command, wrong flag or argument, stale guidance) as its
+      own Todo here. Recurring: re-run after CLI changes land.
+
+- [ ] **Write a doc-truth probe.** Add a probe under `tests/smoke/cli/` that asserts
+      the documented command list and the CLI's real verbs agree — e.g. parse the
+      command table in `.claude/skills/specular/SKILL.md`, run `specular --help`
+      (and/or read the `VERBS` map), and fail if a documented verb doesn't exist or
+      a real verb is undocumented. This is the mechanical net for *removed/renamed*
+      commands; argument-level drift (like `breakpoints`) still needs the audit above.
 
 - [ ] **`snapshot` output ergonomics.** Confirm whether `snapshot` needs a
       `--format` flag to produce parseable output; if so, make agent-friendly JSON

--- a/packs/cli/backlog.md
+++ b/packs/cli/backlog.md
@@ -1,0 +1,37 @@
+# CLI self-heal backlog
+
+The loop's memory. A fresh fire reads this, does the top `## Todo` item (unless a
+probe is red — then it heals that first), then moves it to `## Done` with a date +
+commit sha and appends any new friction it found. Git history of this file is the
+self-heal record.
+
+Top of `## Todo` = next up. Keep items small and concrete.
+
+## Todo
+
+- [ ] **`specular dev restart` is unreliable.** A clean restart is hard: sticky
+      single-instance lock, stale `~/.specular/specular-mcp.json` after SIGKILL,
+      orphaned Vite children, port contention; `scripts/dev-restart.sh` is
+      macOS-only. Add an idempotent, cross-platform restart path (kill process
+      tree → wait for port free → remove stale discovery file → relaunch → poll
+      `/health`). This is the highest-leverage agent-friendliness fix. Write a
+      probe where feasible (may need to assert on the restart script's behavior
+      rather than via the smoke app).
+
+- [ ] **`create page` accepts bare paths silently.** CLAUDE.md and the skill say
+      always pass full URLs (a bare `/garden` is ambiguous across origins), but
+      `src/main/cli-commands.ts` passes the value straight through. Write a probe
+      asserting `specular create page /garden` exits non-zero with a message
+      pointing at full-URL usage, then make it pass.
+
+- [ ] **`snapshot` output ergonomics.** Confirm whether `snapshot` needs a
+      `--format` flag to produce parseable output; if so, make agent-friendly JSON
+      the default (or document the flag in the skill). Write a probe.
+
+- [ ] **Audit call counts for the prescribed workflows** in charter.md (annotate→
+      resolve, group→auto-layout→focus). Where one intent takes 3+ calls, file a
+      simplification item.
+
+## Done
+
+<!-- entries land here as: - [x] YYYY-MM-DD <what> (<short-sha>) -->

--- a/packs/cli/charter.md
+++ b/packs/cli/charter.md
@@ -53,6 +53,20 @@ pnpm build:cli && pnpm test:smoke -- cli
 `pnpm build:cli` rebuilds `out/main/cli.js` so probes exercise your latest change.
 `-- cli` filters vitest to `tests/smoke/cli/`.
 
+## Docs are a maintained surface
+
+The CLI's agent-friendliness includes the docs that describe it. They must match
+observed behavior — treat them as part of "done" for any CLI change:
+
+- `CLAUDE.md` → the `## Specular CLI` and `## Agent integration` sections.
+- `.claude/skills/specular/SKILL.md` and `resources/skills/specular/SKILL.md`
+  (update both in the same commit — see guardrails.md).
+
+When a command's behavior, flags, or arguments change, update these in the same
+commit. When you notice a doc claims something the CLI doesn't do (a missing/renamed
+command, a wrong flag or argument), that is a heal item: fix it if small, else file
+it in backlog.md.
+
 ## Non-goals (do not drift here)
 
 - Renaming variables or reflowing code with no behavior or ergonomics change.

--- a/packs/cli/charter.md
+++ b/packs/cli/charter.md
@@ -1,0 +1,61 @@
+# CLI self-heal charter
+
+This pack aims the self-improvement engine (`harness/loop.sh`) at the Specular
+CLI. The engine is general purpose; everything CLI-specific lives in this folder.
+
+## Goal
+
+Make the `specular` CLI **more agent-friendly** by fixing bugs, simplifying the
+architecture behind it, and smoothing the surface an agent actually touches. The
+CLI is how agents edit the canvas (`src/main/cli.ts`, `src/main/cli-commands.ts`,
+HTTP routes in `src/main/routes/`).
+
+## What "better" means — mechanical friction signals
+
+"Easy to use" is not a feeling; it is measurable. When you run a prescribed
+workflow (below), treat any of these as friction worth a backlog item or a probe:
+
+- **Call count** — one logical intent should take ~one command. Needing 3 calls to
+  do one thing is friction.
+- **Parseable output** — a command's result should be valid JSON on stdout with no
+  extra flag required. If you had to pass `--format` or post-process to parse it,
+  that's friction.
+- **Actionable errors** — a failure must exit non-zero and say *what to do* on
+  stderr, not just what broke. Errors must never land on stdout.
+- **No source-diving** — if you had to read `src/main/` to discover an argument or
+  flag, the help/skill is inadequate.
+- **No guessed flags** — if the flag you needed isn't in the skill
+  (`.claude/skills/specular/SKILL.md`), that's a documentation bug, not your fault.
+
+The durable form of any of these is a probe under `tests/smoke/cli/` that asserts
+the fixed behavior. Freeform notes are only candidates; convert the good ones.
+
+## Prescribed canvas workflows
+
+Run these against the ephemeral smoke app (the probes already do — see probes.md).
+Do not invent your own task to grade; run these, so the assessment measures a
+fixed thing instead of a flattering one.
+
+1. Build a small canvas: create two pages at breakpoints + a note, then read the
+   workspace back and confirm the edits are observable.
+2. Annotate a page, then resolve the annotation.
+3. Group several pages, auto-layout them, then focus the group.
+
+For each: count the calls, check every output parses, check every error is
+actionable. File friction as Todo items in backlog.md.
+
+## Probe command
+
+```
+pnpm build:cli && pnpm test:smoke -- cli
+```
+
+`pnpm build:cli` rebuilds `out/main/cli.js` so probes exercise your latest change.
+`-- cli` filters vitest to `tests/smoke/cli/`.
+
+## Non-goals (do not drift here)
+
+- Renaming variables or reflowing code with no behavior or ergonomics change.
+- New CLI features that aren't on the backlog — file them, don't build them.
+- Touching the renderer or canvas UI. This pack is the CLI surface only.
+- Making a probe pass by weakening it. See guardrails.md.

--- a/packs/cli/charter.md
+++ b/packs/cli/charter.md
@@ -40,6 +40,10 @@ fixed thing instead of a flattering one.
    workspace back and confirm the edits are observable.
 2. Annotate a page, then resolve the annotation.
 3. Group several pages, auto-layout them, then focus the group.
+4. Lay out many items (a dozen+) as a grid via `upsert --json` with a grid
+   directive; read the workspace back and confirm none of them overlap and the
+   result is an even grid. Overlap is the failure mode that only appears at
+   scale — exercise it with enough items to catch it.
 
 For each: count the calls, check every output parses, check every error is
 actionable. File friction as Todo items in backlog.md.

--- a/packs/cli/guardrails.md
+++ b/packs/cli/guardrails.md
@@ -1,0 +1,36 @@
+# CLI self-heal guardrails
+
+Hard limits. These win over the charter and the backlog. A fire that cannot
+proceed without breaking one of these should stop and leave a `REVIEW:` note.
+
+## Branch & landing
+
+- **Branch only, never main.** Commit to the checked-out self-heal branch. Never
+  push to `main`/`master`. The loop refuses to run on those branches.
+- **No auto-merge.** This branch is reviewed by a human before it reaches main.
+  Your job ends at a green commit on the branch.
+- **One unit of work per fire**, one commit (code + backlog.md together).
+
+## Don't game the metric
+
+- **Never weaken, skip, or delete a probe or test to go green.** If a probe is
+  genuinely wrong, leave a `REVIEW: probe X looks wrong because …` note in
+  backlog.md ## Todo and move on. Changing the bar is a human decision.
+- **Never delete a feature** to "simplify." If removal looks right, write a
+  `REVIEW: consider removing X because …` note instead of doing it.
+
+## Verify, always
+
+- `pnpm typecheck && pnpm test:unit` must pass before you commit.
+- The probe command in charter.md must pass before you commit.
+- Heal (red suite) preempts improve (new work). Never start a Todo while red.
+
+## Skill edits
+
+The CLI's agent-friendliness includes its skill docs. If you change CLI behavior
+that the skill describes, update the skill — and per CLAUDE.md, update **both**
+`resources/skills/specular/SKILL.md` and `.claude/skills/specular/SKILL.md` in the
+same commit (the installed `~/.claude` copy is auto-overwritten on app launch).
+
+A skill edit is only safe if the probes still pass using it — a degraded skill
+poisons every future fire. If you can't verify that, leave it as a Todo.

--- a/packs/cli/probes.md
+++ b/packs/cli/probes.md
@@ -1,0 +1,39 @@
+# CLI probes
+
+Smoke-test-like tests that exercise the **real CLI binary** (not the HTTP client)
+the way an agent would, then assert the charter's friction signals. A red probe is
+a self-heal task (top priority). Writing a new probe that asserts a better
+experience — and fixing the CLI until it's green — is how "looking for
+improvements" happens concretely.
+
+## Run
+
+```
+pnpm build:cli && pnpm test:smoke -- cli
+```
+
+## How they work
+
+- They live in `tests/smoke/cli/*.probe.test.ts` and reuse the existing smoke
+  harness: `tests/smoke/global-setup.ts` boots an isolated, throwaway Specular
+  (temp user-data, private discovery file, random port) — never your real app.
+- `cli-probe-utils.ts`'s `runCli()` points the built CLI at that instance via
+  `SPECULAR_DISCOVERY_FILE` and returns `{ code, stdout, stderr, json }`.
+- Assertions encode *agent-friendliness as fact*: parseable stdout, actionable
+  stderr, non-zero exit on misuse, edits observable on read-back.
+
+## Coverage today
+
+- `canvas-workflow.probe.test.ts` — create page/note, read workspace back, a
+  two-page + note workflow. Guards: parseable output, observable edits, clean exits.
+- `error-ergonomics.probe.test.ts` — missing-arg usage messages, stderr/stdout
+  separation. Guards: actionable, machine-legible failures.
+
+## Gaps (candidate probes — convert friction here)
+
+- `snapshot` / `screenshot` output shape and flags.
+- `annotate` → `resolve` round-trip ergonomics.
+- `group` → `auto-layout` → `focus` call count.
+- `update` / `delete` with an unknown id: is the error actionable?
+- `create page` with a bare path (`/garden`): should it be rejected with a message
+  pointing at full-URL usage? (See backlog.md.)

--- a/packs/cli/probes.md
+++ b/packs/cli/probes.md
@@ -28,12 +28,16 @@ pnpm build:cli && pnpm test:smoke -- cli
   two-page + note workflow. Guards: parseable output, observable edits, clean exits.
 - `error-ergonomics.probe.test.ts` — missing-arg usage messages, stderr/stdout
   separation. Guards: actionable, machine-legible failures.
+- `grid-layout.probe.test.ts` — `upsert --json` with a grid directive, geometry
+  read back from `workspace`. Guards: no overlapping entities at scale (12+
+  items, uniform and mixed-size) and a real grid structure, not a collapsed pile.
 
 ## Gaps (candidate probes — convert friction here)
 
 - `snapshot` / `screenshot` output shape and flags.
 - `annotate` → `resolve` round-trip ergonomics.
 - `group` → `auto-layout` → `focus` call count.
+- `distribute` even-gap correctness for a loose multi-selection (ADR 0015).
 - `update` / `delete` with an unknown id: is the error actionable?
 - `create page` with a bare path (`/garden`): should it be rejected with a message
   pointing at full-URL usage? (See backlog.md.)

--- a/tests/smoke/cli/canvas-workflow.probe.test.ts
+++ b/tests/smoke/cli/canvas-workflow.probe.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { runCli } from './cli-probe-utils'
+
+// Prescribed canvas workflow (see packs/cli/charter.md): an agent builds a small
+// canvas with the CLI, then reads it back. The probe asserts the *mechanical
+// friction signals* the charter defines — parseable output, zero exit, the edit
+// is observable — so a CLI that technically works but is awkward fails here.
+//
+// Friction these guard against:
+//   - output that isn't valid JSON (agent can't parse the result of its own edit)
+//   - a successful edit that doesn't show up when reading the workspace back
+
+describe('cli probe: canvas editing workflow', () => {
+  it('create page returns parseable JSON and exits zero', () => {
+    const r = runCli(['create', 'page', 'https://example.com'])
+    expect(r.code, r.stderr).toBe(0)
+    // The agent must be able to parse the result of its own edit without a flag.
+    expect(r.json, `stdout was not JSON:\n${r.stdout}`).toBeDefined()
+  })
+
+  it('the edit is observable when reading the workspace back', () => {
+    runCli(['create', 'note', 'probe canvas note'])
+    const ws = runCli(['workspace'])
+    expect(ws.code, ws.stderr).toBe(0)
+    expect(ws.json, `workspace stdout was not JSON:\n${ws.stdout}`).toBeDefined()
+    // The note we just created is reachable by reading the canvas — one intent,
+    // verifiable in one read.
+    expect(ws.stdout).toContain('probe canvas note')
+  })
+
+  it('a full breakpoint-style workflow completes without an error exit', () => {
+    // Prescribed multi-step task: two pages + a note. Every step must succeed;
+    // a non-zero exit anywhere is friction an agent would have to recover from.
+    const steps = [
+      ['create', 'page', 'https://example.com'],
+      ['create', 'page', 'https://example.org'],
+      ['create', 'note', 'breakpoint workflow probe'],
+    ]
+    for (const args of steps) {
+      const r = runCli(args)
+      expect(r.code, `\`specular ${args.join(' ')}\` → ${r.stderr}`).toBe(0)
+    }
+  })
+})

--- a/tests/smoke/cli/cli-probe-utils.ts
+++ b/tests/smoke/cli/cli-probe-utils.ts
@@ -1,0 +1,74 @@
+import { spawnSync } from 'child_process'
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+
+// ---------------------------------------------------------------------------
+// CLI probe harness
+//
+// These probes exercise the real `specular` CLI binary the way an agent would,
+// pointed at the ephemeral smoke app (see tests/smoke/global-setup.ts). Unlike
+// the HTTP AppClient, they go through the actual agent-facing surface — flags,
+// stdout shape, stderr messages, exit codes — so friction in CLI *ergonomics*
+// shows up as a failing assertion, not just a broken feature.
+//
+// Transport: the smoke app writes a private discovery file at
+// `${tmpdir}/specular-mcp-smoke-${port}.json`. We point the CLI at it via
+// SPECULAR_DISCOVERY_FILE so probes never touch the canonical specular-mcp.json
+// a developer's real app and CLI share.
+// ---------------------------------------------------------------------------
+
+const CLI_BUNDLE = join(process.cwd(), 'out', 'main', 'cli.js')
+const SMOKE_ENV_FILE = join(tmpdir(), 'specular-smoke-env.json')
+
+function smokePort(): number {
+  const raw = readFileSync(SMOKE_ENV_FILE, 'utf8')
+  return (JSON.parse(raw) as { port: number }).port
+}
+
+function discoveryFile(): string {
+  return join(tmpdir(), `specular-mcp-smoke-${smokePort()}.json`)
+}
+
+export interface CliResult {
+  code: number
+  stdout: string
+  stderr: string
+  /** stdout parsed as JSON, or undefined if it was not valid JSON. */
+  json: unknown
+}
+
+/**
+ * Run the built CLI against the smoke app. Mirrors how an agent invokes it:
+ * `specular <args...>`, optional stdin, JSON or text on stdout, errors on stderr.
+ */
+export function runCli(args: string[], opts: { input?: string } = {}): CliResult {
+  if (!existsSync(CLI_BUNDLE)) {
+    throw new Error(
+      `CLI bundle missing at ${CLI_BUNDLE}. Run \`pnpm build:cli\` before the CLI probes ` +
+        `(the canonical command is \`pnpm build:cli && pnpm test:smoke -- cli\`).`,
+    )
+  }
+  const res = spawnSync('node', [CLI_BUNDLE, ...args], {
+    encoding: 'utf8',
+    input: opts.input,
+    timeout: 20_000,
+    env: {
+      ...process.env,
+      SPECULAR_DISCOVERY_FILE: discoveryFile(),
+      // Unique identity per call so the app's presence layer never evicts one
+      // probe's cursor for another's.
+      SPECULAR_SESSION_ID: `probe-${randomUUID()}`,
+      SPECULAR_CLIENT_NAME: `probe-${randomUUID().slice(0, 8)}`,
+    },
+  })
+  const stdout = res.stdout ?? ''
+  let json: unknown
+  try {
+    json = JSON.parse(stdout)
+  } catch {
+    json = undefined
+  }
+  return { code: res.status ?? -1, stdout, stderr: res.stderr ?? '', json }
+}

--- a/tests/smoke/cli/error-ergonomics.probe.test.ts
+++ b/tests/smoke/cli/error-ergonomics.probe.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { runCli } from './cli-probe-utils'
+
+// Error-path ergonomics (see packs/cli/charter.md friction signals). When an
+// agent misuses the CLI, the failure must be machine-legible: a non-zero exit
+// and an actionable message on stderr that says what to do, not just what broke.
+// These currently pass — they are regression guards that keep the error surface
+// agent-friendly as the CLI evolves.
+
+describe('cli probe: error ergonomics', () => {
+  it('create page with no url fails non-zero with an actionable usage message', () => {
+    const r = runCli(['create', 'page'])
+    expect(r.code).not.toBe(0)
+    // Actionable: the message names the command and the missing argument.
+    expect(r.stderr).toMatch(/usage: specular create page <url>/)
+  })
+
+  it('create note with no text fails non-zero with an actionable usage message', () => {
+    const r = runCli(['create', 'note'])
+    expect(r.code).not.toBe(0)
+    expect(r.stderr).toMatch(/usage: specular create note/)
+  })
+
+  it('errors go to stderr, never polluting stdout an agent is parsing', () => {
+    const r = runCli(['create', 'page'])
+    // An agent piping stdout into JSON.parse must not receive the error text.
+    expect(r.stdout).toBe('')
+    expect(r.stderr.length).toBeGreaterThan(0)
+  })
+})

--- a/tests/smoke/cli/grid-layout.probe.test.ts
+++ b/tests/smoke/cli/grid-layout.probe.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { runCli } from './cli-probe-utils'
+
+// Grid layout correctness (charter "Prescribed canvas workflows"): an agent lays
+// out many items as a grid via the CLI and expects them not to overlap. This is
+// the failure mode that only shows up at scale — a handful of items rarely
+// collide, a dozen do. The probe drives the real layout engine through
+// `specular upsert --json` (grid directive), reads geometry back from
+// `specular workspace`, and asserts the geometric property directly.
+//
+// Entities are short-text notes with explicit width/height: deterministic
+// footprints, no webview or renderer measurement needed, and the workspace graph
+// reports canvasX/canvasY/width/height for them.
+
+interface Rect {
+  id: string
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+interface WsEntity {
+  id: string
+  kind: string
+  canvasX?: number
+  canvasY?: number
+  width?: number
+  height?: number
+}
+
+/** Strict AABB overlap with a small epsilon so edge-to-edge touching (gap 0) is allowed. */
+function rectsOverlap(a: Rect, b: Rect, eps = 0.5): boolean {
+  return a.x + a.w - eps > b.x && b.x + b.w - eps > a.x && a.y + a.h - eps > b.y && b.y + b.h - eps > a.y
+}
+
+function firstOverlap(rects: Rect[]): [Rect, Rect] | null {
+  for (let i = 0; i < rects.length; i++) {
+    for (let j = i + 1; j < rects.length; j++) {
+      if (rectsOverlap(rects[i], rects[j])) return [rects[i], rects[j]]
+    }
+  }
+  return null
+}
+
+/** Lay items out with a grid directive in one call; return the created ids. */
+function gridUpsert(items: Array<Record<string, unknown>>, layout: Record<string, unknown>): Set<string> {
+  const r = runCli(['upsert', '--json'], { input: JSON.stringify({ layout, items }) })
+  expect(r.code, `upsert failed: ${r.stderr}`).toBe(0)
+  const created = (r.json as { created?: string[] } | undefined)?.created ?? []
+  expect(created.length, `expected ${items.length} created, got ${JSON.stringify(r.json)}`).toBe(items.length)
+  return new Set(created)
+}
+
+/** Read geometry back for exactly the entities we created (scoped by id). */
+function rectsForIds(ids: Set<string>): Rect[] {
+  const ws = runCli(['workspace'])
+  expect(ws.code, ws.stderr).toBe(0)
+  const entities = (ws.json as { entities?: WsEntity[] } | undefined)?.entities ?? []
+  return entities
+    .filter((e) => ids.has(e.id))
+    .map((e) => ({ id: e.id, x: e.canvasX ?? NaN, y: e.canvasY ?? NaN, w: e.width ?? NaN, h: e.height ?? NaN }))
+}
+
+function distinct(values: number[]): number[] {
+  return [...new Set(values.map((v) => Math.round(v)))]
+}
+
+describe('cli probe: grid layout does not overlap at scale', () => {
+  it('a 12-item uniform grid has no overlaps and a real grid structure', () => {
+    const run = `grid-a-${Date.now()}`
+    const items = Array.from({ length: 12 }, (_, i) => ({
+      kind: 'text',
+      text: `${run}-${i}`,
+      width: 200,
+      height: 150,
+    }))
+    const ids = gridUpsert(items, { kind: 'grid', cols: 4, gap: 24, originX: 0, originY: 0 })
+    const rects = rectsForIds(ids)
+
+    // Every created item is present with real geometry.
+    expect(rects.length).toBe(12)
+    for (const r of rects) {
+      expect(Number.isFinite(r.x) && Number.isFinite(r.y), `entity ${r.id} missing position`).toBe(true)
+      expect(r.w, `entity ${r.id} has no width`).toBeGreaterThan(0)
+      expect(r.h, `entity ${r.id} has no height`).toBeGreaterThan(0)
+    }
+
+    // The core property: no two items overlap.
+    const clash = firstOverlap(rects)
+    expect(clash, clash ? `overlap between ${clash[0].id} and ${clash[1].id}` : '').toBeNull()
+
+    // It is actually a grid, not a collapsed pile or a single column:
+    // 12 items in 4 columns → 4 distinct x tracks and 3 distinct y rows.
+    expect(distinct(rects.map((r) => r.x)).length).toBe(4)
+    expect(distinct(rects.map((r) => r.y)).length).toBe(3)
+  })
+
+  it('a grid of many mixed-size items still leaves no overlaps', () => {
+    const run = `grid-b-${Date.now()}`
+    // Alternating footprints — the case where naive packing collides.
+    const items = Array.from({ length: 9 }, (_, i) => ({
+      kind: 'text',
+      text: `${run}-${i}`,
+      width: i % 2 === 0 ? 200 : 320,
+      height: i % 3 === 0 ? 150 : 240,
+    }))
+    const ids = gridUpsert(items, { kind: 'grid', cols: 3, gap: 24, originX: 0, originY: 0 })
+    const rects = rectsForIds(ids)
+
+    expect(rects.length).toBe(9)
+    const clash = firstOverlap(rects)
+    expect(clash, clash ? `overlap between ${clash[0].id} and ${clash[1].id}` : '').toBeNull()
+  })
+})


### PR DESCRIPTION
A local, fresh-context loop that continuously improves the specular CLI by
dogfooding it against the ephemeral smoke app, measuring concrete friction
signals, fixing one thing, and recording the outcome in git.

- harness/ — domain-agnostic engine (loop.sh + fire.md). Knows nothing about
  the CLI; takes a pack dir. One fresh `claude -p` per round, git as truth.
- packs/cli/ — the docs that aim the engine at the CLI: charter (mechanical
  friction signals + prescribed canvas workflows), guardrails (branch-only,
  don't game probes, flag deletions), backlog (the memory), probes (run + map).
- tests/smoke/cli/ — probes that exercise the real CLI binary against the
  throwaway smoke app and assert agent-friendliness as fact (parseable stdout,
  actionable stderr, observable edits). Reuses the existing smoke harness.
- docs/plans/self-heal-cli-loop.md — the engine/pack split, scope, and the
  v2 deferral (rendering loop history into the live app's canvas).

Verified: typecheck, build:cli, and test:unit (686) green. The CLI probes run
locally via `pnpm build:cli && pnpm test:smoke -- cli` (smoke is local-only;
a headless container can't drive electron-forge's app build).