### PR TITLE
Page panel header controls + comment overlay & fix-agent polish

### DIFF
--- a/src/main/agent-fix/claude-spawner.ts
+++ b/src/main/agent-fix/claude-spawner.ts
@@ -130,37 +130,28 @@ export function invokeClaude(
   })
 }
 
+const RESOLVE_MARKER = '<<RESOLVE>>'
+const WAITING_MARKER = '<<WAITING>>'
+// The agent's whole final message is shown to the user verbatim; the marker
+// only carries the resolve/waiting hint. Cap as a runaway guard — the prompt
+// asks for brevity.
+const MAX_REPLY_CHARS = 2000
+
 export function parseOutput(stdout: string): { summary: string; shouldResolve: boolean } {
-  const lines = stdout.split(/\r?\n/).map((line) => line.trim()).filter((line) => line.length > 0)
-  if (lines.length === 0) {
+  const text = stdout.trim()
+  if (!text) {
     return { summary: '(no output)', shouldResolve: false }
   }
-  let markerIndex = -1
-  let shouldResolve = false
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i]
-    if (line === '<<RESOLVE>>' || line.endsWith('<<RESOLVE>>')) {
-      markerIndex = i
-      shouldResolve = true
-      break
-    }
-    if (line === '<<WAITING>>' || line.endsWith('<<WAITING>>')) {
-      markerIndex = i
-      shouldResolve = false
-      break
-    }
+  // Last marker wins; everything before it is the user-facing answer.
+  const resolveIdx = text.lastIndexOf(RESOLVE_MARKER)
+  const waitingIdx = text.lastIndexOf(WAITING_MARKER)
+  const markerIdx = Math.max(resolveIdx, waitingIdx)
+  if (markerIdx === -1) {
+    return { summary: truncate(text, MAX_REPLY_CHARS), shouldResolve: false }
   }
-  if (markerIndex === -1) {
-    return { summary: truncate(lines[lines.length - 1], 280), shouldResolve: false }
-  }
-  const markerLine = lines[markerIndex]
-  const markerToken = shouldResolve ? '<<RESOLVE>>' : '<<WAITING>>'
-  const inlineSummary = markerLine === markerToken
-    ? ''
-    : markerLine.slice(0, markerLine.length - markerToken.length).trim()
-  const summary = inlineSummary || (markerIndex > 0 ? lines[markerIndex - 1] : '')
+  const answer = text.slice(0, markerIdx).trim()
   return {
-    summary: truncate(summary || '(no summary)', 280),
-    shouldResolve,
+    summary: truncate(answer || '(no summary)', MAX_REPLY_CHARS),
+    shouldResolve: resolveIdx > waitingIdx,
   }
 }

--- a/src/main/agent-fix/fix-orchestrator.ts
+++ b/src/main/agent-fix/fix-orchestrator.ts
@@ -155,13 +155,13 @@ function handleCompletion(
     addAnnotationReply(annotationId, 'agent', `Fix failed: ${shortMessage}`)
     return
   }
+  // shouldResolve is the agent's own "I believe this is fixed" signal — kept on
+  // the progress entry as a hint, but resolving the thread is the user's call
+  // (the comment row's ⋮ → Resolve). We never auto-resolve.
   finalizeFixProgress(annotationId, 'completed', {
     summary: result.summary,
     shouldResolve: result.shouldResolve,
   })
   addAnnotationReply(annotationId, 'agent', result.summary)
-  if (result.shouldResolve) {
-    updateAnnotationStatus(annotationId, 'resolved', 'Auto-resolved by agent', 'agent')
-  }
 }
 

--- a/src/main/agent-fix/prompt-builder.ts
+++ b/src/main/agent-fix/prompt-builder.ts
@@ -1,6 +1,15 @@
 import type { Annotation } from '../../shared/types'
 import { truncate } from '../../shared/annotation-utils'
 
+const REPLY_FORMAT = [
+  'Reply format — REQUIRED:',
+  '- Your entire final message is the only thing the user sees, so keep it brief and self-contained — no references to your steps, tool output, or anything "above" they cannot see.',
+  '- End the message with one of:',
+  '  <<RESOLVE>>   if you have addressed the comment (made the change or answered it)',
+  '  <<WAITING>>   if you need more information from the user',
+  'Do not write anything after the marker.',
+]
+
 export function buildFixPrompt(annotation: Annotation): string {
   const lines: string[] = []
 
@@ -95,12 +104,7 @@ export function buildFixPrompt(annotation: Annotation): string {
   lines.push('Do not use chrome-devtools or any other browser automation tool — specular')
   lines.push('covers every case above and has the right page already focused.')
   lines.push('')
-  lines.push('Reply format — REQUIRED:')
-  lines.push('- Your entire final message is the only thing the user sees, so keep it brief and self-contained — no references to your steps, tool output, or anything "above" they cannot see.')
-  lines.push('- End the message with one of:')
-  lines.push('  <<RESOLVE>>   if you have addressed the comment (made the change or answered it)')
-  lines.push('  <<WAITING>>   if you need more information from the user')
-  lines.push('Do not write anything after the marker.')
+  lines.push(...REPLY_FORMAT)
 
   return lines.join('\n')
 }
@@ -118,12 +122,7 @@ export function buildFollowUpPrompt(replyText: string): string {
     'Continue the thread — make a change if it calls for one, or just answer if it is a question.',
     'Use the specular skill to inspect the live page as before.',
     '',
-    'Reply format — REQUIRED:',
-    '- Your entire final message is the only thing the user sees, so keep it brief and self-contained — no references to your steps, tool output, or anything "above" they cannot see.',
-    '- End the message with one of:',
-    '  <<RESOLVE>>   if you have addressed the comment (made the change or answered it)',
-    '  <<WAITING>>   if you need more information from the user',
-    'Do not write anything after the marker.',
+    ...REPLY_FORMAT,
   ].join('\n')
 }
 

--- a/src/main/agent-fix/prompt-builder.ts
+++ b/src/main/agent-fix/prompt-builder.ts
@@ -4,7 +4,7 @@ import { truncate } from '../../shared/annotation-utils'
 export function buildFixPrompt(annotation: Annotation): string {
   const lines: string[] = []
 
-  lines.push('You are fixing a UI comment left on a live web page.')
+  lines.push('You are responding to a comment left on a live web page.')
   lines.push('')
 
   const pageUrl = annotation.metadata?.pageUrl
@@ -81,8 +81,9 @@ export function buildFixPrompt(annotation: Annotation): string {
   }
 
   lines.push('')
-  lines.push('Make the minimal code change in this repo to address the feedback.')
-  lines.push('Verify your change does not break typecheck when reasonable.')
+  lines.push('The comment may request a change or simply ask a question.')
+  lines.push('- If it calls for a change, make the minimal code change in this repo to address it, then verify typecheck when reasonable.')
+  lines.push('- If it is a question or needs no change, just answer it. Do not edit code only to have made a change.')
   lines.push('')
   lines.push('Inspecting the live page: the specular skill already has it open. Prefer:')
   lines.push('  specular snapshot -i -f <pageId>     # element refs + accessibility tree')
@@ -95,8 +96,9 @@ export function buildFixPrompt(annotation: Annotation): string {
   lines.push('covers every case above and has the right page already focused.')
   lines.push('')
   lines.push('Reply format — REQUIRED:')
-  lines.push('- Your final output MUST end with one short IM-style summary line (under 280 chars), then a newline, then one of:')
-  lines.push('  <<RESOLVE>>   if you believe the issue is now fixed')
+  lines.push('- Your entire final message is the only thing the user sees, so keep it brief and self-contained — no references to your steps, tool output, or anything "above" they cannot see.')
+  lines.push('- End the message with one of:')
+  lines.push('  <<RESOLVE>>   if you have addressed the comment (made the change or answered it)')
   lines.push('  <<WAITING>>   if you need more information from the user')
   lines.push('Do not write anything after the marker.')
 
@@ -113,11 +115,13 @@ export function buildFollowUpPrompt(replyText: string): string {
     'The user replied on the same comment thread:',
     `[User] ${message}`,
     '',
-    'Continue the fix. Use the specular skill to inspect the live page as before.',
+    'Continue the thread — make a change if it calls for one, or just answer if it is a question.',
+    'Use the specular skill to inspect the live page as before.',
     '',
     'Reply format — REQUIRED:',
-    '- End with one short IM-style summary line (under 280 chars), then a newline, then one of:',
-    '  <<RESOLVE>>   if you believe the issue is now fixed',
+    '- Your entire final message is the only thing the user sees, so keep it brief and self-contained — no references to your steps, tool output, or anything "above" they cannot see.',
+    '- End the message with one of:',
+    '  <<RESOLVE>>   if you have addressed the comment (made the change or answered it)',
     '  <<WAITING>>   if you need more information from the user',
     'Do not write anything after the marker.',
   ].join('\n')

--- a/src/main/ipc/register-comment-hover-ipc.ts
+++ b/src/main/ipc/register-comment-hover-ipc.ts
@@ -64,12 +64,13 @@ function payloadSignature(payload: {
   active: boolean
   pointer: { x: number; y: number } | null
   regionRect: { x: number; y: number; width: number; height: number } | null
+  displayScale?: number
 }): string {
   const p = payload.pointer ? `${payload.pointer.x},${payload.pointer.y}` : '-'
   const r = payload.regionRect
     ? `${payload.regionRect.x},${payload.regionRect.y},${payload.regionRect.width},${payload.regionRect.height}`
     : '-'
-  return `${payload.active ? '1' : '0'}|${p}|${r}`
+  return `${payload.active ? '1' : '0'}|${p}|${r}|${payload.displayScale ?? 1}`
 }
 
 function sendIfChanged(
@@ -79,6 +80,7 @@ function sendIfChanged(
     active: boolean
     pointer: { x: number; y: number } | null
     regionRect: { x: number; y: number; width: number; height: number } | null
+    displayScale?: number
   },
 ): void {
   const sig = payloadSignature(payload)
@@ -130,6 +132,9 @@ function broadcastPointerState(state: PointerStateInput): void {
       active: true,
       pointer,
       regionRect,
+      // cssScale = pageCSSpx / onScreenPx = 1 / displayZoom — the factor that
+      // counter-scales the in-page label back to a constant screen size.
+      displayScale: cssScale,
     })
   }
 }

--- a/src/main/ipc/register-right-details-panel-ipc.ts
+++ b/src/main/ipc/register-right-details-panel-ipc.ts
@@ -24,7 +24,7 @@ import {
   setFileDeviceOrientation,
   toggleFileDeviceShell,
 } from '../runtime/document-commands'
-import { navigatePage, togglePageLinked } from '../navigation-sync'
+import { togglePageLinked } from '../navigation-sync'
 import { deletePages } from '../workspace-entities'
 import { duplicatePageFromSource } from '../workspace-pages'
 import {
@@ -344,43 +344,7 @@ export function registerRightDetailsPanelIpc(): void {
     },
   )
 
-  // --- Page navigation & actions ---
-
-  ipcMain.on(
-    'right-details-panel-navigate-page',
-    (_event, payload: { pageId: string; url: string }) => {
-      const page = pages.find((p) => p.id === payload?.pageId)
-      if (!page) return
-      navigatePage(page, { type: 'load-url', url: payload.url })
-    },
-  )
-
-  ipcMain.on(
-    'right-details-panel-go-back-page',
-    (_event, payload: { pageId: string }) => {
-      const page = pages.find((p) => p.id === payload?.pageId)
-      if (!page) return
-      navigatePage(page, { type: 'go-back', fallbackUrl: page.pageView.webContents.getURL() })
-    },
-  )
-
-  ipcMain.on(
-    'right-details-panel-go-forward-page',
-    (_event, payload: { pageId: string }) => {
-      const page = pages.find((p) => p.id === payload?.pageId)
-      if (!page) return
-      navigatePage(page, { type: 'go-forward', fallbackUrl: page.pageView.webContents.getURL() })
-    },
-  )
-
-  ipcMain.on(
-    'right-details-panel-reload-page',
-    (_event, payload: { pageId: string }) => {
-      const page = pages.find((p) => p.id === payload?.pageId)
-      if (!page) return
-      navigatePage(page, { type: 'reload', fallbackUrl: page.pageView.webContents.getURL() })
-    },
-  )
+  // --- Page actions ---
 
   ipcMain.on(
     'right-details-panel-duplicate-page',

--- a/src/preload/canvas-bg.ts
+++ b/src/preload/canvas-bg.ts
@@ -249,6 +249,8 @@ const api: CanvasBgElectronAPI = {
     ipcRenderer.send('right-details-panel-resolve-annotation', { annotationId }),
   deleteAnnotation: (annotationId: string) =>
     ipcRenderer.send('right-details-panel-delete-annotation', { annotationId }),
+  fixSingleAnnotation: (annotationId: string) =>
+    ipcRenderer.send('right-details-panel-fix-single-annotation', { annotationId }),
   openAnnotationThread: (annotationId: string) =>
     ipcRenderer.send('annotation-open-thread', { annotationId }),
   setCommentOverlayActive: (active: boolean) =>

--- a/src/preload/comment-hover-overlay.ts
+++ b/src/preload/comment-hover-overlay.ts
@@ -88,7 +88,7 @@ function buildOutline(rect: DOMRect | { left: number; top: number; width: number
   return outline
 }
 
-function paintPointerElement(x: number, y: number): void {
+function paintPointerElement(x: number, y: number, labelScale: number): void {
   clearMarqueeLayer()
   const target = pickContentElementAtPoint(x, y)
   if (!target) {
@@ -96,7 +96,7 @@ function paintPointerElement(x: number, y: number): void {
     return
   }
   ensureDomInspectionOverlay()
-  updateDomInspectionOverlay(target, inspectionPayload(target))
+  updateDomInspectionOverlay(target, inspectionPayload(target), { labelScale })
 }
 
 function paintRegionIntersection(region: { x: number; y: number; width: number; height: number }): void {
@@ -154,7 +154,7 @@ function refresh(state: CommentToolPagePreviewState): void {
     return
   }
   if (state.pointer) {
-    paintPointerElement(state.pointer.x, state.pointer.y)
+    paintPointerElement(state.pointer.x, state.pointer.y, state.displayScale ?? 1)
     return
   }
   clearMarqueeLayer()
@@ -163,6 +163,7 @@ function refresh(state: CommentToolPagePreviewState): void {
 
 function statesEqual(a: CommentToolPagePreviewState, b: CommentToolPagePreviewState): boolean {
   if (a.active !== b.active) return false
+  if ((a.displayScale ?? 1) !== (b.displayScale ?? 1)) return false
   if ((a.pointer == null) !== (b.pointer == null)) return false
   if (a.pointer && b.pointer && (a.pointer.x !== b.pointer.x || a.pointer.y !== b.pointer.y)) {
     return false

--- a/src/preload/dom-inspection.ts
+++ b/src/preload/dom-inspection.ts
@@ -468,6 +468,9 @@ export function updateDomInspectionOverlay(
     pinnedElement?: Element | null
     pinnedPayload?: ReturnType<typeof inspectionPayload> | null
     showLabel?: boolean
+    /** Counter-scale (1 / displayZoom) so the label reads at a constant
+     *  on-screen size despite the webview being zoom-scaled. */
+    labelScale?: number
   },
 ): void {
   ensureDomInspectionOverlay()
@@ -515,6 +518,11 @@ export function updateDomInspectionOverlay(
 
   domInspectionLabelEl.style.display = 'block'
   buildLabelContent(domInspectionLabelEl, element, styles)
+  // Counter-scale before measuring so the clamp math uses the on-screen
+  // footprint. Origin top-left keeps the visual box anchored at left/top.
+  const labelScale = options?.labelScale ?? 1
+  domInspectionLabelEl.style.transformOrigin = '0 0'
+  domInspectionLabelEl.style.transform = labelScale === 1 ? '' : `scale(${labelScale})`
   const outerPadding = 2
   const labelRect = domInspectionLabelEl.getBoundingClientRect()
   const maxLeft = Math.max(outerPadding, window.innerWidth - Math.ceil(labelRect.width) - outerPadding)

--- a/src/preload/right-details-panel.ts
+++ b/src/preload/right-details-panel.ts
@@ -77,6 +77,7 @@ const api: DevtoolsPanelElectronAPI = {
     ipcRenderer.send('right-details-panel-set-device-orientation', { pageId, orientation }),
   toggleDeviceShell: (pageId: string) =>
     ipcRenderer.send('right-details-panel-toggle-device-shell', { pageId }),
+  focusSelection: () => ipcRenderer.send('canvas-focus-selection'),
   toggleSvgDeviceShell: (pageId: string) =>
     ipcRenderer.send('right-details-panel-toggle-svg-device-shell', { pageId }),
   navigatePage: (pageId: string, url: string) =>

--- a/src/preload/right-details-panel.ts
+++ b/src/preload/right-details-panel.ts
@@ -82,14 +82,6 @@ const api: DevtoolsPanelElectronAPI = {
   focusSelection: () => ipcRenderer.send('canvas-focus-selection'),
   toggleSvgDeviceShell: (pageId: string) =>
     ipcRenderer.send('right-details-panel-toggle-svg-device-shell', { pageId }),
-  navigatePage: (pageId: string, url: string) =>
-    ipcRenderer.send('right-details-panel-navigate-page', { pageId, url }),
-  goBackPage: (pageId: string) =>
-    ipcRenderer.send('right-details-panel-go-back-page', { pageId }),
-  goForwardPage: (pageId: string) =>
-    ipcRenderer.send('right-details-panel-go-forward-page', { pageId }),
-  reloadPage: (pageId: string) =>
-    ipcRenderer.send('right-details-panel-reload-page', { pageId }),
   duplicatePage: (pageId: string) =>
     ipcRenderer.send('right-details-panel-duplicate-page', { pageId }),
   toggleLinkedPage: (pageId: string) =>

--- a/src/preload/right-details-panel.ts
+++ b/src/preload/right-details-panel.ts
@@ -77,6 +77,8 @@ const api: DevtoolsPanelElectronAPI = {
     ipcRenderer.send('right-details-panel-set-device-orientation', { pageId, orientation }),
   toggleDeviceShell: (pageId: string) =>
     ipcRenderer.send('right-details-panel-toggle-device-shell', { pageId }),
+  // Reuses the global focus channel — the panel only surfaces the selected
+  // page, so "focus selection" and "focus this page" are the same action.
   focusSelection: () => ipcRenderer.send('canvas-focus-selection'),
   toggleSvgDeviceShell: (pageId: string) =>
     ipcRenderer.send('right-details-panel-toggle-svg-device-shell', { pageId }),

--- a/src/renderer/above-view/CommentBadgesLayer.tsx
+++ b/src/renderer/above-view/CommentBadgesLayer.tsx
@@ -16,8 +16,14 @@ interface CommentBadge {
   x: number
   y: number
   transform: string
+  opacity: number
   highlightRect?: { left: number; top: number; width: number; height: number }
 }
+
+// How far (screen px) an element-anchored badge may travel outside its page's
+// content band before it fully fades. Keeps badges from drifting onto the page
+// chrome above the frame or floating far off-page after scroll.
+const BADGE_FADE_MARGIN = 48
 
 export function CommentBadgesLayer({
   annotations,
@@ -45,7 +51,7 @@ export function CommentBadgesLayer({
     <>
       {hoveredBadge?.highlightRect ? (
         <div
-          className="pointer-events-none absolute z-[90]"
+          className="pointer-events-none absolute z-[14]"
           style={{
             left: hoveredBadge.highlightRect.left,
             top: hoveredBadge.highlightRect.top,
@@ -64,15 +70,18 @@ export function CommentBadgesLayer({
           type="button"
           data-overlay-ui="comment-badge"
           aria-label={`${badge.count} unresolved messages`}
-          className="pointer-events-auto absolute z-[100] inline-flex items-center gap-1.5 rounded-full border border-blue-300/90 bg-blue-500 px-2 py-1.5 text-[10px] font-semibold leading-none text-white shadow-[0_2px_6px_rgba(0,0,0,0.25)]"
+          className="pointer-events-auto absolute z-[15] inline-flex items-center gap-1.5 rounded-full border border-blue-300/90 bg-blue-500 px-2 py-1.5 text-[10px] font-semibold leading-none text-white shadow-[0_2px_6px_rgba(0,0,0,0.25)]"
           style={{
             left: badge.x,
             top: badge.y,
             transform: badge.transform,
+            opacity: badge.opacity,
+            pointerEvents: badge.opacity < 0.4 ? 'none' : undefined,
           }}
           onClick={(event) => {
             event.preventDefault()
             event.stopPropagation()
+            setHoveredKey(null)
             onOpenThread(badge.annotationId)
           }}
           onPointerEnter={() => setHoveredKey(badge.key)}
@@ -84,7 +93,7 @@ export function CommentBadgesLayer({
       ))}
       {hoveredBadge ? (
         <div
-          className="pointer-events-none absolute z-[110] w-[260px] whitespace-pre-wrap rounded-[14px] border border-zinc-400/80 bg-white px-2.5 py-2 text-[11px] leading-[1.4] text-zinc-900 shadow-[0_8px_16px_rgba(0,0,0,0.15)] dark:border-zinc-600 dark:bg-zinc-900 dark:text-zinc-100"
+          className="pointer-events-none absolute z-[19] w-[260px] whitespace-pre-wrap rounded-[14px] border border-zinc-400/80 bg-white px-2.5 py-2 text-[11px] leading-[1.4] text-zinc-900 shadow-[0_8px_16px_rgba(0,0,0,0.15)] dark:border-zinc-600 dark:bg-zinc-900 dark:text-zinc-100"
           style={{
             left: Math.max(8, Math.min(hoveredBadge.x - 240, window.innerWidth - 268)),
             top: Math.max(8, Math.min(hoveredBadge.y + 22, window.innerHeight - 108)),
@@ -140,6 +149,8 @@ export function commentBadgesForLayout(
       const page = pagesById.get(anchor.pageId)
       const rect = page ? elementAnnotationRect(annotation, page, layoutData, liveBboxes) : null
       if (!rect) continue
+      const opacity = page ? badgeOpacity(rect.top + 8, page, layoutData) : 1
+      if (opacity <= 0) continue
       badges.push({
         key,
         annotationId: annotation.id,
@@ -148,6 +159,7 @@ export function commentBadgesForLayout(
         x: rect.left + rect.width - 8,
         y: rect.top + 8,
         transform: 'translate(-100%, 0)',
+        opacity,
         highlightRect: rect,
       })
       continue
@@ -160,18 +172,41 @@ export function commentBadgesForLayout(
         Math.max(page.screenY + anchor.offsetY * page.screenHeight, page.screenY + 10),
         page.screenY + page.screenHeight - 10,
       )
+      const top = y - layoutData.canvasOrigin.y
+      const opacity = badgeOpacity(top, page, layoutData)
+      if (opacity <= 0) continue
       badges.push({
         key,
         annotationId: annotation.id,
         count: value.count,
         summary: annotation.text,
         x: rightX,
-        y: y - layoutData.canvasOrigin.y,
+        y: top,
         transform: 'translate(-100%, -50%)',
+        opacity,
       })
     }
   }
   return badges
+}
+
+// Fade a badge as its anchor point leaves the page's vertical content band.
+// Keyed on the badge's own y (the element's top edge / page offset), not the
+// element's full height — a tall element (e.g. #main) straddles the band even
+// when its anchored top has scrolled far out of view. Returns 1 inside the
+// band, ramps to 0 across BADGE_FADE_MARGIN of overflow, 0 beyond.
+function badgeOpacity(
+  anchorY: number,
+  page: CanvasScenePageEntity,
+  layoutData: LayoutUpdateData,
+): number {
+  const contentScreenY = page.contentScreenY ?? page.screenY
+  const contentScreenHeight = page.contentScreenHeight ?? page.screenHeight
+  const top = contentScreenY - layoutData.canvasOrigin.y
+  const bottom = top + contentScreenHeight
+  const overflow = Math.max(top - anchorY, anchorY - bottom, 0)
+  if (overflow <= 0) return 1
+  return Math.max(0, 1 - overflow / BADGE_FADE_MARGIN)
 }
 
 function elementAnnotationRect(

--- a/src/renderer/above-view/CommentsLayer.tsx
+++ b/src/renderer/above-view/CommentsLayer.tsx
@@ -5,6 +5,7 @@ import {
   type AnnotationLiveBboxLookup,
   type PendingAnnotation,
 } from './annotationMath'
+import { Play } from 'lucide-react'
 import { CircleCheckIcon, MoreVerticalIcon, TrashIcon } from '../shared/PanelIcons'
 import { CommentBubble, CommentInput } from '../shared/CommentPrimitives'
 import { FixEventList, fixStatusLabel } from '../shared/FixEventList'
@@ -230,7 +231,11 @@ export function AnnotationThreadPopover({
   threadInputRef,
   threadPosition,
 }: {
-  api: { deleteAnnotation: (annotationId: string) => void; resolveAnnotation: (annotationId: string) => void }
+  api: {
+    deleteAnnotation: (annotationId: string) => void
+    resolveAnnotation: (annotationId: string) => void
+    fixSingleAnnotation: (annotationId: string) => void
+  }
   closeThread: () => void
   drawCursor: string
   drawInteractionEnabled: boolean
@@ -286,6 +291,17 @@ export function AnnotationThreadPopover({
           >
             <div className="text-[12px] font-semibold">Comment</div>
             <div className="flex items-center gap-1">
+              <button
+                type="button"
+                data-overlay-ui
+                className="flex h-7 w-7 items-center justify-center rounded-full text-zinc-500 hover:bg-[var(--surface-popover)] disabled:opacity-40 dark:text-zinc-300 dark:hover:bg-[var(--surface-popover)]"
+                aria-label="Fix with agent"
+                title="Fix with agent"
+                disabled={progress?.status === 'running'}
+                onClick={() => api.fixSingleAnnotation(openThread.id)}
+              >
+                <Play className="size-3.5" />
+              </button>
               <div className="relative">
                 <button
                   type="button"

--- a/src/renderer/right-details-panel/App.tsx
+++ b/src/renderer/right-details-panel/App.tsx
@@ -67,6 +67,9 @@ export default function App({ initialTheme }: { initialTheme: ThemeData }) {
             selection={panelData.selection}
             pages={pages}
             fixProgress={panelData.fixProgress ?? {}}
+            originBindings={panelData.originBindings ?? {}}
+            fixInProgress={panelData.fixInProgress ?? {}}
+            fixConfig={panelData.fixConfig ?? { model: 'opus', permissions: 'dangerously', configured: false }}
           />
         ) : null
 

--- a/src/renderer/right-details-panel/App.tsx
+++ b/src/renderer/right-details-panel/App.tsx
@@ -70,8 +70,6 @@ export default function App({ initialTheme }: { initialTheme: ThemeData }) {
             pages={pages}
             fixProgress={panelData.fixProgress ?? {}}
             originBindings={panelData.originBindings ?? {}}
-            fixInProgress={panelData.fixInProgress ?? {}}
-            fixConfig={panelData.fixConfig ?? DEFAULT_FIX_CONFIG}
           />
         ) : null
 

--- a/src/renderer/right-details-panel/App.tsx
+++ b/src/renderer/right-details-panel/App.tsx
@@ -16,6 +16,8 @@ import { TextEntityPane } from './components/TextEntityPane'
 import { rightDetailsPanelApi } from './rightDetailsPanelApi'
 import { useRightDetailsPanelData } from './useRightDetailsPanelData'
 
+const DEFAULT_FIX_CONFIG = { model: 'opus', permissions: 'dangerously', configured: false } as const
+
 export default function App({ initialTheme }: { initialTheme: ThemeData }) {
   const panelData = useRightDetailsPanelData()
   const isDark = useTheme(initialTheme, rightDetailsPanelApi.onThemeChanged)
@@ -69,7 +71,7 @@ export default function App({ initialTheme }: { initialTheme: ThemeData }) {
             fixProgress={panelData.fixProgress ?? {}}
             originBindings={panelData.originBindings ?? {}}
             fixInProgress={panelData.fixInProgress ?? {}}
-            fixConfig={panelData.fixConfig ?? { model: 'opus', permissions: 'dangerously', configured: false }}
+            fixConfig={panelData.fixConfig ?? DEFAULT_FIX_CONFIG}
           />
         ) : null
 
@@ -120,7 +122,7 @@ export default function App({ initialTheme }: { initialTheme: ThemeData }) {
             originBindings={panelData.originBindings ?? {}}
             fixInProgress={panelData.fixInProgress ?? {}}
             fixProgress={panelData.fixProgress ?? {}}
-            fixConfig={panelData.fixConfig ?? { model: 'opus', permissions: 'dangerously', configured: false }}
+            fixConfig={panelData.fixConfig ?? DEFAULT_FIX_CONFIG}
           />
         )
     }

--- a/src/renderer/right-details-panel/components/CommentsPane.tsx
+++ b/src/renderer/right-details-panel/components/CommentsPane.tsx
@@ -193,7 +193,7 @@ function FixProgressButton({
           size={11}
           className={progress.status === 'running' ? 'animate-spin shrink-0' : 'shrink-0'}
         />
-        <span className="truncate">{label}</span>
+        <span className="truncate font-mono">{label}</span>
       </Popover.Trigger>
       <Popover.Portal>
         <Popover.Positioner sideOffset={4} align="start">

--- a/src/renderer/right-details-panel/components/DocumentPane.tsx
+++ b/src/renderer/right-details-panel/components/DocumentPane.tsx
@@ -92,7 +92,7 @@ export function DocumentPane({
   )
 }
 
-function FixMenu({
+export function FixMenu({
   isDark,
   originGroups,
   originBindings,

--- a/src/renderer/right-details-panel/components/DocumentPane.tsx
+++ b/src/renderer/right-details-panel/components/DocumentPane.tsx
@@ -135,7 +135,7 @@ function FixMenu({
     : 'bg-zinc-50 text-zinc-600 hover:bg-zinc-200'
   const btnClass = isPrimary ? primaryBtnClass : secondaryBtnClass
 
-  const popupClass = `z-50 min-w-[260px] rounded-[10px] border shadow-xl outline-none ${
+  const popupClass = `z-50 w-[256px] rounded-[10px] border shadow-xl outline-none ${
     isDark
       ? 'border-zinc-700 bg-zinc-900 text-zinc-100'
       : 'border-zinc-200 bg-white text-zinc-900'
@@ -179,7 +179,7 @@ function FixMenu({
       </div>
 
       <Popover.Portal>
-        <Popover.Positioner sideOffset={4} align="end">
+        <Popover.Positioner sideOffset={4} align="end" collisionPadding={8}>
           <Popover.Popup className={popupClass}>
             {showSettings ? (
               <FixSettingsView
@@ -242,7 +242,7 @@ function FixSettingsView({
   }
 
   return (
-    <div className="w-[280px]">
+    <div className="w-full">
       <div className={`px-3 py-2.5 text-[12px] leading-relaxed text-pretty ${isDark ? 'text-zinc-300' : 'text-zinc-600'}`}>
         Fix uses Claude Code to read your comments and make changes in linked repositories.
         Pick a model and permission level below.

--- a/src/renderer/right-details-panel/components/DocumentPane.tsx
+++ b/src/renderer/right-details-panel/components/DocumentPane.tsx
@@ -92,7 +92,7 @@ export function DocumentPane({
   )
 }
 
-export function FixMenu({
+function FixMenu({
   isDark,
   originGroups,
   originBindings,

--- a/src/renderer/right-details-panel/components/PagePane.tsx
+++ b/src/renderer/right-details-panel/components/PagePane.tsx
@@ -5,7 +5,9 @@ import {
   Copy,
   Laptop,
   Link2,
+  Loader2,
   Maximize2,
+  Play,
   Smartphone,
   Tablet,
   Trash2,
@@ -16,7 +18,6 @@ import type {
   Annotation,
   DevtoolsPanelPageSummary,
   DevtoolsPanelSelectionSummary,
-  FixConfig,
   FixProgressEntry,
   InspectPanelState,
   OriginBindings,
@@ -39,7 +40,6 @@ import { useElementCommentDraft } from '../useElementCommentDraft'
 import { useInspectTreeState } from '../useInspectTreeState'
 import { RotateIcon } from '../../shared/CustomIcons'
 import { CommentRow } from './CommentsPane'
-import { FixMenu } from './DocumentPane'
 import { ElementCommentComposer } from './ElementCommentComposer'
 import { InspectDetailSection } from './InspectDetailSection'
 import { InspectTree } from './InspectTree'
@@ -53,8 +53,6 @@ export function PagePane({
   pages,
   fixProgress,
   originBindings,
-  fixInProgress,
-  fixConfig,
 }: {
   inspect: InspectPanelState
   annotations: Annotation[]
@@ -62,8 +60,6 @@ export function PagePane({
   pages: DevtoolsPanelPageSummary[]
   fixProgress: Record<string, FixProgressEntry>
   originBindings: OriginBindings
-  fixInProgress: Record<string, number>
-  fixConfig: FixConfig
 }) {
   const isDark = usePaneTheme()
   const muted = mutedClass(isDark)
@@ -147,8 +143,6 @@ export function PagePane({
           collapsiblePanelClass={collapsiblePanelClass}
           fixProgress={fixProgress}
           originBindings={originBindings}
-          fixInProgress={fixInProgress}
-          fixConfig={fixConfig}
         />
 
         {/* Inspect tree (collapsible) */}
@@ -295,8 +289,6 @@ function PageCommentsSection({
   collapsiblePanelClass,
   fixProgress,
   originBindings,
-  fixInProgress,
-  fixConfig,
 }: {
   annotations: Annotation[]
   activePageId: string | null
@@ -306,12 +298,24 @@ function PageCommentsSection({
   collapsiblePanelClass: string
   fixProgress: Record<string, FixProgressEntry>
   originBindings: OriginBindings
-  fixInProgress: Record<string, number>
-  fixConfig: FixConfig
 }) {
   const pageComments = unresolvedCommentsForPage(annotations, activePageId)
   if (!pageComments.length) return null
-  const originGroups = groupAnnotationsByOrigin(pageComments)
+  // Fix is scoped to this page's comments — each is queued individually rather
+  // than via the origin-wide trigger, so we don't touch the canvas's other pages.
+  const hasBinding = groupAnnotationsByOrigin(pageComments).some(
+    (g) => originBindings[g.origin],
+  )
+  const working = pageComments.some((a) => fixProgress[a.id]?.status === 'running')
+  const fixPageComments = () => {
+    if (!hasBinding || working) return
+    for (const annotation of pageComments) {
+      rightDetailsPanelApi.fixSingleAnnotation(annotation.id)
+    }
+  }
+  const fixBtnClass = isDark
+    ? 'border-blue-500/70 bg-blue-600/80 text-white hover:bg-blue-600'
+    : 'border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100'
   return (
     <section className={`border-t ${divider}`}>
       <Collapsible.Root defaultOpen>
@@ -326,14 +330,21 @@ function PageCommentsSection({
               ({pageComments.length})
             </span>
           </Collapsible.Trigger>
-          {originGroups.length > 0 ? (
-            <FixMenu
-              isDark={isDark}
-              originGroups={originGroups}
-              originBindings={originBindings}
-              fixInProgress={fixInProgress}
-              fixConfig={fixConfig}
-            />
+          {hasBinding ? (
+            <button
+              type="button"
+              onClick={fixPageComments}
+              disabled={working}
+              title="Fix this page's comments"
+              className={`mr-2 inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] font-medium disabled:opacity-40 ${fixBtnClass}`}
+            >
+              {working ? (
+                <Loader2 size={11} className="shrink-0 animate-spin" />
+              ) : (
+                <Play size={11} className="shrink-0" />
+              )}
+              <span>Fix {pageComments.length}</span>
+            </button>
           ) : null}
         </div>
         <Collapsible.Panel className={collapsiblePanelClass}>

--- a/src/renderer/right-details-panel/components/PagePane.tsx
+++ b/src/renderer/right-details-panel/components/PagePane.tsx
@@ -381,17 +381,20 @@ function PageHeaderActions({
     isDark ? 'text-zinc-400 hover:bg-red-500/12 hover:text-red-400' : 'text-zinc-500 hover:bg-red-50 hover:text-red-600'
   }`
 
-  const showShell = page?.showDeviceFrame ?? false
-  const orientation = page?.deviceOrientation ?? 'portrait'
-
+  // Gate device controls on `page` — without the summary we can't read the
+  // current orientation, so a rotate would flip from the wrong base.
   return (
     <div className="flex items-center gap-0.5">
-      <button type="button" className={showShell ? activeBtnClass : btnClass} aria-label="Toggle device frame" title="Device frame" onClick={() => rightDetailsPanelApi.toggleDeviceShell(pageId)}>
-        <Smartphone size={13} />
-      </button>
-      <button type="button" className={btnClass} aria-label="Rotate viewport" title="Rotate viewport" onClick={() => rightDetailsPanelApi.setDeviceOrientation(pageId, orientation === 'portrait' ? 'landscape' : 'portrait')}>
-        <RotateIcon size={13} />
-      </button>
+      {page ? (
+        <>
+          <button type="button" className={page.showDeviceFrame ? activeBtnClass : btnClass} aria-label="Toggle device frame" title="Device frame" onClick={() => rightDetailsPanelApi.toggleDeviceShell(pageId)}>
+            <Smartphone size={13} />
+          </button>
+          <button type="button" className={btnClass} aria-label="Rotate viewport" title="Rotate viewport" onClick={() => rightDetailsPanelApi.setDeviceOrientation(pageId, page.deviceOrientation === 'landscape' ? 'portrait' : 'landscape')}>
+            <RotateIcon size={13} />
+          </button>
+        </>
+      ) : null}
       <button type="button" className={btnClass} aria-label="Focus page" title="Focus page" onClick={() => rightDetailsPanelApi.focusSelection()}>
         <Maximize2 size={13} />
       </button>

--- a/src/renderer/right-details-panel/components/PagePane.tsx
+++ b/src/renderer/right-details-panel/components/PagePane.tsx
@@ -1,12 +1,11 @@
 import { Collapsible } from '@base-ui/react/collapsible'
 import {
   ChevronDown,
-  ChevronLeft,
   ChevronRight,
   Copy,
   Laptop,
   Link2,
-  RotateCw,
+  Maximize2,
   Smartphone,
   Tablet,
   Trash2,
@@ -17,10 +16,11 @@ import type {
   Annotation,
   DevtoolsPanelPageSummary,
   DevtoolsPanelSelectionSummary,
+  FixConfig,
   FixProgressEntry,
   InspectPanelState,
+  OriginBindings,
 } from '../../../shared/types'
-import { resolveAddressInput } from '../../../shared/url'
 import {
   dividerClass,
   isUnresolved,
@@ -31,13 +31,15 @@ import { usePaneTheme } from '../PaneContext'
 import {
   buildUnresolvedCountsByNodeId,
   getInspectDetailState,
+  groupAnnotationsByOrigin,
   resolvePageDimensions,
 } from '../rightDetailsPanelSelectors'
 import { useClearInspectHoverOnLeave } from '../useClearInspectHoverOnLeave'
 import { useElementCommentDraft } from '../useElementCommentDraft'
 import { useInspectTreeState } from '../useInspectTreeState'
+import { RotateIcon } from '../../shared/CustomIcons'
 import { CommentRow } from './CommentsPane'
-import { DeviceSection } from './DeviceSection'
+import { FixMenu } from './DocumentPane'
 import { ElementCommentComposer } from './ElementCommentComposer'
 import { InspectDetailSection } from './InspectDetailSection'
 import { InspectTree } from './InspectTree'
@@ -50,12 +52,18 @@ export function PagePane({
   selection,
   pages,
   fixProgress,
+  originBindings,
+  fixInProgress,
+  fixConfig,
 }: {
   inspect: InspectPanelState
   annotations: Annotation[]
   selection?: DevtoolsPanelSelectionSummary
   pages: DevtoolsPanelPageSummary[]
   fixProgress: Record<string, FixProgressEntry>
+  originBindings: OriginBindings
+  fixInProgress: Record<string, number>
+  fixConfig: FixConfig
 }) {
   const isDark = usePaneTheme()
   const muted = mutedClass(isDark)
@@ -116,6 +124,7 @@ export function PagePane({
             label={activePage?.label ?? 'Page'}
             actions={
               <PageHeaderActions
+                page={activePage}
                 pageId={inspect.activePageId!}
                 linked={activePage?.linked ?? false}
                 isDark={isDark}
@@ -129,20 +138,6 @@ export function PagePane({
           />
         )}
 
-        {/* Navigation & page actions */}
-        {activePage ? (
-          <PageNavigationSection
-            page={activePage}
-            isDark={isDark}
-            divider={divider}
-          />
-        ) : null}
-
-        {/* Dimensions & device page */}
-        {activePage ? (
-          <DeviceFrameSection page={activePage} />
-        ) : null}
-
         {/* Page comments (collapsible, only when there are unresolved comments) */}
         <PageCommentsSection
           annotations={annotations}
@@ -152,6 +147,9 @@ export function PagePane({
           muted={muted}
           collapsiblePanelClass={collapsiblePanelClass}
           fixProgress={fixProgress}
+          originBindings={originBindings}
+          fixInProgress={fixInProgress}
+          fixConfig={fixConfig}
         />
 
         {/* Inspect tree (collapsible) */}
@@ -297,6 +295,9 @@ function PageCommentsSection({
   muted,
   collapsiblePanelClass,
   fixProgress,
+  originBindings,
+  fixInProgress,
+  fixConfig,
 }: {
   annotations: Annotation[]
   activePageId: string | null
@@ -305,22 +306,37 @@ function PageCommentsSection({
   muted: string
   collapsiblePanelClass: string
   fixProgress: Record<string, FixProgressEntry>
+  originBindings: OriginBindings
+  fixInProgress: Record<string, number>
+  fixConfig: FixConfig
 }) {
   const pageComments = unresolvedCommentsForPage(annotations, activePageId)
   if (!pageComments.length) return null
+  const originGroups = groupAnnotationsByOrigin(pageComments)
   return (
     <section className={`border-t ${divider}`}>
       <Collapsible.Root defaultOpen>
-        <Collapsible.Trigger
-          className={`group flex w-full items-center gap-1.5 px-2 py-2 text-[12px] font-medium`}
-        >
-          <ChevronDown size={12} className="hidden group-data-[panel-open]:block" />
-          <ChevronRight size={12} className="block group-data-[panel-open]:hidden" />
-          Comments
-          <span className={`text-[10px] font-normal ${muted}`}>
-            ({pageComments.length})
-          </span>
-        </Collapsible.Trigger>
+        <div className="flex items-center">
+          <Collapsible.Trigger
+            className={`group flex flex-1 items-center gap-1.5 px-2 py-2 text-[12px] font-medium`}
+          >
+            <ChevronDown size={12} className="hidden group-data-[panel-open]:block" />
+            <ChevronRight size={12} className="block group-data-[panel-open]:hidden" />
+            Comments
+            <span className={`text-[10px] font-normal ${muted}`}>
+              ({pageComments.length})
+            </span>
+          </Collapsible.Trigger>
+          {originGroups.length > 0 ? (
+            <FixMenu
+              isDark={isDark}
+              originGroups={originGroups}
+              originBindings={originBindings}
+              fixInProgress={fixInProgress}
+              fixConfig={fixConfig}
+            />
+          ) : null}
+        </div>
         <Collapsible.Panel className={collapsiblePanelClass}>
           <div className="space-y-2 px-2 pb-2">
             {pageComments.map((annotation) => (
@@ -345,10 +361,12 @@ function PageCommentsSection({
 // --- Page Header Actions (inline with PaneHeader) ---
 
 function PageHeaderActions({
+  page,
   pageId,
   linked,
   isDark,
 }: {
+  page?: DevtoolsPanelPageSummary
   pageId: string
   linked: boolean
   isDark: boolean
@@ -356,12 +374,27 @@ function PageHeaderActions({
   const btnClass = `rounded p-1 ${
     isDark ? 'text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200' : 'text-zinc-500 hover:bg-zinc-200 hover:text-zinc-700'
   }`
+  const activeBtnClass = `rounded p-1 ${
+    isDark ? 'bg-zinc-700 text-zinc-100' : 'bg-zinc-200 text-zinc-800'
+  }`
   const deleteBtnClass = `rounded p-1 ${
     isDark ? 'text-zinc-400 hover:bg-red-500/12 hover:text-red-400' : 'text-zinc-500 hover:bg-red-50 hover:text-red-600'
   }`
 
+  const showShell = page?.showDeviceFrame ?? false
+  const orientation = page?.deviceOrientation ?? 'portrait'
+
   return (
     <div className="flex items-center gap-0.5">
+      <button type="button" className={showShell ? activeBtnClass : btnClass} aria-label="Toggle device frame" title="Device frame" onClick={() => rightDetailsPanelApi.toggleDeviceShell(pageId)}>
+        <Smartphone size={13} />
+      </button>
+      <button type="button" className={btnClass} aria-label="Rotate viewport" title="Rotate viewport" onClick={() => rightDetailsPanelApi.setDeviceOrientation(pageId, orientation === 'portrait' ? 'landscape' : 'portrait')}>
+        <RotateIcon size={13} />
+      </button>
+      <button type="button" className={btnClass} aria-label="Focus page" title="Focus page" onClick={() => rightDetailsPanelApi.focusSelection()}>
+        <Maximize2 size={13} />
+      </button>
       <button type="button" className={btnClass} aria-label="Duplicate" title="Duplicate" onClick={() => rightDetailsPanelApi.duplicatePage(pageId)}>
         <Copy size={13} />
       </button>
@@ -382,137 +415,6 @@ function PageHeaderActions({
         <Trash2 size={13} />
       </button>
     </div>
-  )
-}
-
-// --- Page Navigation & Actions ---
-
-function PageNavigationSection({
-  page,
-  isDark,
-  divider,
-}: {
-  page: DevtoolsPanelPageSummary
-  isDark: boolean
-  divider: string
-}) {
-  const [urlValue, setUrlValue] = useState(page.url)
-  const [isEditingUrl, setIsEditingUrl] = useState(false)
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  useEffect(() => {
-    setUrlValue(page.url)
-  }, [page.url])
-
-  useEffect(() => {
-    if (isEditingUrl) {
-      inputRef.current?.focus()
-      inputRef.current?.select()
-    }
-  }, [isEditingUrl])
-
-  const handleCommitUrl = () => {
-    const value = urlValue.trim()
-    if (value && value !== page.url) {
-      rightDetailsPanelApi.navigatePage(page.id, resolveAddressInput(value))
-    }
-    setIsEditingUrl(false)
-  }
-
-  const navBtnClass = isDark
-    ? 'rounded-md p-1 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200 disabled:pointer-events-none disabled:opacity-40'
-    : 'rounded-md p-1 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-700 disabled:pointer-events-none disabled:opacity-40'
-
-  const inputContainerClass = isDark
-    ? 'flex h-7 items-center rounded-md border border-[var(--surface-input-border)] bg-[var(--surface-input)] px-2 text-zinc-200 transition-[border-color,box-shadow] focus-within:border-amber-500 focus-within:ring-1 focus-within:ring-amber-500'
-    : 'flex h-7 items-center rounded-md border border-[var(--surface-input-border)] bg-[var(--surface-input)] px-2 text-zinc-800 transition-[border-color,box-shadow] focus-within:border-amber-500 focus-within:ring-1 focus-within:ring-amber-500'
-
-  return (
-    <section className={`border-t ${divider}`}>
-      {/* Navigation bar */}
-      <div className="flex items-center gap-1 px-2 py-1.5">
-        <button
-          type="button"
-          className={navBtnClass}
-          disabled={!page.canGoBack}
-          title="Back"
-          onClick={() => rightDetailsPanelApi.goBackPage(page.id)}
-        >
-          <ChevronLeft size={14} />
-        </button>
-        <button
-          type="button"
-          className={navBtnClass}
-          disabled={!page.canGoForward}
-          title="Forward"
-          onClick={() => rightDetailsPanelApi.goForwardPage(page.id)}
-        >
-          <ChevronRight size={14} />
-        </button>
-        <button
-          type="button"
-          className={navBtnClass}
-          title={page.isLoading ? 'Loading' : 'Reload'}
-          onClick={() => rightDetailsPanelApi.reloadPage(page.id)}
-        >
-          <RotateCw size={13} className={page.isLoading ? 'animate-spin' : ''} />
-        </button>
-
-        {/* URL bar */}
-        <div className={`${inputContainerClass} ml-1 min-w-0 flex-1`}>
-          {isEditingUrl ? (
-            <input
-              ref={inputRef}
-              type="text"
-              value={urlValue}
-              onChange={(e) => setUrlValue(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleCommitUrl()
-                if (e.key === 'Escape') {
-                  setUrlValue(page.url)
-                  setIsEditingUrl(false)
-                }
-              }}
-              onBlur={handleCommitUrl}
-              spellCheck={false}
-              className={`min-w-0 flex-1 border-0 bg-transparent text-[11px] outline-none ${
-                isDark ? 'text-zinc-100 placeholder:text-zinc-500' : 'text-zinc-900 placeholder:text-zinc-400'
-              }`}
-            />
-          ) : (
-            <span
-              className={`min-w-0 flex-1 cursor-text truncate text-[11px] ${
-                isDark ? 'text-zinc-400' : 'text-zinc-500'
-              }`}
-              onClick={() => setIsEditingUrl(true)}
-              title={page.url}
-            >
-              {page.url}
-            </span>
-          )}
-        </div>
-      </div>
-
-    </section>
-  )
-}
-
-// --- Page Dimensions & Device Controls ---
-
-function DeviceFrameSection({ page }: { page: DevtoolsPanelPageSummary }) {
-  return (
-    <DeviceSection
-      deviceId={page.deviceId ?? null}
-      orientation={page.deviceOrientation ?? 'portrait'}
-      showShell={page.showDeviceFrame ?? false}
-      width={page.width}
-      height={page.height}
-      presetIndex={page.presetIndex ?? null}
-      onSelectPreset={(index) => rightDetailsPanelApi.setPagePreset(page.id, index)}
-      onSelectCustom={() => rightDetailsPanelApi.setPageCustom(page.id)}
-      onSetOrientation={(o) => rightDetailsPanelApi.setDeviceOrientation(page.id, o)}
-      onToggleShell={() => rightDetailsPanelApi.toggleDeviceShell(page.id)}
-    />
   )
 }
 

--- a/src/renderer/right-details-panel/components/PagePane.tsx
+++ b/src/renderer/right-details-panel/components/PagePane.tsx
@@ -126,7 +126,6 @@ export function PagePane({
               <PageHeaderActions
                 page={activePage}
                 pageId={inspect.activePageId!}
-                linked={activePage?.linked ?? false}
                 isDark={isDark}
               />
             }
@@ -363,14 +362,15 @@ function PageCommentsSection({
 function PageHeaderActions({
   page,
   pageId,
-  linked,
   isDark,
 }: {
+  // `pageId` comes from inspect.activePageId (always present); `page` is the
+  // summary lookup, which can briefly be undefined before the broadcast lands.
   page?: DevtoolsPanelPageSummary
   pageId: string
-  linked: boolean
   isDark: boolean
 }) {
+  const linked = page?.linked ?? false
   const btnClass = `rounded p-1 ${
     isDark ? 'text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200' : 'text-zinc-500 hover:bg-zinc-200 hover:text-zinc-700'
   }`

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2125,6 +2125,7 @@ export interface DevtoolsPanelElectronAPI {
   setDeviceOrientation: (pageId: string, orientation: string) => void
   toggleDeviceShell: (pageId: string) => void
   toggleSvgDeviceShell: (pageId: string) => void
+  focusSelection: () => void
   navigatePage: (pageId: string, url: string) => void
   goBackPage: (pageId: string) => void
   goForwardPage: (pageId: string) => void

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1861,6 +1861,7 @@ export interface CanvasBgElectronAPI {
   addAnnotationReply: (annotationId: string, text: string) => void
   resolveAnnotation: (annotationId: string) => void
   deleteAnnotation: (annotationId: string) => void
+  fixSingleAnnotation: (annotationId: string) => void
   openAnnotationThread: (annotationId: string) => void
   setCommentOverlayActive: (active: boolean) => void
   onCaptureMode: (callback: (active: boolean) => void) => () => void
@@ -2331,6 +2332,10 @@ export interface CommentToolPagePreviewState {
   active: boolean
   pointer: { x: number; y: number } | null
   regionRect: { x: number; y: number; width: number; height: number } | null
+  /** Counter-scale for the in-page hover label (= 1 / displayZoom). Keeps the
+   *  label a constant on-screen size despite the webview being zoom-scaled, so
+   *  it matches the screen-space inspect popover. */
+  displayScale?: number
 }
 
 /** Live-bbox subscription request: identifies an element-anchored annotation

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2126,10 +2126,6 @@ export interface DevtoolsPanelElectronAPI {
   toggleDeviceShell: (pageId: string) => void
   toggleSvgDeviceShell: (pageId: string) => void
   focusSelection: () => void
-  navigatePage: (pageId: string, url: string) => void
-  goBackPage: (pageId: string) => void
-  goForwardPage: (pageId: string) => void
-  reloadPage: (pageId: string) => void
   duplicatePage: (pageId: string) => void
   toggleLinkedPage: (pageId: string) => void
   deletePage: (pageId: string) => void

--- a/tests/unit/claude-spawner.test.ts
+++ b/tests/unit/claude-spawner.test.ts
@@ -2,23 +2,23 @@ import { describe, expect, it } from 'vitest'
 import { parseOutput } from '../../src/main/agent-fix/claude-spawner'
 
 describe('parseOutput', () => {
-  it('treats <<RESOLVE>> on its own line as resolving, with prior line as summary', () => {
-    const stdout = 'Some preamble\nShrunk the header padding to 12px.\n<<RESOLVE>>\n'
+  it('keeps the full message before <<RESOLVE>> and marks resolved', () => {
+    const stdout = 'Shrunk the header padding to 12px.\n\nAlternatives:\n- 8px for tighter\n<<RESOLVE>>\n'
     expect(parseOutput(stdout)).toEqual({
-      summary: 'Shrunk the header padding to 12px.',
+      summary: 'Shrunk the header padding to 12px.\n\nAlternatives:\n- 8px for tighter',
       shouldResolve: true,
     })
   })
 
-  it('treats <<WAITING>> as not resolving', () => {
+  it('treats <<WAITING>> as not resolving and keeps the message', () => {
     const stdout = 'Looked at the component.\nNeed clarification on spacing.\n<<WAITING>>'
     expect(parseOutput(stdout)).toEqual({
-      summary: 'Need clarification on spacing.',
+      summary: 'Looked at the component.\nNeed clarification on spacing.',
       shouldResolve: false,
     })
   })
 
-  it('extracts inline summary when marker is on the same line', () => {
+  it('handles the marker inline with the message', () => {
     const stdout = 'Header padding reduced. <<RESOLVE>>'
     expect(parseOutput(stdout)).toEqual({
       summary: 'Header padding reduced.',
@@ -26,10 +26,10 @@ describe('parseOutput', () => {
     })
   })
 
-  it('falls back to last line when no marker is present', () => {
+  it('keeps the whole output when no marker is present', () => {
     const stdout = 'Line one\nLine two\nFinal line without marker'
     expect(parseOutput(stdout)).toEqual({
-      summary: 'Final line without marker',
+      summary: 'Line one\nLine two\nFinal line without marker',
       shouldResolve: false,
     })
   })
@@ -41,12 +41,11 @@ describe('parseOutput', () => {
     })
   })
 
-  it('truncates very long summaries', () => {
-    const long = 'x'.repeat(400)
-    const stdout = `${long}\n<<RESOLVE>>`
-    const result = parseOutput(stdout)
+  it('truncates a runaway message', () => {
+    const long = 'x'.repeat(2400)
+    const result = parseOutput(`${long}\n<<RESOLVE>>`)
     expect(result.shouldResolve).toBe(true)
-    expect(result.summary.length).toBeLessThanOrEqual(280)
+    expect(result.summary.length).toBeLessThanOrEqual(2000)
     expect(result.summary.endsWith('…')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

Two related-area threads of work on this branch.

**Page device controls in the right panel header**
- Move the selected page's device controls into the right-details-panel header, alongside the existing page actions: **device-frame toggle** (highlights when active), **rotate**, and **focus** icons.
- Remove the redundant URL/nav row and the standalone device-picker row from the page pane — the canvas page popup already covers URL editing and preset switching.
- Wire `focusSelection` through the panel preload to the existing global `canvas-focus-selection` IPC handler (no new channel).
- Surface the page-comments fix-menu in the page pane, scoped to that page's comments (fans out single-annotation fixes rather than the origin-wide trigger so other pages aren't touched).

**Comment overlay + fix-agent polish**
- Reframe the comment agent from "fix only" to "respond": it can answer a question without editing code, and it no longer auto-resolves — `shouldResolve` is kept as a hint, resolving stays the user's call. The agent's full final message is shown verbatim (capped as a runaway guard) instead of a scraped summary line.
- Add a per-comment **fix button** to the thread popover via a new `fixSingleAnnotation` bridge (disabled while a fix runs).
- Fade element-anchored comment badges as their anchor leaves a page's content band, and drop their z-indexes so badges sit below other overlay UI.
- Counter-scale the in-page hover inspect label by `1/displayZoom` so it reads at a constant on-screen size on zoom-scaled webviews.

## Test plan

- [ ] Page header shows device-frame, rotate, focus icons inline with duplicate/link/devtools/delete; toggles/rotates/focuses correctly.
- [ ] No URL bar / back-forward row and no device-size dropdown remain in the panel.
- [ ] Page Comments section header shows the fix-menu and only fixes that page's comments.
- [ ] Per-comment play button in the thread popover sends a single comment to the agent; disabled while running.
- [ ] Agent can answer a question-only comment without editing code, and threads are not auto-resolved.
- [ ] Comment badges fade out as they scroll past a page's content band.
- [ ] Hover inspect label stays a constant size when the page is zoomed in/out.

## Follow-up

- A shared renderer z-layer scale (named constants) would replace the scattered z-index literals across the above-view stack.
- A `fixPendingAnnotationsForPage(pageId)` orchestrator entry point could own the page-scoped fan-out instead of the renderer looping single-fixes.
- Lifting a shared icon-button primitive into `src/renderer/shared/` would let the panel and `above-view` share the device-control buttons (currently blocked by the layer boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
