### PR TITLE
perf: build canvas layout data once per layout pass instead of twice

### DIFF
--- a/src/main/runtime/canvas-layout-data.ts
+++ b/src/main/runtime/canvas-layout-data.ts
@@ -221,11 +221,7 @@ export function selectedComponentTreePayload():
   return { pageId, tree: page.componentTree ?? [] }
 }
 
-export function sendAnnotationLayoutUpdate(data: {
-  pages: CanvasScenePageEntity[]
-  activeSelection: ActiveCanvasEntitySelection | null
-}): void {
-  const payload = buildCanvasLayoutData(data.pages, data.activeSelection)
+export function sendAnnotationLayoutUpdate(payload: LayoutUpdateData): void {
   if (aboveView) safeSend(aboveView.webContents, 'layout-update', payload)
   if (cursorOverlayWindow && !cursorOverlayWindow.isDestroyed()) {
     safeSend(cursorOverlayWindow.webContents, 'layout-update', payload)

--- a/src/main/runtime/layout-engine.ts
+++ b/src/main/runtime/layout-engine.ts
@@ -234,14 +234,9 @@ function layoutAllViews(): void {
     const bgWidth = Math.max(0, width - (devtoolsOpen ? devtoolsWidth : 0))
     layoutCache.lastBackgroundBoundsKey = setBoundsIfChanged(bgView, { x: 0, y: 0, width: bgWidth, height }, layoutCache.lastBackgroundBoundsKey)
     if (consumeDirty('canvas')) {
-      bgView.webContents.send(
-        'layout-update',
-        buildCanvasLayoutData(pageOverlays, nextActiveSelection),
-      )
-      sendAnnotationLayoutUpdate({
-        pages: pageOverlays,
-        activeSelection: nextActiveSelection,
-      })
+      const layoutData = buildCanvasLayoutData(pageOverlays, nextActiveSelection)
+      bgView.webContents.send('layout-update', layoutData)
+      sendAnnotationLayoutUpdate(layoutData)
       bgView.webContents.send('component-tree-data', selectedComponentTreePayload())
     }
   }

--- a/src/main/runtime/window-init.ts
+++ b/src/main/runtime/window-init.ts
@@ -204,11 +204,9 @@ export function initWindow(): void {
     currentBgView.webContents.send('theme-changed', { isDark: isDark() })
     const pageOverlays = backgroundPageOverlays()
     const nextActiveSelection = activeCanvasSelection()
-    currentBgView.webContents.send('layout-update', buildCanvasLayoutData(pageOverlays, nextActiveSelection))
-    sendAnnotationLayoutUpdate({
-      pages: pageOverlays,
-      activeSelection: nextActiveSelection,
-    })
+    const initialLayoutData = buildCanvasLayoutData(pageOverlays, nextActiveSelection)
+    currentBgView.webContents.send('layout-update', initialLayoutData)
+    sendAnnotationLayoutUpdate(initialLayoutData)
     currentBgView.webContents.send('component-tree-data', selectedComponentTreePayload())
     // The renderer subscribes to layout updates during mount, so send one more
     // pass on the next tick to avoid dropping the initial canvas paint.
@@ -253,10 +251,7 @@ export function initWindow(): void {
     currentAboveView.webContents.send('theme-changed', { isDark: isDark() })
     const pageOverlays = backgroundPageOverlays()
     const nextActiveSelection = activeCanvasSelection()
-    sendAnnotationLayoutUpdate({
-      pages: pageOverlays,
-      activeSelection: nextActiveSelection,
-    })
+    sendAnnotationLayoutUpdate(buildCanvasLayoutData(pageOverlays, nextActiveSelection))
     layoutCache.lastCommentOverlayBoundsKey = null
     requestLayout()
   })


### PR DESCRIPTION
Closes #257

## What

`buildCanvasLayoutData` was being called twice on every layout pass that touched the canvas:

1. Once to build the payload for `bgView` (canvas-bg renderer)
2. Again inside `sendAnnotationLayoutUpdate` for `aboveView` and `cursorOverlayWindow`

Both calls used the same inputs (`pageOverlays`, `activeSelection`) at the same point in time, so they produced identical payloads.

## Fix

Build the payload once and pass it to all senders. `sendAnnotationLayoutUpdate` now accepts a pre-built `LayoutUpdateData` instead of rebuilding internally. Applied the same pattern to the two initial-load call sites in `window-init.ts`.

## Impact

~2x reduction in `buildCanvasLayoutData` cost per layout pass. Since `buildCanvasLayoutData` rebuilds the full entity scene (all text/file/drawing/shape entities with screen coordinates, group membership scans, Y.Doc entity order read + sort) on every pan tick, this directly reduces selection border lag during pan — Option C from the issue analysis.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvaDC1WtUfzLhtaoComzpA)_