### PR TITLE
Fix unguarded tryEnter + dangling beginBatch in resize/multi-resize/edge-drag begin (I3)

### DIFF
--- a/src/main/ipc/register-canvas-drag-ipc.ts
+++ b/src/main/ipc/register-canvas-drag-ipc.ts
@@ -375,7 +375,8 @@ export function registerCanvasDragIpc(): void {
       // the first move tick, aboveView blurs, and the renderer's window-blur
       // listener cancels the gesture after one pixel. Same gotcha as the
       // drag-start ordering — see runtime/CLAUDE.md.
-      tryEnter({ kind: 'resizing-entity', target: { id: entityId, kind: entityKind } })
+      const resizeToken = tryEnter({ kind: 'resizing-entity', target: { id: entityId, kind: entityKind } })
+      if ('refused' in resizeToken) return
       resizingEntityId = entityId
       initializeResizeGuides(entityId, handle)
       // Coalesce the gesture's per-tick bounds mutations into one Y.Doc
@@ -396,7 +397,8 @@ export function registerCanvasDragIpc(): void {
   })
 
   ipcMain.on('canvas-multi-resize-begin', () => {
-    tryEnter({ kind: 'resizing-multi-selection' })
+    const multiResizeToken = tryEnter({ kind: 'resizing-multi-selection' })
+    if ('refused' in multiResizeToken) return
     beginBatch()
   })
 
@@ -412,11 +414,12 @@ export function registerCanvasDragIpc(): void {
       _event,
       { fromEntityId, fromSide }: { fromEntityId: string; fromSide: EdgeSide },
     ) => {
-      tryEnter({
+      const edgeToken = tryEnter({
         kind: 'dragging-edge',
         from: { id: fromEntityId, kind: resolveEntityKind(fromEntityId) },
         fromSide,
       })
+      if ('refused' in edgeToken) return
       setHoverEntity(null)
       requestLayout()
     },

--- a/src/main/routes/test.ts
+++ b/src/main/routes/test.ts
@@ -242,7 +242,11 @@ export const testRoutes: Route[] = [
     method: 'POST',
     pattern: '/test/canvas-multi-resize/begin',
     async handler({ response }) {
-      tryEnter({ kind: 'resizing-multi-selection' })
+      const token = tryEnter({ kind: 'resizing-multi-selection' })
+      if ('refused' in token) {
+        writeJson(response, 200, { ok: false, refused: true, reason: token.reason })
+        return
+      }
       beginBatch()
       writeJson(response, 200, { ok: true })
     },

--- a/tests/smoke/app-client.ts
+++ b/tests/smoke/app-client.ts
@@ -601,7 +601,7 @@ export type MultiResizeEntry = {
 }
 
 export function beginMultiResize() {
-  return post<{ ok: true }>('/test/canvas-multi-resize/begin')
+  return post<{ ok: boolean; refused?: true; reason?: string }>('/test/canvas-multi-resize/begin')
 }
 
 export function applyMultiResize(entries: MultiResizeEntry[]) {

--- a/tests/smoke/gestures.test.ts
+++ b/tests/smoke/gestures.test.ts
@@ -1,17 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
+  applyMultiResize,
   beginInteraction,
+  beginMultiResize,
   cancelActiveInteraction,
   cancelInteraction,
   commitInteraction,
   createPages,
+  createTextEntities,
   deletePages,
+  deleteTextEntities,
+  endMultiResize,
   getInteractionMode,
+  getTextEntities,
+  getUndoState,
   resetInteraction,
+  resetSmokeState,
+  undoWorkspace,
   type CancelReason,
   type InteractionToken,
   type TryEnterInput,
 } from './app-client'
+import { wait } from './test-utils'
 
 /**
  * Per-mode begin/commit/cancel matrix for the InteractionController.
@@ -128,4 +138,65 @@ describe('InteractionController state machine', () => {
     expect(after.mode.kind).toBe('idle')
   })
 
+})
+
+describe('I3 violation fix: conflicting gesture-begin does not corrupt batch/undo', () => {
+  const createdTextIds: string[] = []
+
+  beforeEach(async () => {
+    await resetSmokeState()
+    await resetInteraction()
+  })
+
+  afterEach(async () => {
+    await resetInteraction()
+    if (createdTextIds.length) {
+      await deleteTextEntities(createdTextIds.splice(0))
+    }
+  })
+
+  it('second concurrent multi-resize-begin is refused and does not open a dangling batch', async () => {
+    const { ids } = await createTextEntities([
+      { canvasX: 0, canvasY: 0, text: 'resize-me', width: 100, height: 50 },
+    ])
+    createdTextIds.push(...ids)
+    await wait(50)
+
+    const before = await getTextEntities()
+    const init = before.textEntities.find((t) => t.id === ids[0])!
+
+    // Begin the first gesture.
+    const first = await beginMultiResize()
+    expect(first.ok).toBe(true)
+
+    // A second begin while the first is active must be refused.
+    const second = await beginMultiResize()
+    expect(second.ok).toBe(false)
+    expect(second.refused).toBe(true)
+
+    // Apply a resize tick on the first gesture.
+    await applyMultiResize([
+      { id: ids[0], kind: 'text', width: 150, height: 50, canvasX: init.canvasX, canvasY: init.canvasY },
+    ])
+
+    // End the first gesture — batch count should be balanced (one begin, one end).
+    await endMultiResize()
+    await wait(50)
+
+    const afterResize = await getTextEntities()
+    const resized = afterResize.textEntities.find((t) => t.id === ids[0])!
+    expect(resized.width).toBe(150)
+
+    // Undo must round-trip cleanly — if the batch were mismatched, undo would
+    // either no-op or corrupt a prior step.
+    const undoState = await getUndoState()
+    expect(undoState.canUndo).toBe(true)
+
+    await undoWorkspace()
+    await wait(50)
+
+    const afterUndo = await getTextEntities()
+    const undone = afterUndo.textEntities.find((t) => t.id === ids[0])!
+    expect(undone.width).toBe(init.width)
+  })
 })


### PR DESCRIPTION
Closes #230

## What changed

Three gesture-begin IPC handlers (`canvas-resize-begin`, `canvas-multi-resize-begin`, `canvas-edge-drag-begin`) called `tryEnter()` and discarded the result, then ran side effects (`beginBatch`, `setHoverEntity`, `requestLayout`) unconditionally — violating invariant I3 from `docs/interaction-layer.md §6`.

When a second gesture fired while one was active, `tryEnter` refused but `beginBatch()` still opened a second batch. The matching `*-end` handler then ran `endBatch() + markUndoBoundary() + commitActive()` against the wrong gesture, producing a mismatched batch count and a corrupt undo step.

## Fix

Capture the `tryEnter` return value and return early on refusal before any batch or side effects — mirrors the existing `beginDragSession` pattern in the same file:

```ts
// before
tryEnter({ kind: 'resizing-multi-selection' })
beginBatch()

// after
const token = tryEnter({ kind: 'resizing-multi-selection' })
if ('refused' in token) return
beginBatch()
```

Same fix applied to all three begin handlers and to the `/test/canvas-multi-resize/begin` HTTP test route.

## Verification

- `pnpm typecheck` — no new errors introduced (pre-existing Electron env errors unchanged)
- `pnpm test:unit` — 686/686 pass
- Added smoke test in `gestures.test.ts`: verifies second concurrent `beginMultiResize` is refused, batch stays balanced, and undo round-trips cleanly after the first gesture ends

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRBiiifEzSj2mWXEBsncwh)_