### PR TITLE
Add 'Copy as PNG' to image entity context menu

### DIFF
--- a/src/main/ipc/register-canvas-entity-ipc.ts
+++ b/src/main/ipc/register-canvas-entity-ipc.ts
@@ -1,4 +1,4 @@
-import { clipboard, ipcMain, Menu, shell, type MenuItemConstructorOptions } from 'electron'
+import { clipboard, ipcMain, Menu, nativeImage, shell, type MenuItemConstructorOptions } from 'electron'
 import { VIEWPORT_PRESETS } from '../../shared/constants'
 import { DRAWING_FEATURE_ENABLED } from '../../shared/featureFlags'
 import type { AnnotationCreateRequest } from '../../shared/types'
@@ -749,6 +749,10 @@ export function registerCanvasEntityIpc(): void {
 
   ipcMain.on('canvas-show-file-in-finder', (_event, { filePath }: { filePath: string }) => {
     shell.showItemInFolder(filePath)
+  })
+
+  ipcMain.on('canvas-copy-file-as-png', (_event, { filePath }: { filePath: string }) => {
+    clipboard.writeImage(nativeImage.createFromPath(filePath))
   })
 
   ipcMain.handle('read-note-file', (_event, { filePath }: { filePath: string }) => {

--- a/src/preload/canvas-bg.ts
+++ b/src/preload/canvas-bg.ts
@@ -171,6 +171,8 @@ const api: CanvasBgElectronAPI = {
   cancelEntityEdit: () => ipcRenderer.send('canvas-cancel-entity-edit'),
   showFileInFinder: (filePath: string) =>
     ipcRenderer.send('canvas-show-file-in-finder', { filePath }),
+  copyFileAsPng: (filePath: string) =>
+    ipcRenderer.send('canvas-copy-file-as-png', { filePath }),
   updateGroupEntity: (id: string, patch: { width?: number; height?: number; canvasX?: number; canvasY?: number; label?: string; color?: string }) =>
     ipcRenderer.send('canvas-update-group-entity', { id, patch }),
   duplicateGroup: (id: string) =>

--- a/src/renderer/above-view/FileBodyLayer.tsx
+++ b/src/renderer/above-view/FileBodyLayer.tsx
@@ -166,6 +166,14 @@ function FileBodyCard({
               >
                 Show in Finder
               </Menu.Item>
+              {entity.rendererTag === 'image' && (
+                <Menu.Item
+                  className={menuItemClass}
+                  onClick={() => fileApi.copyFileAsPng(entity.file)}
+                >
+                  Copy as PNG
+                </Menu.Item>
+              )}
               <div
                 role="separator"
                 className={isDark ? 'my-1 h-px bg-zinc-700' : 'my-1 h-px bg-zinc-200'}

--- a/src/renderer/canvas-bg/entity-renderers/filePathToSrc.ts
+++ b/src/renderer/canvas-bg/entity-renderers/filePathToSrc.ts
@@ -11,6 +11,7 @@ export function filePathToSrc(filePath: string): string {
 
 export interface RendererFileApi {
   showFileInFinder: (path: string) => void
+  copyFileAsPng: (path: string) => void
   reorderStack: (
     action: 'bring-forward' | 'send-backward' | 'bring-to-front' | 'send-to-back',
     targetId?: string,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1765,6 +1765,7 @@ export interface CanvasBgElectronAPI {
   /** Cancel the active inline edit (renderers fire on Escape). */
   cancelEntityEdit: () => void
   showFileInFinder: (filePath: string) => void
+  copyFileAsPng: (filePath: string) => void
   updateGroupEntity: (id: string, patch: { width?: number; height?: number; canvasX?: number; canvasY?: number; label?: string; color?: string }) => void
   duplicateGroup: (id: string) => void
   deleteGroup: (id: string) => void


### PR DESCRIPTION
Closes #210

## Summary

- Adds a `canvas-copy-file-as-png` IPC channel wired through all layers
- Conditionally renders a **Copy as PNG** menu item (below Show in Finder) only when `entity.rendererTag === 'image'`
- Main handler uses `nativeImage.createFromPath` + `clipboard.writeImage` — both already available in electron's main process

## Changes

- `src/main/ipc/register-canvas-entity-ipc.ts` — add `nativeImage` import and IPC handler
- `src/preload/canvas-bg.ts` — add `copyFileAsPng` bridge
- `src/shared/types.ts` — add `copyFileAsPng` to `CanvasBgElectronAPI`
- `src/renderer/canvas-bg/entity-renderers/filePathToSrc.ts` — add `copyFileAsPng` to `RendererFileApi`
- `src/renderer/above-view/FileBodyLayer.tsx` — add conditional menu item

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGkAxvJdZ6yUXd7aNQ6b7d)_