### PR TITLE
Gate test routes out of production builds (#216)

### DIFF
--- a/src/main/app-control-server.ts
+++ b/src/main/app-control-server.ts
@@ -6,6 +6,7 @@ import { homedir, tmpdir } from 'os'
 import type { Duplex } from 'stream'
 import { WebSocket, WebSocketServer, type RawData } from 'ws'
 
+import { app } from 'electron'
 import { APP_CONTROL_DISCOVERY_FILE, APP_CONTROL_PORT, APP_CONTROL_VERSION } from '../shared/constants'
 import { getUiState } from './ui-state'
 import { findPageById, clearAutomationInteractivePageIds, automationInteractivePageCounts, getZoom } from './runtime/runtime-context'
@@ -252,7 +253,7 @@ const routes: Route[] = [
   ...entityRoutes,
   ...stackOrderHttpRoutes,
   ...designSystemRoutes,
-  ...testRoutes,
+  ...(!app.isPackaged ? testRoutes : []),
 ]
 
 async function route(request: IncomingMessage, response: ServerResponse): Promise<void> {


### PR DESCRIPTION
Closes #216

## Change

Register `testRoutes` only when `!app.isPackaged`, so the smoke-test HTTP endpoints are excluded from production/packaged builds. Smoke tests run unpackaged, so they are unaffected.

Two-line diff in `src/main/app-control-server.ts`:
- Add `import { app } from 'electron'`
- Spread `testRoutes` conditionally: `...(!app.isPackaged ? testRoutes : [])`

## Verification

- `pnpm test:unit` — 686/686 passed
- Pre-existing typecheck errors in unrelated files (forge.config.ts, ipc handlers) are not introduced by this change

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMcd4sdd5tbQtxJnvfFKYx)_