### PR TITLE
Interaction-layer dead-code sweep + small dedups (~190 LOC)

### DIFF
--- a/src/main/runtime/focus-reconciler-runtime.ts
+++ b/src/main/runtime/focus-reconciler-runtime.ts
@@ -9,6 +9,7 @@
 
 import type { WebContents } from 'electron'
 import type { FocusTarget } from '../../shared/interaction-types'
+import { canvasInteractionModeKind } from '../../shared/gesture-utils'
 import { expectedFocus, focusKey, type FocusState } from './focus-reconciler'
 import { aboveView, bgView, toolbarView, leftSidebarView, win } from './view-refs'
 import {
@@ -22,25 +23,11 @@ import { isTextEditingFor } from './binding-dispatcher'
 import { isCommentOverlayVisible, selectedPageIndex, workspaceViewMode } from '../ui-state'
 import { currentKeyboardTargetPageId } from './selection-controller'
 
-function interactionModeKey(): FocusState['interactionMode'] {
-  switch (interactionState.kind) {
-    case 'idle': return 'idle'
-    case 'panning-canvas': return 'panning'
-    case 'marquee-select': return 'marquee'
-    case 'dragging-entities': return 'dragging-entities'
-    case 'resizing-entity': return 'resizing-entity'
-    case 'resizing-multi-selection': return 'resizing-multi-selection'
-    case 'dragging-edge': return 'dragging-edge'
-    case 'editing-entity': return 'editing-entity'
-    case 'reordering-row': return 'reordering-row'
-  }
-}
-
 function currentFocusState(): FocusState {
   const idx = selectedPageIndex(pages.map((p) => p.id))
   const selectedPage = idx != null ? pages[idx] : null
   return {
-    interactionMode: interactionModeKey(),
+    interactionMode: canvasInteractionModeKind(interactionState),
     editingEntityId: getEditingEntityId(),
     selectedPageId: selectedPage?.id ?? null,
     workspaceViewMode: workspaceViewMode(),

--- a/src/main/runtime/interaction-controller.ts
+++ b/src/main/runtime/interaction-controller.ts
@@ -142,13 +142,6 @@ function isActive(token: Token): boolean {
   return current !== null && current.id === token.id
 }
 
-export function update(token: Token): void {
-  if (!isActive(token)) return
-  // Phase 2: payload-free; specific update helpers (e.g. updateEdgeDragTarget)
-  // continue to be called directly by the drag IPC handlers. Phase 5 moves
-  // those payloads into this method.
-}
-
 export function commit(token: Token): void {
   if (!isActive(token)) return
   clearTimeout(current!.timer)

--- a/src/main/runtime/selection-controller.ts
+++ b/src/main/runtime/selection-controller.ts
@@ -34,8 +34,7 @@ import {
   shouldFocusSelectedPage,
   type FocusSelectionInput,
 } from '../../shared/should-focus-selected-page'
-import type { InteractionMode } from '../../shared/interaction-types'
-import type { CanvasInteractionState } from '../../shared/types'
+import { canvasInteractionModeKind } from '../../shared/gesture-utils'
 
 type SelectionCommand =
   | { kind: 'none' }
@@ -68,22 +67,6 @@ function predicateSelectionInput(selection: UiState['selection']): FocusSelectio
   return { kind: 'none' }
 }
 
-function predicateInteractionKind(
-  state: CanvasInteractionState,
-): InteractionMode['kind'] {
-  switch (state.kind) {
-    case 'idle': return 'idle'
-    case 'panning-canvas': return 'panning'
-    case 'marquee-select': return 'marquee'
-    case 'dragging-entities': return 'dragging-entities'
-    case 'resizing-entity': return 'resizing-entity'
-    case 'resizing-multi-selection': return 'resizing-multi-selection'
-    case 'dragging-edge': return 'dragging-edge'
-    case 'editing-entity': return 'editing-entity'
-    case 'reordering-row': return 'reordering-row'
-  }
-}
-
 /**
  * Predicate-derived "which page should hold keyboard + receive forwarded
  * input." Single source of truth for the focus reconciler, page cursor
@@ -93,7 +76,7 @@ export function currentKeyboardTargetPageId(): string | null {
   const ui = getUiState()
   return shouldFocusSelectedPage({
     selection: predicateSelectionInput(ui.selection),
-    interactionKind: predicateInteractionKind(interactionState),
+    interactionKind: canvasInteractionModeKind(interactionState),
     activeTool: ui.activeTool,
     commentOverlayActive: isCommentOverlayVisible(ui),
   })

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -17,6 +17,7 @@ import {
   canvasToScreenX,
   canvasToScreenY,
   canScrollWheelTarget,
+  DRAG_THRESHOLD,
   isOverlayUiTarget,
   normalizeRect,
   screenPointToCanvasPoint,
@@ -863,7 +864,6 @@ export default function App({
   // cursor via `inspectAtPoint`; element hit → element anchor; nothing →
   // canvas-point anchor. Drag past threshold → marquee → region anchor on
   // pointerup. Threshold matches the rest of the canvas pointer router.
-  const COMMENT_DRAG_THRESHOLD = 4
   // The comment tool needs to keep capturing pointerdowns while a pending
   // annotation or region rect is open so the user can retarget by clicking a
   // different element. `isOverlayUiTarget` below still filters out clicks on
@@ -956,7 +956,7 @@ export default function App({
           if (!crossedThreshold) {
             const dx = ev.clientX - startX
             const dy = ev.clientY - startY
-            if (Math.abs(dx) < COMMENT_DRAG_THRESHOLD && Math.abs(dy) < COMMENT_DRAG_THRESHOLD) {
+            if (Math.abs(dx) < DRAG_THRESHOLD && Math.abs(dy) < DRAG_THRESHOLD) {
               return
             }
             crossedThreshold = true

--- a/src/renderer/above-view/FileChrome.tsx
+++ b/src/renderer/above-view/FileChrome.tsx
@@ -12,7 +12,7 @@ import type {
   CanvasSceneFileEntity,
   LayoutUpdateData,
 } from '../../shared/types'
-import { MARKDOWN_EXTENSIONS, WIREFRAME_EXTENSIONS } from '../canvas-bg/entityConstants'
+import { fileDisplayName } from '../canvas-bg/entityConstants'
 import { CanvasItemChrome } from './CanvasItemChrome'
 import { iconForFilePath } from '../shared/fileIcon'
 import { startOptionAwareEntityDrag, type DragCopyPreviewBox } from './optionDragCopy'
@@ -78,12 +78,7 @@ const FileChromeItem = memo(function FileChromeItem({
   optionHeldRef: MutableRefObject<boolean>
   setDragCopyPreview: (preview: DragCopyPreviewBox[]) => void
 }) {
-  const fileName = entity.file.split('/').pop() ?? entity.file
-  const displayName = WIREFRAME_EXTENSIONS.test(entity.file)
-    ? fileName.replace(/\.wireframe\.json$/i, '')
-    : MARKDOWN_EXTENSIONS.test(entity.file)
-      ? fileName.replace(/\.md$/i, '')
-      : fileName
+  const displayName = fileDisplayName(entity.file)
   const FileIcon = iconForFilePath(entity.file)
 
   const onPointerDown = (event: React.PointerEvent) => {

--- a/src/renderer/above-view/FilePopup.tsx
+++ b/src/renderer/above-view/FilePopup.tsx
@@ -11,16 +11,9 @@ import type {
 import { CanvasItemPopup } from './CanvasItemPopup'
 import { DistributeAction } from './DistributeAction'
 import { InlineEditLabel } from '../shared/InlineEditLabel'
-import { MARKDOWN_EXTENSIONS, WIREFRAME_EXTENSIONS } from '../canvas-bg/entityConstants'
+import { fileDisplayName } from '../canvas-bg/entityConstants'
 import { renderPopupContributions } from './file-popup-contributions'
 import { POPUP_OFFSET_Y, usePopupDelayedKey } from './usePopupDelayedKey'
-
-function displayNameFor(file: string): string {
-  const base = file.split('/').pop() ?? file
-  if (WIREFRAME_EXTENSIONS.test(file)) return base.replace(/\.wireframe\.json$/i, '')
-  if (MARKDOWN_EXTENSIONS.test(file)) return base.replace(/\.md$/i, '')
-  return base
-}
 
 export function FilePopup({
   api,
@@ -92,7 +85,7 @@ export function FilePopup({
                   ) : null}
                   <CanvasItemPopup.Section grow>
                     <InlineEditLabel
-                      value={displayNameFor(single.file)}
+                      value={fileDisplayName(single.file)}
                       isEditing={isRenaming}
                       onStartEdit={() => setIsRenaming(true)}
                       onCommit={(next) => {

--- a/src/renderer/above-view/GroupRenameLabel.tsx
+++ b/src/renderer/above-view/GroupRenameLabel.tsx
@@ -18,11 +18,9 @@ import type {
   CanvasSceneGroupEntity,
   LayoutUpdateData,
 } from '../../shared/types'
-import { resolveCanvasColor } from '../../shared/canvas-colors'
+import { DRAG_THRESHOLD } from '../../shared/gesture-utils'
 import { InlineEditLabel } from '../shared/InlineEditLabel'
 import { startOptionAwareGroupDrag, type DragCopyPreviewBox } from './optionDragCopy'
-
-const GROUP_DRAG_THRESHOLD = 4
 
 export function GroupRenameOverlay({
   api,
@@ -87,9 +85,6 @@ function GroupRenameItem({
   // coordinate space; subtract canvasOrigin.y to drop into overlay coords.
   const left = group.screenX
   const top = group.screenY - layoutData.canvasOrigin.y
-  // Suppress per-page React thinks-unused warning by referencing the resolved
-  // colour for future styling extension; today we lean on existing tokens.
-  void resolveCanvasColor
 
   const onPointerDown = isRenaming
     ? (event: React.PointerEvent) => event.stopPropagation()
@@ -111,8 +106,8 @@ function GroupRenameItem({
           const totalDy = ev.screenY - startY
           if (
             !dragging &&
-            Math.abs(totalDx) < GROUP_DRAG_THRESHOLD &&
-            Math.abs(totalDy) < GROUP_DRAG_THRESHOLD
+            Math.abs(totalDx) < DRAG_THRESHOLD &&
+            Math.abs(totalDy) < DRAG_THRESHOLD
           ) {
             return
           }

--- a/src/renderer/above-view/SelectionOutlineLayer.tsx
+++ b/src/renderer/above-view/SelectionOutlineLayer.tsx
@@ -21,19 +21,7 @@ import type {
   LayoutUpdateData,
 } from '../../shared/types'
 import { selectionColor } from '../canvas-bg/canvasBgConstants'
-import { aspectRatioResizeModeForCanvasFile } from '../canvas-bg/entityConstants'
-import {
-  MIN_FILE_HEIGHT,
-  MIN_FILE_WIDTH,
-  MIN_GROUP_HEIGHT,
-  MIN_GROUP_WIDTH,
-  MIN_SHAPE_HEIGHT,
-  MIN_SHAPE_WIDTH,
-  MIN_TEXT_HEIGHT,
-  MIN_TEXT_WIDTH,
-} from '../canvas-bg/entityConstants'
 import { MULTI_SELECTION_OUTLINE_PADDING_PX } from '../../shared/canvas-hit-geometry'
-import { entityResizesAutomatically } from '../../shared/hit-test'
 import { CornerResizeHandle, EdgeResizeHandle } from '../canvas-bg/ResizeHandles'
 import { SelectionResizeGrid } from '../canvas-bg/SelectionResizeGrid'
 
@@ -45,7 +33,6 @@ interface PageOutlineProps {
 }
 
 function PageSelectionOverlay({ page, originY, isDark, showResizeHandles }: PageOutlineProps) {
-  const zoom = page.width > 0 ? page.screenWidth / page.width : 1
   return (
     <div
       className="absolute border-2"
@@ -60,20 +47,7 @@ function PageSelectionOverlay({ page, originY, isDark, showResizeHandles }: Page
       data-overlay-ui
     >
       {showResizeHandles ? (
-        <SelectionResizeGrid
-          id={page.id}
-          width={page.width}
-          height={page.height}
-          canvasX={page.canvasX}
-          canvasY={page.canvasY}
-          zoom={zoom}
-          minWidth={320}
-          minHeight={200}
-          onResize={() => {
-            /* hit-test in router drives resize; visual handles only */
-          }}
-          isDark={isDark}
-        />
+        <SelectionResizeGrid isDark={isDark} />
       ) : null}
     </div>
   )
@@ -125,26 +99,6 @@ function EntitySelectionOverlay({
   isSelected,
   showResizeHandles,
 }: EntityOutlineProps) {
-  const minWidth =
-    entity.kind === 'text'
-      ? MIN_TEXT_WIDTH
-      : entity.kind === 'file'
-        ? MIN_FILE_WIDTH
-        : entity.kind === 'shape'
-          ? MIN_SHAPE_WIDTH
-          : 16
-  const minHeight =
-    entity.kind === 'text'
-      ? MIN_TEXT_HEIGHT
-      : entity.kind === 'file'
-        ? MIN_FILE_HEIGHT
-        : entity.kind === 'shape'
-          ? MIN_SHAPE_HEIGHT
-          : 16
-  const aspectRatioResizeMode =
-    entity.kind === 'file' ? aspectRatioResizeModeForCanvasFile(entity.file) : 'off'
-  const zoom = entity.width > 0 ? entity.screenWidth / entity.width : 1
-
   return (
     <div
       className="absolute border-2"
@@ -161,21 +115,7 @@ function EntitySelectionOverlay({
       data-overlay-ui
     >
       {isSelected && showResizeHandles ? (
-        <SelectionResizeGrid
-          id={entity.id}
-          width={entity.width}
-          height={entity.height}
-          canvasX={entity.canvasX}
-          canvasY={entity.canvasY}
-          zoom={zoom}
-          minWidth={minWidth}
-          minHeight={minHeight}
-          onResize={() => {
-            /* hit-test in router drives resize; visual handles only */
-          }}
-          aspectRatioResizeMode={aspectRatioResizeMode}
-          isDark={isDark}
-        />
+        <SelectionResizeGrid isDark={isDark} />
       ) : null}
     </div>
   )
@@ -254,7 +194,6 @@ function GroupSelectionOverlay({
   originY: number
   isDark: boolean
 }) {
-  const zoom = group.width > 0 ? group.screenWidth / group.width : 1
   return (
     <div
       className="absolute border-2"
@@ -269,20 +208,7 @@ function GroupSelectionOverlay({
         pointerEvents: 'none',
       }}
     >
-      <SelectionResizeGrid
-        id={group.id}
-        width={group.width}
-        height={group.height}
-        canvasX={group.canvasX}
-        canvasY={group.canvasY}
-        zoom={zoom}
-        minWidth={MIN_GROUP_WIDTH}
-        minHeight={MIN_GROUP_HEIGHT}
-        onResize={() => {
-          /* hit-test in router drives resize; visual handles only */
-        }}
-        isDark={isDark}
-      />
+      <SelectionResizeGrid isDark={isDark} />
     </div>
   )
 }
@@ -448,7 +374,7 @@ export function SelectionOutlineLayer({
             borderRadius={borderRadius}
             isDark={isDark}
             isSelected={isSelected}
-            showResizeHandles={!isMultiSelect && !entityResizesAutomatically(entity)}
+            showResizeHandles={!isMultiSelect}
           />
         )
       })}

--- a/src/renderer/above-view/useCanvasPointerRouter.ts
+++ b/src/renderer/above-view/useCanvasPointerRouter.ts
@@ -52,6 +52,7 @@ import {
 } from '../../shared/multi-resize-accumulator'
 import {
   entitiesOverlappingRect,
+  DRAG_THRESHOLD,
   isOverlayUiTarget,
   isTypingTarget,
   middleDragDelta,
@@ -138,10 +139,16 @@ const ALL_KINDS: ReadonlySet<CanvasPointerAction['kind']> = new Set<CanvasPointe
  *  and edge gestures. */
 export const FULL_ROUTER_CONSUME = ALL_KINDS
 
-const GROUP_DRAG_THRESHOLD = 4
-const MARQUEE_DRAG_THRESHOLD = 4
-const PAGE_BODY_DRAG_THRESHOLD = 4
-const ENTITY_PRESS_DRAG_THRESHOLD = GROUP_DRAG_THRESHOLD
+function layoutToHitInputs(layout: { entities: HitInputs['entities']; edges?: HitInputs['edges'] | null; selectedEntityIds: HitInputs['selectedEntityIds']; selectedGroupId?: string | null; hover?: { id: string } | null; zoom?: number | null }): HitInputs {
+  return {
+    entities: layout.entities,
+    edges: layout.edges ?? [],
+    selectedEntityIds: layout.selectedEntityIds,
+    selectedGroupId: layout.selectedGroupId ?? null,
+    hoveredEntityId: layout.hover?.id ?? null,
+    zoom: layout.zoom ?? 1,
+  }
+}
 
 function capturePointer(event: PointerEvent): (() => void) | null {
   const target = event.target
@@ -201,14 +208,7 @@ export function useCanvasPointerRouter(options: UseCanvasPointerRouterOptions): 
       // aboveView's WCV starts at canvasOrigin.y; scene entities use
       // window-relative screenY, so add the offset before hit-testing.
       const windowY = event.clientY + layout.canvasOrigin.y
-      const inputs: HitInputs = {
-        entities: layout.entities,
-        edges: layout.edges ?? [],
-        selectedEntityIds: layout.selectedEntityIds,
-        selectedGroupId: layout.selectedGroupId ?? null,
-        hoveredEntityId: layout.hover?.id ?? null,
-        zoom: layout.zoom ?? 1,
-      }
+      const inputs = layoutToHitInputs(layout)
       const target = hitTest(inputs, { x: event.clientX, y: windowY })
 
       // Inline-edit outside-click (primary button) commits the active edit
@@ -285,17 +285,7 @@ export function useCanvasPointerRouter(options: UseCanvasPointerRouterOptions): 
       const layout = layoutRef.current
       if (layout.viewMode !== 'canvas') return
       const windowY = event.clientY + layout.canvasOrigin.y
-      const target = hitTest(
-        {
-          entities: layout.entities,
-          edges: layout.edges ?? [],
-          selectedEntityIds: layout.selectedEntityIds,
-          selectedGroupId: layout.selectedGroupId ?? null,
-          hoveredEntityId: layout.hover?.id ?? null,
-          zoom: layout.zoom ?? 1,
-        },
-        { x: event.clientX, y: windowY },
-      )
+      const target = hitTest(layoutToHitInputs(layout), { x: event.clientX, y: windowY })
       const action = routePointerDoubleClick(target)
       switch (action.kind) {
         case 'noop':
@@ -441,8 +431,8 @@ function runEntityPress(
       const totalDx = ev.screenX - startScreenX
       const totalDy = ev.screenY - startScreenY
       if (
-        Math.abs(totalDx) < ENTITY_PRESS_DRAG_THRESHOLD &&
-        Math.abs(totalDy) < ENTITY_PRESS_DRAG_THRESHOLD
+        Math.abs(totalDx) < DRAG_THRESHOLD &&
+        Math.abs(totalDy) < DRAG_THRESHOLD
       ) {
         return
       }
@@ -519,8 +509,8 @@ function runPageBodyPress(
     const totalDy = ev.screenY - startScreenY
     if (
       !dragging &&
-      Math.abs(totalDx) < PAGE_BODY_DRAG_THRESHOLD &&
-      Math.abs(totalDy) < PAGE_BODY_DRAG_THRESHOLD
+      Math.abs(totalDx) < DRAG_THRESHOLD &&
+      Math.abs(totalDy) < DRAG_THRESHOLD
     ) {
       return
     }
@@ -602,8 +592,8 @@ function runGroupDrag(
     const totalDy = ev.screenY - startScreenY
     if (
       !dragging &&
-      Math.abs(totalDx) < GROUP_DRAG_THRESHOLD &&
-      Math.abs(totalDy) < GROUP_DRAG_THRESHOLD
+      Math.abs(totalDx) < DRAG_THRESHOLD &&
+      Math.abs(totalDy) < DRAG_THRESHOLD
     ) {
       return
     }
@@ -921,7 +911,7 @@ function runBackgroundSelectionGesture(
     if (!dragged) {
       const dx = ev.clientX - startClientX
       const dy = ev.clientY - startClientY
-      if (Math.abs(dx) < MARQUEE_DRAG_THRESHOLD && Math.abs(dy) < MARQUEE_DRAG_THRESHOLD) return
+      if (Math.abs(dx) < DRAG_THRESHOLD && Math.abs(dy) < DRAG_THRESHOLD) return
       dragged = true
     }
     const layout = layoutRef.current

--- a/src/renderer/canvas-bg/SelectionResizeGrid.tsx
+++ b/src/renderer/canvas-bg/SelectionResizeGrid.tsx
@@ -1,4 +1,3 @@
-import type { AspectRatioResizeMode, EntityResizePatch } from './entityConstants'
 import { CornerResizeHandle, EdgeResizeHandle } from './ResizeHandles'
 
 /**
@@ -6,21 +5,7 @@ import { CornerResizeHandle, EdgeResizeHandle } from './ResizeHandles'
  * selected entity. It is visual-only; canvas resize gestures are routed
  * through aboveView's canvas pointer router.
  */
-export function SelectionResizeGrid({
-  isDark,
-}: {
-  id: string
-  width: number
-  height: number
-  canvasX: number
-  canvasY: number
-  zoom: number
-  minWidth: number
-  minHeight: number
-  onResize: (id: string, patch: EntityResizePatch) => void
-  aspectRatioResizeMode?: AspectRatioResizeMode
-  isDark: boolean
-}) {
+export function SelectionResizeGrid({ isDark }: { isDark: boolean }) {
   return (
     <>
       <EdgeResizeHandle edge="top" />

--- a/src/renderer/canvas-bg/entityConstants.ts
+++ b/src/renderer/canvas-bg/entityConstants.ts
@@ -22,8 +22,15 @@ export {
   WIREFRAME_EXTENSIONS,
   HTML_EXTENSIONS,
 } from '../../shared/file-extensions'
-import { IMAGE_EXTENSIONS, VIDEO_EXTENSIONS } from '../../shared/file-extensions'
+import { IMAGE_EXTENSIONS, VIDEO_EXTENSIONS, MARKDOWN_EXTENSIONS, WIREFRAME_EXTENSIONS } from '../../shared/file-extensions'
 import { RESIZE_HANDLE_VISUAL_PX } from '../../shared/canvas-hit-geometry'
+
+export function fileDisplayName(file: string): string {
+  const base = file.split('/').pop() ?? file
+  if (WIREFRAME_EXTENSIONS.test(file)) return base.replace(/\.wireframe\.json$/i, '')
+  if (MARKDOWN_EXTENSIONS.test(file)) return base.replace(/\.md$/i, '')
+  return base
+}
 
 /** Images/videos: lock aspect unless Shift. Other files: free resize unless Shift (then lock). */
 export function aspectRatioResizeModeForCanvasFile(filePath: string): AspectRatioResizeMode {

--- a/src/shared/drag-ids.ts
+++ b/src/shared/drag-ids.ts
@@ -8,6 +8,3 @@ export function newDragId(): DragId {
   return `drag_${Date.now().toString(36)}_${counter.toString(36)}_${rand}` as DragId
 }
 
-function isDragId(value: unknown): value is DragId {
-  return typeof value === 'string' && value.startsWith('drag_')
-}

--- a/src/shared/gesture-utils.ts
+++ b/src/shared/gesture-utils.ts
@@ -1,5 +1,8 @@
-import type { CanvasSceneEntity, LayoutUpdateData } from './types'
+import type { CanvasInteractionState, CanvasSceneEntity, LayoutUpdateData } from './types'
+import type { InteractionMode } from './interaction-types'
 import { GRID_SIZE } from './constants'
+
+export const DRAG_THRESHOLD = 4
 
 export {
   canvasToScreenX,
@@ -144,16 +147,18 @@ export function isPlainShortcutKey(
   return event.key.toLowerCase() === key.toLowerCase() && hasNoModifierKeys(event)
 }
 
-function isCommandShortcutKey(
-  event: Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>,
-  key: string,
-): boolean {
-  return (
-    event.key.toLowerCase() === key.toLowerCase() &&
-    (event.metaKey || event.ctrlKey) &&
-    !event.altKey &&
-    !event.shiftKey
-  )
+export function canvasInteractionModeKind(state: CanvasInteractionState): InteractionMode['kind'] {
+  switch (state.kind) {
+    case 'idle': return 'idle'
+    case 'panning-canvas': return 'panning'
+    case 'marquee-select': return 'marquee'
+    case 'dragging-entities': return 'dragging-entities'
+    case 'resizing-entity': return 'resizing-entity'
+    case 'resizing-multi-selection': return 'resizing-multi-selection'
+    case 'dragging-edge': return 'dragging-edge'
+    case 'editing-entity': return 'editing-entity'
+    case 'reordering-row': return 'reordering-row'
+  }
 }
 
 export function classifyViewportWheel(event: Pick<WheelEvent, 'metaKey' | 'ctrlKey' | 'deltaX' | 'deltaY' | 'screenX' | 'screenY'>): ViewportWheelAction {

--- a/src/shared/hit-test.ts
+++ b/src/shared/hit-test.ts
@@ -173,18 +173,9 @@ function collectResizeHandles(inputs: HitInputs): HitTarget[] {
   if (inputs.selectedGroupId) selected.add(inputs.selectedGroupId)
   for (const entity of inputs.entities) {
     if (!selected.has(entity.id)) continue
-    if (entityResizesAutomatically(entity)) continue
     pushPerEntityHandles(out, entity)
   }
   return out
-}
-
-// Reserved for entities whose bounds are purely content-driven and should
-// never show manual resize handles. Plain text in 'auto' widthMode used to
-// qualify, but resize is now wired to flip 'auto' → 'fixed' on drag-begin,
-// so it can be handled like any other entity.
-export function entityResizesAutomatically(_entity: CanvasSceneEntity): boolean {
-  return false
 }
 
 function pushPerEntityHandles(out: HitTarget[], entity: CanvasSceneEntity): void {

--- a/src/shared/interaction-priority.ts
+++ b/src/shared/interaction-priority.ts
@@ -28,6 +28,3 @@ export const HIT_LAYER_ORDER: readonly HitLayer[] = [
   'background',
 ] as const
 
-function compareLayers(a: HitLayer, b: HitLayer): number {
-  return HIT_LAYER_ORDER.indexOf(a) - HIT_LAYER_ORDER.indexOf(b)
-}


### PR DESCRIPTION
Closes #231

## Dead code removed

- `compareLayers` from `interaction-priority.ts` (private, zero callers)
- `isDragId` from `drag-ids.ts` (private, zero callers)
- `isCommandShortcutKey` from `gesture-utils.ts` (private, zero callers)
- `update()` export from `interaction-controller.ts` (exported but uncalled Phase-5 stub)
- `entityResizesAutomatically` always-false stub from `hit-test.ts`; inlined `false` at the one call site in `collectResizeHandles` (guard was never-true)
- Unused props on `SelectionResizeGrid` (`id`, `width`, `height`, `canvasX`, `canvasY`, `zoom`, `minWidth`, `minHeight`, `onResize`, `aspectRatioResizeMode`); trimmed all call sites in `SelectionOutlineLayer` and removed the now-dead computed vars and their imports
- `void resolveCanvasColor` speculative import in `GroupRenameLabel.tsx`

## Small dedups landed

- **(a)** Shared `canvasInteractionModeKind(state)` in `gesture-utils.ts` replaces identical switch tables in `interactionModeKey` (`focus-reconciler-runtime.ts`) and `predicateInteractionKind` (`selection-controller.ts`)
- **(b)** `fileDisplayName(file)` in `entityConstants.ts` replaces duplicated basename + suffix-strip in `FileChrome.tsx` and `FilePopup.tsx`
- **(c)** `layoutToHitInputs(layout)` helper in `useCanvasPointerRouter.ts` replaces two identical `HitInputs` literal constructions
- **(d)** `DRAG_THRESHOLD = 4` exported from `gesture-utils.ts` replaces four module-local constants in `useCanvasPointerRouter.ts` plus local copies in `GroupRenameLabel.tsx` (`GROUP_DRAG_THRESHOLD`) and `App.tsx` (`COMMENT_DRAG_THRESHOLD`)

## Verification

- `pnpm typecheck`: no new errors in changed files
- `pnpm test:unit`: 686/686 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_015Edx7E4JRo9xtsycpYyzJA)_