### PR TITLE
Add PolyForm Shield 1.0.0 license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,157 @@
+# PolyForm Shield License 1.0.0
+
+<https://polyformproject.org/licenses/shield/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Lyle Klyne (https://github.com/lklyne/specular)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncompete
+
+Any purpose is a permitted purpose, except for providing any
+product that competes with the software or any product the
+licensor or any of its affiliates provides using the software.
+
+## Competition
+
+Goods and services compete even when they provide functionality
+through different technical means.
+
+## New Products
+
+If you make a new product based on the software, you may not use
+that product to compete with the software or any product the
+licensor or any of its affiliates provides using the software.
+
+## Discontinued Products
+
+You may begin using the software to compete with a product
+or service that the licensor or any of its affiliates has
+stopped providing, unless the licensor includes a plain-text
+line beginning with `Licensor Line of Business:` with the
+software that mentions that line of business.  For example:
+
+> Licensor Line of Business: 1-800-555-1212 directory-assistance
+> services
+
+## Sales of Business
+
+If the licensor or any of its affiliates sells a line of
+business developing the software or using the software to
+provide a product, the buyer can also enforce [Noncompete](#noncompete)
+for that product.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law.  These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+A **product** can be a good or service, or a combination
+of them.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+its affiliates.
+
+**Affiliates** means the other organizations than an
+organization has control over, is under the control of, or is
+under common control with.
+
+**Control** means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies
+by vote, contract, or otherwise.  Control can be direct or
+indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.
+
+---
+
+Copyright © 2026 Lyle Klyne

--- a/README.md
+++ b/README.md
@@ -1,35 +1,29 @@
 # Specular
 
-Part web browser and part canvas, specular is a hybrid design tool for thinking through ideas spatially and iterating on software. 
+Part web browser and part canvas, specular is a hybrid design tool for thinking through ideas spatially and iterating on software.
 
-Code is the source of truth for making ideas real, but long chat threads and single browser tabs aren't ideal for the exploratory, divergent, and visual thinking that's often required to design something great. A canvas is a much more familiar place for this type of work, but there's a gap between what you see on the canvas and what is built. There's lots of products and tools that bridge this gap in a variety of ways, but there's always some level of friction moving back and forth between canvas and code.
-
-Specular sidesteps this with a different approach: full-featured browser tabs on a canvas. The actual website, product, or prototype lives spatially alongside notes, images, and drawings making it easy to build and explore in one place.
-
-All this stuff is designed with collaboration in mind, so it's easy to vibe out designs, research, and more as you work with teams of people and agents.
+Code is the source of truth for making ideas real, but long chat threads and single browser tabs aren't great for the exploratory, divergent thinking that designing something great requires. A canvas fits that work better — but there's usually friction moving back and forth between canvas and code. Specular sidesteps it with full-featured browser tabs on a canvas: the actual website, product, or prototype lives spatially alongside notes, images, and drawings, designed so people and agents can vibe out designs and research in one place.
 
 <!-- TODO: Add screenshot or GIF demo here -->
 
-## Some ways you can use this
-1. Explore different directions and see them all side-by-side
-2. Annotate live websites with feedback and pass that directly back to an agent
-3. Create layouts with different device breakpoints to check responsiveness
-4. Ask an agent to share its thinking visually
-5. Add a repo and ingest its design system
-6. Switch to browser mode for a more classic tab-based browser
+## What you can do
+
+- Explore different directions and see them side-by-side
+- Annotate live websites and pass the feedback straight back to an agent
+- Lay out a page at multiple device breakpoints to check responsiveness
+- Ask an agent to share its thinking visually, or ingest a repo's design system
+- Switch to browser mode for a classic tab-based browser
 
 ## Key features
 
-- **Canvas** — Arrange real browser windows on an infinite, zoomable canvas.
-- **Agent-friendly** — Agents drive the canvas through a `specular` CLI (primary) or an MCP server (fallback) — creating frames, navigating, inspecting the DOM, clicking, typing, and taking screenshots
+- **Canvas** — Real browser windows on an infinite, zoomable canvas
+- **Agent-friendly** — Agents drive the canvas through a `specular` CLI (primary) or MCP server (fallback): creating frames, navigating, inspecting the DOM, clicking, typing, screenshotting
 - **Agent presence** — See an agent's live cursor and task status as it works alongside you
-- **Commenting & annotations** — Create annotations on any frame, usable by people and agents
-- **Device frames** — Preview sites at preset device sizes (iPhone, iPad, Laptop, etc.) with visual device shells
-- **Groups & layout** — Organize frames into groups with freeform, row, or grid layout modes
-- **Edges & connections** — Draw connections between entities on the canvas
-- **Undo/redo** — Full undo history backed by Yjs CRDTs
-- **Local-first storage** — No sign-in, no account. All files live on your computer
-- **Open file formats** — Canvas layout uses the [JSON Canvas](https://jsoncanvas.org) spec (also used by Obsidian); text and media are plain `.md`, `.png`, and `.webm` files that live on your computer in a folder.
+- **Annotations** — Comment on any frame, usable by people and agents
+- **Device frames** — Preview sites at preset device sizes with visual device shells
+- **Groups & edges** — Organize frames into freeform/row/grid groups and draw connections between them
+- **Local-first** — No sign-in, no account; full undo history backed by Yjs CRDTs
+- **Open formats** — Layout uses [JSON Canvas](https://jsoncanvas.org); text and media are plain `.md`, `.png`, and `.webm` files on disk
 
 ## Inspiration and related products
 - [Paper](https://paper.design): imo the best full-featured design tool with agent collaboration
@@ -51,11 +45,7 @@ Updates are delivered automatically via `update-electron-app`. You'll be prompte
 
 ## Using with AI agents
 
-Specular is designed to be driven by agents as a first-class collaborator. There are two ways in:
-
-### CLI (primary)
-
-The `specular` CLI is the main interface for agents. It exposes the full canvas surface — creating and arranging frames, snapshotting the DOM, clicking and filling fields, leaving annotations, and more — as composable commands that fit naturally into an agent's working loop.
+The `specular` CLI is the main interface for agents — composable commands that fit an agent's working loop:
 
 ```bash
 specular workspace                       # inspect the current canvas
@@ -64,11 +54,7 @@ specular snapshot -i                     # get element refs for the selected fra
 specular annotate "<feedback>"           # leave a comment for a human or agent
 ```
 
-A Claude Code skill ships with the app so agents know how to use it. See [`resources/skills/specular/SKILL.md`](resources/skills/specular/SKILL.md) for the full command surface.
-
-### MCP server (fallback)
-
-An MCP server is also available for clients that prefer the Model Context Protocol. It covers the same core operations as the CLI. See the [MCP tools source](src/main/mcp-tools.ts) for the tool list.
+A Claude Code skill ships with the app — see [`resources/skills/specular/SKILL.md`](resources/skills/specular/SKILL.md) for the full surface. An [MCP server](src/main/mcp-tools.ts) covers the same operations for clients that prefer it.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -73,3 +73,7 @@ An MCP server is also available for clients that prefer the Model Context Protoc
 ## Security
 
 To report a security vulnerability, see [SECURITY.md](SECURITY.md).
+
+## License
+
+Licensed under [PolyForm Shield 1.0.0](LICENSE.md). Copyright © 2026 Lyle Klyne.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "https://github.com/lklyne/specular.git"
   },
+  "license": "PolyForm-Shield-1.0.0",
   "main": ".vite/build/index.js",
   "config": {
     "forge": "./forge.config.ts"


### PR DESCRIPTION
Adds source-available licensing under PolyForm Shield 1.0.0.

- `LICENSE.md` — canonical PolyForm Shield 1.0.0 text, copyright © 2026 Lyle Klyne
- `package.json` — `"license": "PolyForm-Shield-1.0.0"`
- `README.md` — License section

Note: PolyForm Shield is source-available, not OSI-approved — GitHub will label it "Other".

🤖 Generated with [Claude Code](https://claude.com/claude-code)