### PR TITLE
Add ponytail plugin + deep-audit skill; file architecture-cleanup issues (#212–#228)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "ponytail": {
+      "source": {
+        "source": "github",
+        "repo": "DietrichGebert/ponytail"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "ponytail@ponytail": true
+  }
+}

--- a/.claude/skills/deep-audit/SKILL.md
+++ b/.claude/skills/deep-audit/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: deep-audit
+description: Repeatable architectural audit of one codebase area — fan out gather-agents over a static-analysis ground truth, synthesize the one missing-abstraction diagnosis, and emit tracer-bullet cleanup issues. Use when the user wants to audit/improve an area for bloat, code reduction, deepening, or continued architectural improvement, or says "deep audit", "audit <area>", "find what to cut".
+---
+
+# Deep Audit
+
+Turn one area of the codebase into a ranked, no-regression cleanup plan. Conduct, don't do-it-all: agents gather, you synthesize. Reductions only — every proposal deletes, reuses, or collapses.
+
+Default scope is `$ARGUMENTS` (a directory or domain). If none given, ask which area; never audit "the whole app" — smaller scope, deeper insight.
+
+## Loop
+
+### 1. Ground truth first
+Run the `fallow` skill over the area. Its dead-code / duplicate-clone / cycle / complexity output is the agents' **evidence base** — they interpret it, they don't guess. Note which "dead" symbols are exported (may be test-only — verify before anyone deletes).
+
+### 2. Read the domain
+Read `CONTEXT.md`, the relevant `docs/adr/*`, and the nearest `CLAUDE.md`. Agents must use real glossary terms and must know which invariants are load-bearing.
+
+### 3. Fan out a FIXED set of gather-agents
+One per sub-domain (aim 4–6, not "the app"). Two passes on the highest-value sub-domain, one elsewhere. Hard-cap it.
+
+Each agent: **foreground** (not background), model **sonnet**, given the Fallow output + the domain docs + this contract:
+
+> One turn. Do the full analysis with Grep/Read now; your FINAL message MUST be the report — no status updates, no "I'll continue". Grep to verify before asserting unused. Apply the ponytail lens (delete/reuse/collapse over add). Return EXACTLY:
+> 1. MAP — key files, LOC, responsibilities (one paragraph)
+> 2. BLOAT & DEAD CODE — items with file:line + confidence
+> 3. CONSOLIDATE — patterns to combine + rough LOC saved
+> 4. DEEPEN — where one stronger primitive replaces several shallow ones
+> 5. CUT CANDIDATES — what a minimal version drops + what's lost
+> 6. GREENFIELD NOTE — what a lean rebuild MUST keep
+> Each item: effort (S/M/L) + risk (low/med/high).
+
+If an agent returns a placeholder instead of a report, re-dispatch it once. Don't let the set re-spawn beyond the fixed plan.
+
+### 4. Synthesize (you, the lead — the valuable part)
+Dedupe across agents, rank by leverage, and force the two questions that produce real insight:
+- **"What single primitive, if it existed, would dissolve the most duplication?"** — the one diagnosis the lists are symptoms of.
+- **"What here is load-bearing and must NOT be touched?"** — from the GREENFIELD notes + ADRs.
+
+Separate **Tier-0 cleanup** (dead code, safe dedup, any correctness bugs the audit surfaced) from **macro proposals** (the missing abstractions). Flag decision-forks as HITL.
+
+### 5. Emit issues
+Run the `to-issues` skill on the synthesis: tracer-bullet slices, cold-agent context, and a "tests green, no functionality loss" gate on every refactor slice. ADRs/decisions become HITL issues; cleanups are AFK.
+
+## Guardrails
+- Reductions only. If a proposal adds code, it must delete more than it adds.
+- Never propose refactoring away something a GREENFIELD note or ADR flags as load-bearing.
+- Cap coverage at ~2 passes/sub-domain — re-treads add nothing.
+- Sonnet to gather, lead model to synthesize.

--- a/.claude/skills/deep-audit/SKILL.md
+++ b/.claude/skills/deep-audit/SKILL.md
@@ -11,8 +11,8 @@ Default scope is `$ARGUMENTS` (a directory or domain). If none given, ask which 
 
 ## Loop
 
-### 1. Ground truth first
-Run the `fallow` skill over the area. Its dead-code / duplicate-clone / cycle / complexity output is the agents' **evidence base** — they interpret it, they don't guess. Note which "dead" symbols are exported (may be test-only — verify before anyone deletes).
+### 1. Ground truth first (optional sharpener, NOT a gate)
+If the area is JS/TS, run the `fallow` skill and hand its output to the agents as **evidence to interpret** for the dead-code section. It does not scope the audit: agents read/grep the whole area in step 3 regardless, and Fallow misses plenty (logic bugs, missing abstractions, non-exported dead symbols — all of which agents must still find). Unflagged ≠ unevaluated. Skip this step entirely if Fallow doesn't apply or isn't available. Where it does flag, note which "dead" symbols are exported — may be test-only, verify before deleting.
 
 ### 2. Read the domain
 Read `CONTEXT.md`, the relevant `docs/adr/*`, and the nearest `CLAUDE.md`. Agents must use real glossary terms and must know which invariants are load-bearing.
@@ -20,7 +20,7 @@ Read `CONTEXT.md`, the relevant `docs/adr/*`, and the nearest `CLAUDE.md`. Agent
 ### 3. Fan out a FIXED set of gather-agents
 One per sub-domain (aim 4–6, not "the app"). Two passes on the highest-value sub-domain, one elsewhere. Hard-cap it.
 
-Each agent: **foreground** (not background), model **sonnet**, given the Fallow output + the domain docs + this contract:
+Each agent reads/greps its **whole** sub-domain (Fallow flags are leads, not the boundary). Each agent: **foreground** (not background), model **sonnet**, given the Fallow output (if any) + the domain docs + this contract:
 
 > One turn. Do the full analysis with Grep/Read now; your FINAL message MUST be the report — no status updates, no "I'll continue". Grep to verify before asserting unused. Apply the ponytail lens (delete/reuse/collapse over add). Return EXACTLY:
 > 1. MAP — key files, LOC, responsibilities (one paragraph)

--- a/docs/audit/future.md
+++ b/docs/audit/future.md
@@ -1,0 +1,53 @@
+# Audit loop — future ideas (not built)
+
+`deep-audit` runs on one area, on demand. These are notes for turning it into a
+scheduled, looping system **later** — deliberately not built yet.
+
+## Decision: validate manually first
+
+Run `/deep-audit <area>` by hand on a few areas before automating anything.
+Automate only the parts that prove tediously repetitive. Signals to watch
+across manual runs (they decide whether/what to automate):
+
+- Issue quality — are filed issues real and triageable, or noise?
+- Dedup pain — does a second run re-propose existing issues?
+- Triage throughput — can a human clear the `needs-triage` queue one area produces?
+- Cross-area signal — does a recurring missing-primitive pattern emerge, or was it a one-off?
+
+## The shape, if/when it's worth building
+
+```
+manifest (areas + last-audited SHA) ─pick stalest *changed* area─▶ /deep-audit <area>
+       ▲                                                                 │
+       │ update SHA + 1-line digest                       files issues (dedup) + appends synthesis
+       │                                                                 ▼
+  weekly trigger ◀──────────────────────────────────────────────  ledger (per-area diagnoses)
+       │                                                                 │
+       └── every N runs ─▶ cross-cut pass reads ledger ─▶ cross-area proposals as issues
+```
+
+- **Manifest** (`docs/audit/areas.md`) — logical groups seeded from `architecture.md`
+  (runtime, canvas/interaction, preload/IPC, control-plane, panels, plugin), each with
+  last-audited SHA + one-line digest. No auto-clustering; the seams are already known.
+- **Pick = churn heuristic, not a planner** — area with the most `git diff` since its
+  last-audited SHA. Quiet areas are skipped.
+- **Ledger** (`docs/audit/ledger.md`) — append each area's synthesis (missing-abstraction
+  diagnosis + GREENFIELD must-keeps). This is the substrate for cross-area insight.
+- **Cross-cut pass** — every N runs, read the ledger; surface primitives that recur across
+  3+ areas (e.g. this session's "entity kind is the wrong unit of code" spanned six layers).
+- **Schedule** — weekly web trigger (or `/loop`), one area per fire. Weekly, not continuous:
+  architecture moves slowly; re-auditing unchanged code is waste.
+
+## Review gates (map to existing primitives)
+
+- Loop files `needs-triage` issues → human triages (`ready-for-agent` / `ready-for-human` / `wontfix`).
+- Macro proposals land as HITL ADR issues that block their implementation slices.
+- `ready-for-agent` work is built by the `afk-feature` pipeline (one PR/step, integration PR to review).
+- The loop **proposes only** — never edits code, never merges.
+
+## Guardrails
+
+- Dedup against open issues before filing.
+- Backpressure: if the loop's own open `needs-triage` count exceeds a threshold, pause filing and just report.
+- Churn-gate: no diff since last audit → skip.
+- One area + at most one PR per fire. Bounded cost (~6 agents/run), bounded review.


### PR DESCRIPTION
## Summary

Adds the **ponytail** Claude Code plugin at project scope, then uses its "reduce-before-add" lens to run a full bloat/architecture audit of the codebase and capture the results as actionable issues and a reusable workflow.

## What's in this branch
- **`.claude/settings.json`** — registers the `DietrichGebert/ponytail` marketplace and enables the plugin for collaborators (project scope). Ponytail injects a "reuse before generate" ruleset.
- **`.claude/skills/deep-audit/SKILL.md`** — a repeatable audit workflow (`/deep-audit <area>`): fan out gather-agents over an optional `fallow` static-analysis ground truth, synthesize the one missing-abstraction diagnosis, and emit tracer-bullet issues via `to-issues`. Encodes the failure-mode fixes learned this session (foreground agents, fixed set, report-as-final-message, reductions-only, capped coverage).

## How we got here
1. Added ponytail (plugin marketplace + enable).
2. Ran a six-domain audit (runtime/state, canvas/interaction, UI panels, preload/IPC, control planes, extras/plugin) via parallel gather-agents, cross-validated and synthesized.
3. Turned the synthesis into 17 tracer-bullet issues (#212–#228), framed as simplify/remove/deepen with a no-regression gate, organized under four macro proposals — entity registry, command core, open plugin surface, presence-scope decision — plus a Tier-0 dead-code/bug sweep (incl. 3 façade-bypass bugs the audit surfaced).
4. Codified the whole loop as the `deep-audit` skill so it can be re-run on other areas.

No production code changed here — this branch is tooling + config; the actual refactors live as issues #212–#228.

https://claude.ai/code/session_0122XpwShwE13J7cRH5CNoS8