### PR TITLE
Add frameChromeCanvasBounds + projectFramePointToCanvas helpers

### DIFF
--- a/src/main/ipc/register-annotation-inspection-ipc.ts
+++ b/src/main/ipc/register-annotation-inspection-ipc.ts
@@ -4,6 +4,7 @@ import {
   bgView,
   aboveView,
   pageBodyCanvasBounds,
+  projectFramePointToCanvas,
   requestLayout,
 } from '../runtime/surface-layout'
 import {
@@ -72,16 +73,16 @@ function annotationCanvasBounds(annotation: Annotation): WorkspaceBounds | null 
     case 'element': {
       const page = findPageById(anchor.pageId)
       if (!page) return null
-      const body = pageBodyCanvasBounds(page)
       if (anchor.boundingBox) {
+        const origin = projectFramePointToCanvas(page, anchor.boundingBox)
         return {
-          x: body.x + anchor.boundingBox.x,
-          y: body.y + anchor.boundingBox.y,
+          x: origin.x,
+          y: origin.y,
           width: anchor.boundingBox.width,
           height: anchor.boundingBox.height,
         }
       }
-      return body
+      return pageBodyCanvasBounds(page)
     }
     case 'page': {
       const page = findPageById(anchor.pageId)

--- a/src/main/presence-manager.ts
+++ b/src/main/presence-manager.ts
@@ -24,7 +24,7 @@ import {
 import {
   findPageById,
 } from './runtime/runtime-context'
-import { pageBodyCanvasBounds, pageContentSize } from './runtime/runtime-geometry'
+import { pageContentSize, projectFramePointToCanvas } from './runtime/runtime-geometry'
 
 // --- Re-exports from presence-session ---
 export {
@@ -162,13 +162,13 @@ export function resolveCanvasPointForPage(
     fallbackX: width / 2,
     fallbackY: height / 2,
   })
-  // DOM point lives in content coordinates; shift to the body origin so
+  // DOM point lives in content coordinates; project to canvas space so
   // the cursor lands on the page body (inside any device-frame bezel).
-  const body = pageBodyCanvasBounds(page)
-  return {
-    canvasX: body.x + clamp(point.x, 0, width),
-    canvasY: body.y + clamp(point.y, 0, height),
-  }
+  const canvas = projectFramePointToCanvas(page, {
+    x: clamp(point.x, 0, width),
+    y: clamp(point.y, 0, height),
+  })
+  return { canvasX: canvas.x, canvasY: canvas.y }
 }
 
 export function extractCanvasPosition(url: string, body: Record<string, unknown>): { x: number; y: number } | null {

--- a/src/main/runtime/canvas-layout-data.ts
+++ b/src/main/runtime/canvas-layout-data.ts
@@ -61,8 +61,8 @@ import {
 } from './runtime-constants'
 import { currentKeyboardTargetPageId } from './selection-controller'
 import {
-  pageBodyCanvasBounds,
   pageContentSize,
+  projectFramePointToCanvas,
   boundEffectivePageContentSize as effectivePageContentSize,
   boundAvailableCanvasViewport as localAvailableCanvasViewport,
   boundCanvasOrigin as localCanvasOrigin,
@@ -462,11 +462,10 @@ export function buildCanvasLayoutData(
             const clampedX = Math.max(0, Math.min(point.x, page.width))
             const clampedY = Math.max(0, Math.min(point.y, page.height))
             const pageWcv = findPageById(page.id)
-            const body = pageWcv ? pageBodyCanvasBounds(pageWcv) : { x: page.canvasX, y: page.canvasY }
-            return {
-              canvasX: body.x + clampedX,
-              canvasY: body.y + clampedY,
-            }
+            const proj = pageWcv
+              ? projectFramePointToCanvas(pageWcv, { x: clampedX, y: clampedY })
+              : { x: page.canvasX + clampedX, y: page.canvasY + clampedY }
+            return { canvasX: proj.x, canvasY: proj.y }
           }
         }
         // In browser mode, place canvas-surface cursors on the active page

--- a/src/main/runtime/runtime-geometry.ts
+++ b/src/main/runtime/runtime-geometry.ts
@@ -138,6 +138,31 @@ export function pageVisualBounds(
   }
 }
 
+/** Chrome band that floats above the snap rect. */
+export function frameChromeCanvasBounds(
+  page: Pick<Page, 'presetIndex' | 'canvasX' | 'canvasY' | 'peekWidth' | 'peekHeight' | 'metadata'>,
+): WorkspaceBounds {
+  const snap = pageSnapBounds(page)
+  return {
+    x: snap.x,
+    y: snap.y - CHROME_HEADER_HEIGHT,
+    width: snap.width,
+    height: CHROME_HEADER_HEIGHT,
+  }
+}
+
+/**
+ * Project a content-space DOM point (from a page iframe) into canvas coordinates.
+ * Accounts for shell insets so callers never need to add chromeHeight manually.
+ */
+export function projectFramePointToCanvas(
+  page: Pick<Page, 'presetIndex' | 'canvasX' | 'canvasY' | 'peekWidth' | 'peekHeight' | 'metadata'>,
+  point: { x: number; y: number },
+): { x: number; y: number } {
+  const body = pageBodyCanvasBounds(page)
+  return { x: body.x + point.x, y: body.y + point.y }
+}
+
 // ---------------------------------------------------------------------------
 // Pure computation functions (parameterized — no runtime state)
 // ---------------------------------------------------------------------------

--- a/src/main/runtime/surface-layout.ts
+++ b/src/main/runtime/surface-layout.ts
@@ -27,6 +27,8 @@ export {
   pageSnapBounds,
   pageVisualBounds,
   pageContentSize,
+  frameChromeCanvasBounds,
+  projectFramePointToCanvas,
 } from './runtime-geometry'
 
 export { snapToGrid } from '../../shared/gesture-utils'


### PR DESCRIPTION
Closes #17

## What

Adds two geometry helpers to `runtime-geometry.ts` (and re-exports via `surface-layout.ts`) to eliminate the footgun where callers must manually account for the chrome-height offset when projecting DOM content-space points to canvas coordinates:

- **`frameChromeCanvasBounds(page)`** — chrome band bounds (`{ x, y, width, height }`) sitting above the snap rect
- **`projectFramePointToCanvas(page, point)`** — converts a content-space DOM point into canvas coordinates, correctly accounting for shell/bezel insets

Routes three call sites through `projectFramePointToCanvas`:
- `presence-manager.ts` — cursor position projection
- `canvas-layout-data.ts` — presence cursor canvas placement
- `register-annotation-inspection-ipc.ts` — element bounding box projection

## Why

`page.canvasY` is the snap-rect top, not the content origin. Content sits below by any shell insets. Every caller projecting a DOM point to canvas had to remember to get the body bounds first — and historically this caused silent 44 px cursor misplacements (already fixed, but by duplicating the pattern). The new helper makes the correct path the obvious one.

---
_Generated by [Claude Code](https://claude.ai/code/session_014hYGoocRchydYgNaP8zNwP)_