### PR TITLE
Add comment mode support for file canvas entities

### DIFF
--- a/src/main/ipc/register-canvas-entity-ipc.ts
+++ b/src/main/ipc/register-canvas-entity-ipc.ts
@@ -10,6 +10,7 @@ import { setPendingFocus } from '../runtime/runtime-context'
 import { executeRegionSelect } from '../runtime/region-select'
 import { queryElementAtPoint } from '../runtime/page-queries'
 import {
+  fileAtWindowPoint,
   pageAtWindowPoint,
   windowPointToCanvasPoint,
 } from '../runtime/window-coords'
@@ -588,6 +589,17 @@ export function registerCanvasEntityIpc(): void {
             canvasY: canvasPoint.y,
           })
         }
+      }
+
+      const fileId = fileAtWindowPoint(windowX, windowY)
+      if (fileId) {
+        setCommentOverlayActive(true)
+        setPendingFocus({ kind: 'aboveView' })
+        requestLayout()
+        if (aboveView && !aboveView.webContents.isDestroyed()) {
+          aboveView.webContents.send('annotate-file-selected', { fileId })
+        }
+        return
       }
 
       const hit = pageAtWindowPoint(windowX, windowY)

--- a/src/main/runtime/window-coords.ts
+++ b/src/main/runtime/window-coords.ts
@@ -11,6 +11,7 @@
  */
 
 import { pages, pan, zoom } from './runtime-context'
+import { fileEntities } from './file-entity-state'
 import {
   boundCanvasOrigin,
   boundEffectivePageContentSize,
@@ -56,6 +57,31 @@ export function pageAtWindowPoint(windowX: number, windowY: number): PageHit | n
       pageId: page.id,
       localX: Math.round((windowX - bounds.x) * cssScale),
       localY: Math.round((windowY - bounds.y) * cssScale),
+    }
+  }
+  return null
+}
+
+/**
+ * Returns the id of the topmost file entity whose content rect contains
+ * (windowX, windowY), or null. Iterates in reverse array order so later
+ * entries — painted on top — win. Uses content bounds, ignoring shell insets.
+ */
+export function fileAtWindowPoint(windowX: number, windowY: number): string | null {
+  const origin = boundCanvasOrigin()
+  for (let i = fileEntities.length - 1; i >= 0; i--) {
+    const entity = fileEntities[i]
+    const contentScreenX = origin.x + entity.canvasX * zoom + pan.x
+    const contentScreenY = origin.y + entity.canvasY * zoom + pan.y
+    const contentScreenW = entity.width * zoom
+    const contentScreenH = entity.height * zoom
+    if (
+      windowX >= contentScreenX &&
+      windowX <= contentScreenX + contentScreenW &&
+      windowY >= contentScreenY &&
+      windowY <= contentScreenY + contentScreenH
+    ) {
+      return entity.id
     }
   }
   return null

--- a/src/preload/canvas-bg.ts
+++ b/src/preload/canvas-bg.ts
@@ -257,6 +257,12 @@ const api: CanvasBgElectronAPI = {
     ipcRenderer.on('annotate-element-selected', handler)
     return () => ipcRenderer.removeListener('annotate-element-selected', handler)
   },
+  onAnnotateFileSelected: (callback) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: Parameters<typeof callback>[0]) =>
+      callback(data)
+    ipcRenderer.on('annotate-file-selected', handler)
+    return () => ipcRenderer.removeListener('annotate-file-selected', handler)
+  },
   onRegionSelectCommitted: (callback) => {
     const handler = (_event: Electron.IpcRendererEvent, data: Parameters<typeof callback>[0]) =>
       callback(data)

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -848,6 +848,33 @@ export default function App({
     }
   }, [api, hitTestHoverTarget, hoverForwardingEnabled, layoutRef, pendingPlacement])
 
+  // Track which file entity the pointer is hovering while the comment tool is
+  // active (with no pending annotation open). Drives the dashed-blue hover
+  // outline rendered below.
+  const [commentToolHoveredFileId, setCommentToolHoveredFileId] = useState<string | null>(null)
+  const commentToolActiveNoPending =
+    layoutData.activeTool.kind === 'comment' && !pendingAnnotation && !pendingRegionRect
+  useEffect(() => {
+    if (!commentToolActiveNoPending) {
+      setCommentToolHoveredFileId(null)
+      return
+    }
+    const onMove = (event: PointerEvent) => {
+      if (isOverlayUiTarget(event.target)) {
+        setCommentToolHoveredFileId(null)
+        return
+      }
+      const nextId = hitTestHoverTarget(event.clientX, event.clientY)
+      const entity = nextId ? layoutRef.current.entities.find((e) => e.id === nextId) : null
+      setCommentToolHoveredFileId(entity?.kind === 'file' ? nextId : null)
+    }
+    window.addEventListener('pointermove', onMove)
+    return () => {
+      window.removeEventListener('pointermove', onMove)
+      setCommentToolHoveredFileId(null)
+    }
+  }, [commentToolActiveNoPending, hitTestHoverTarget, layoutRef])
+
   const routerOwnsCanvasPointers =
     !overlayInteractive &&
     !pendingPlacement &&
@@ -1324,6 +1351,29 @@ html:active, body:active, body *:active { cursor: grabbing !important; }`
             layoutData={layoutData}
             onOpenThread={openThreadById}
           />
+
+          {commentToolHoveredFileId ? (() => {
+            const fe = layoutData.entities.find(
+              (e) => e.id === commentToolHoveredFileId && e.kind === 'file',
+            )
+            if (!fe) return null
+            return (
+              <div
+                className="pointer-events-none absolute"
+                style={{
+                  left: fe.screenX,
+                  top: fe.screenY - layoutData.canvasOrigin.y,
+                  width: Math.max(1, fe.screenWidth),
+                  height: Math.max(1, fe.screenHeight),
+                  border: '1px dashed rgba(59, 130, 246, 0.95)',
+                  background: 'rgba(59, 130, 246, 0.14)',
+                  boxShadow: '0 0 0 1px rgba(255, 255, 255, 0.22) inset',
+                  boxSizing: 'border-box',
+                  zIndex: 40,
+                }}
+              />
+            )
+          })() : null}
 
           <PendingElementOutline
             pending={pendingAnnotation}

--- a/src/renderer/above-view/CommentsLayer.tsx
+++ b/src/renderer/above-view/CommentsLayer.tsx
@@ -194,6 +194,29 @@ export function PendingElementOutline({
   liveBboxes: AnnotationLiveBboxLookup
 }) {
   if (!pending) return null
+
+  if (pending.request.anchor.type === 'file') {
+    const fileId = pending.request.anchor.fileId
+    const fileEntity = layoutData.entities.find((e) => e.id === fileId && e.kind === 'file')
+    if (!fileEntity) return null
+    return (
+      <div
+        className="pointer-events-none absolute"
+        style={{
+          left: fileEntity.screenX,
+          top: fileEntity.screenY - layoutData.canvasOrigin.y,
+          width: Math.max(1, fileEntity.screenWidth),
+          height: Math.max(1, fileEntity.screenHeight),
+          border: '1px dashed rgba(59, 130, 246, 0.95)',
+          background: 'rgba(59, 130, 246, 0.14)',
+          boxShadow: '0 0 0 1px rgba(255, 255, 255, 0.22) inset',
+          boxSizing: 'border-box',
+          zIndex: 40,
+        }}
+      />
+    )
+  }
+
   const rect = pendingElementScreenRect(pending, layoutData, liveBboxes)
   if (!rect) return null
   return (

--- a/src/renderer/above-view/annotationMath.ts
+++ b/src/renderer/above-view/annotationMath.ts
@@ -185,6 +185,15 @@ export function annotationScreenPos(
       transform: 'translate(-50%, 0)',
     }
   }
+  if (anchor.type === 'file') {
+    const fileEntity = layout.entities.find((e) => e.id === anchor.fileId && e.kind === 'file')
+    if (!fileEntity) return null
+    return {
+      x: fileEntity.screenX + fileEntity.screenWidth,
+      y: toOverlayY(layout, fileEntity.screenY),
+      transform: 'translate(-100%, 0)',
+    }
+  }
   if (anchor.type === 'page' || anchor.type === 'element') {
     const page = layout.entities.find((f) => f.id === anchor.pageId)
     if (!page) return null

--- a/src/renderer/above-view/useAnnotationDraftState.ts
+++ b/src/renderer/above-view/useAnnotationDraftState.ts
@@ -3,6 +3,7 @@ import type {
   AnnotationAnchor,
   AnnotationElementSelectionPayload,
   CanvasBgElectronAPI,
+  CanvasSceneFileEntity,
   LayoutUpdateData,
   WorkspaceBounds,
 } from '../../shared/types'
@@ -113,6 +114,22 @@ export function useAnnotationDraftState({
       setDrawingSession(null)
       setCommentText('')
       setElementNameDraft(payload.name?.trim() ?? '')
+    })
+    return cleanup
+  }, [api, layoutRef])
+
+  useEffect(() => {
+    const cleanup = api.onAnnotateFileSelected(({ fileId }) => {
+      const layout = layoutRef.current
+      const fileEntity = layout.entities.find(
+        (e): e is CanvasSceneFileEntity => e.id === fileId && e.kind === 'file',
+      )
+      const pending = buildFileEntityPendingAnnotation(fileId, fileEntity, layout)
+      setPendingAnnotation(pending)
+      setPendingRegionRect(null)
+      setDrawingSession(null)
+      setCommentText('')
+      setElementNameDraft('')
     })
     return cleanup
   }, [api, layoutRef])
@@ -272,6 +289,38 @@ function buildPendingAnnotation(
 
 function makeDraftId(): string {
   return `draft:${Math.random().toString(36).slice(2, 10)}:${Date.now().toString(36)}`
+}
+
+function buildFileEntityPendingAnnotation(
+  fileId: string,
+  fileEntity: CanvasSceneFileEntity | undefined,
+  layout: LayoutUpdateData,
+): PendingAnnotation {
+  const composerWidth = Math.min(CANVAS_POINT_COMPOSER_WIDTH, window.innerWidth - VIEWPORT_PADDING * 2)
+  let composerX = VIEWPORT_PADDING
+  let composerY = VIEWPORT_PADDING
+  if (fileEntity) {
+    const rightEdge = fileEntity.screenX + fileEntity.screenWidth + COMPOSER_MARGIN
+    const overlayY = toOverlayY(layout, fileEntity.screenY) + COMPOSER_MARGIN
+    composerX = Math.min(
+      Math.max(rightEdge, VIEWPORT_PADDING),
+      window.innerWidth - composerWidth - VIEWPORT_PADDING,
+    )
+    composerY = Math.min(
+      Math.max(overlayY, VIEWPORT_PADDING),
+      window.innerHeight - COMPOSER_MIN_HEIGHT - VIEWPORT_PADDING,
+    )
+  }
+  return {
+    draftId: makeDraftId(),
+    request: {
+      anchor: { type: 'file', fileId },
+      text: '',
+    },
+    composerX,
+    composerY,
+    composerWidth,
+  }
 }
 
 function buildCanvasPointPendingAnnotation(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1824,6 +1824,11 @@ export interface CanvasBgElectronAPI {
   onAnnotateElementSelected: (
     callback: (data: AnnotationElementSelectionPayload) => void,
   ) => () => void
+  /** Comment-tool click that landed on a file entity. Renderer mounts a
+   *  pending composer anchored to the file entity. */
+  onAnnotateFileSelected: (
+    callback: (data: { fileId: string }) => void,
+  ) => () => void
   onRegionSelectCommitted: (
     callback: (data: { canvasRect: WorkspaceBounds }) => void,
   ) => () => void
@@ -2104,6 +2109,7 @@ export type AnnotationAnchor =
   | { type: 'page'; pageId: string; offsetX: number; offsetY: number }
   | { type: 'element'; pageId: string; selector: string; elementPath?: string; boundingBox?: DevtoolsPanelDomRect }
   | { type: 'region'; canvasRect: WorkspaceBounds }
+  | { type: 'file'; fileId: string }
 
 export type AnnotationStatus = 'pending' | 'acknowledged' | 'resolved' | 'dismissed'
 export type AnnotationStatusFilter = AnnotationStatus | 'unresolved' | 'all'


### PR DESCRIPTION
Closes #1

## What

Extends the comment tool to file entities (images, SVG, markdown, HTML canvas entities), mirroring the per-element hover-highlight + click treatment already used for page frames.

## Changes

- **`AnnotationAnchor`** — adds `{ type: 'file'; fileId: string }` variant so comments persist anchored to a specific file entity
- **Main process hit-test** — `fileAtWindowPoint()` in `window-coords.ts` checks file entity content bounds; the `canvas-comment-click-at` handler tries file entities before pages, firing `annotate-file-selected` IPC when one is hit
- **Hover outline** — `App.tsx` tracks which file entity is under the pointer when the comment tool is active (no pending draft) and renders a dashed-blue `rgba(59,130,246,0.95)` outline matching the DOM-inspection style
- **Pending outline** — `PendingElementOutline` in `CommentsLayer.tsx` handles the `file` anchor type, drawing the same selection outline around the clicked entity while the composer is open
- **Composer placement** — `buildFileEntityPendingAnnotation` in `useAnnotationDraftState.ts` positions the composer adjacent to the file entity's right edge (or clamps to viewport)
- **Thread icon placement** — `annotationScreenPos` in `annotationMath.ts` positions the annotation marker at the entity's top-right corner so the thread popover appears in the expected spot
- **Preload bridge** — `onAnnotateFileSelected` added to `canvas-bg.ts` preload

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRDp2F9Lw1crSGt6dANaen)_