### PR TITLE
perf: track canvas selection chrome live during pan (#257)

### DIFF
--- a/src/main/runtime/viewport-control.ts
+++ b/src/main/runtime/viewport-control.ts
@@ -32,6 +32,7 @@ import {
   pageVisualBoundsForContentSize,
 } from './runtime-geometry'
 import { scheduleWorkspaceAutosave } from './workspace-autosave'
+import { broadcastViewportNudge } from './viewport-nudge'
 import { safeSend } from './safe-send'
 import { clampCanvasZoom } from '../../shared/zoom'
 import {
@@ -65,6 +66,7 @@ export function setZoom(value: number): void {
   if (nextZoom === zoom) return
   setZoomState(nextZoom)
   markDirty('canvas', 'toolbar')
+  broadcastViewportNudge()
   broadcastCanvasZoomToPages()
   if (!suppressCameraAutosave) scheduleWorkspaceAutosave()
 }
@@ -81,6 +83,7 @@ export function setPan(x: number, y: number): void {
   if (pan.x === x && pan.y === y) return
   setPanState({ x, y })
   markDirty('canvas')
+  broadcastViewportNudge()
   if (!suppressCameraAutosave) scheduleWorkspaceAutosave()
 }
 

--- a/src/main/runtime/viewport-nudge.ts
+++ b/src/main/runtime/viewport-nudge.ts
@@ -1,0 +1,20 @@
+import type { ViewportNudge } from '../../shared/types'
+import { aboveView, bgView } from './view-refs'
+import { pan, zoom } from './runtime-context'
+import { safeSend } from './safe-send'
+
+/**
+ * Push the authoritative viewport to the canvas overlay renderers immediately,
+ * bypassing the debounced layout pass. The canvas-bg and above-view scene
+ * layers translate by (livePan − payloadPan) so selection chrome and entity
+ * bodies track the natively-positioned page views during a pan, instead of
+ * trailing until the next full layout-update rebuild lands (which scales with
+ * entity count). The eventual layout-update reconciles the offset back to zero.
+ * See #257.
+ */
+export function broadcastViewportNudge(): void {
+  if (!bgView && !aboveView) return
+  const payload: ViewportNudge = { pan: { x: pan.x, y: pan.y }, zoom }
+  if (bgView) safeSend(bgView.webContents, 'viewport-nudge', payload)
+  if (aboveView) safeSend(aboveView.webContents, 'viewport-nudge', payload)
+}

--- a/src/preload/canvas-bg.ts
+++ b/src/preload/canvas-bg.ts
@@ -8,6 +8,7 @@ import type {
   LayoutUpdateData,
   SelectionOverlayPayload,
   ToolDefaultPatch,
+  ViewportNudge,
 } from '../shared/types'
 import type { BindingId } from '../shared/bindings'
 import type { CancelReason } from '../shared/interaction-types'
@@ -357,6 +358,11 @@ const api: CanvasBgElectronAPI = {
     const handler = (_event: Electron.IpcRendererEvent, data: LayoutUpdateData) => callback(data)
     ipcRenderer.on('layout-update', handler)
     return () => ipcRenderer.removeListener('layout-update', handler)
+  },
+  onViewportNudge: (callback) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: ViewportNudge) => callback(data)
+    ipcRenderer.on('viewport-nudge', handler)
+    return () => ipcRenderer.removeListener('viewport-nudge', handler)
   },
   onFixProgressUpdate: (callback) => {
     const handler = (_event: Electron.IpcRendererEvent, data: LayoutUpdateData['fixProgress']) =>

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -80,6 +80,7 @@ import { useCanvasClipboard } from '../canvas-bg/useCanvasClipboard'
 import { buildAboveViewHandlers } from './binding-handlers'
 import { useReportTextEditing } from '../shared/hooks/useReportTextEditing'
 import { useRendererBindingHandlers } from '../shared/hooks/useRendererBindingHandlers'
+import { useScenePanOffset } from '../shared/hooks/useScenePanOffset'
 import { useTheme } from '../shared/hooks/useTheme'
 import { useViewportWheelAndMiddlePan } from '../shared/hooks/useViewportWheelAndMiddlePan'
 
@@ -407,6 +408,7 @@ export default function App({
   const threadInputRef = useRef<HTMLTextAreaElement>(null)
   const activeStrokeRef = useRef<{ pointerId: number; strokeId: string } | null>(null)
   const [layoutData, setLayoutData] = useState<LayoutUpdateData>(initialLayoutData)
+  const panOffset = useScenePanOffset(api.onViewportNudge, layoutData)
   const [fixProgress, setFixProgress] = useState<LayoutUpdateData['fixProgress']>(
     initialLayoutData.fixProgress,
   )
@@ -1319,6 +1321,15 @@ html:active, body:active, body *:active { cursor: grabbing !important; }`
       onPointerUp={handleOverlayPointerUp}
       onPointerCancel={handleOverlayPointerCancel}
     >
+      {/* Translate the whole canvas scene live with the pan gesture so selection
+          chrome and entity bodies track the natively-positioned page views
+          instead of trailing until the next layout-update rebuild (#257). Pan is
+          disabled during focus, where the only viewport-pinned chrome exists, so
+          every layer here is canvas-space and moves together. */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ transform: `translate3d(${panOffset.x}px, ${panOffset.y}px, 0)` }}
+      >
       {placementPreview && selectionOverlay?.variant !== 'place-shape' ? (
         <PlacementPreviewLayer
           isDark={isDark}
@@ -1591,6 +1602,7 @@ html:active, body:active, body *:active { cursor: grabbing !important; }`
           />
         </>
       ) : null}
+      </div>
     </div>
   )
 }

--- a/src/renderer/canvas-bg/App.tsx
+++ b/src/renderer/canvas-bg/App.tsx
@@ -17,6 +17,7 @@ import { PageBorderLayer } from './PageBorderLayer'
 import { SvgDeviceShellLayer } from './SvgDeviceShellLayer'
 import { useCanvasLayoutState } from './useCanvasLayoutState'
 import { useCanvasViewportGestures } from './useCanvasViewportGestures'
+import { useScenePanOffset } from '../shared/hooks/useScenePanOffset'
 
 const api = (window as unknown as { electronAPI: CanvasBgElectronAPI }).electronAPI
 
@@ -34,6 +35,11 @@ export default function App({
   const isDark = useTheme(initialTheme, api.onThemeChanged)
   useReportTextEditing(api.setTextEditing)
   const { layoutData, layoutRef, layoutTick } = useCanvasLayoutState({ api, initialLayoutData })
+  const panOffset = useScenePanOffset(api.onViewportNudge, layoutData)
+  const livePan = useMemo(
+    () => ({ x: layoutData.pan.x + panOffset.x, y: layoutData.pan.y + panOffset.y }),
+    [layoutData.pan.x, layoutData.pan.y, panOffset.x, panOffset.y],
+  )
 
   useCanvasViewportGestures({
     api,
@@ -81,27 +87,35 @@ export default function App({
         bgRef={bgRef}
         isDark={isDark}
         canvasOrigin={layoutData.canvasOrigin}
-        pan={layoutData.pan}
+        pan={livePan}
         zoom={layoutData.zoom}
       />
-      <GroupBackgroundLayer
-        groups={hideContext ? [] : (layoutData.groups ?? [])}
-        isDark={isDark}
-      />
-      <div className="pointer-events-none absolute inset-0">
-        <PageBorderLayer
-          pages={chromePages}
-          fileEntities={chromeFiles}
-        />
-        <DeviceShellLayer
-          pages={chromePages.filter((f) => !f.useSvgDeviceShell)}
-          fileEntities={chromeFiles}
+      {/* Translate the page chrome live with the pan gesture so borders and
+          device shells track the natively-positioned page views instead of
+          trailing until the next layout-update rebuild lands (#257). */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ transform: `translate3d(${panOffset.x}px, ${panOffset.y}px, 0)` }}
+      >
+        <GroupBackgroundLayer
+          groups={hideContext ? [] : (layoutData.groups ?? [])}
           isDark={isDark}
         />
-        <SvgDeviceShellLayer
-          pages={chromePages.filter((f) => f.useSvgDeviceShell)}
-          isDark={isDark}
-        />
+        <div className="pointer-events-none absolute inset-0">
+          <PageBorderLayer
+            pages={chromePages}
+            fileEntities={chromeFiles}
+          />
+          <DeviceShellLayer
+            pages={chromePages.filter((f) => !f.useSvgDeviceShell)}
+            fileEntities={chromeFiles}
+            isDark={isDark}
+          />
+          <SvgDeviceShellLayer
+            pages={chromePages.filter((f) => f.useSvgDeviceShell)}
+            isDark={isDark}
+          />
+        </div>
       </div>
 
       {/* Group selection popup migrated to above-view (ADR 0008 §1, step 5).

--- a/src/renderer/shared/hooks/useScenePanOffset.ts
+++ b/src/renderer/shared/hooks/useScenePanOffset.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+import type { ViewportNudge } from '../../../shared/types'
+
+const ZERO = { x: 0, y: 0 }
+
+/**
+ * Live screen-space offset to apply to the canvas scene so it tracks a pan
+ * before the debounced `layout-update` catches up. Main pushes a viewport
+ * nudge on every pan/zoom; the offset is `livePan − payloadPan`, which
+ * self-reconciles to zero as soon as a fresh layout-update lands with the
+ * matching pan.
+ *
+ * Pan-only: a zoom change rescales the scene rather than translating it, so
+ * when the nudge's zoom differs from the payload we yield no offset and let the
+ * next layout-update reposition. Zoom gestures are comparatively rare and the
+ * payload lands within a couple of frames. See #257.
+ */
+export function useScenePanOffset(
+  onViewportNudge: (cb: (nudge: ViewportNudge) => void) => () => void,
+  payload: { pan: { x: number; y: number }; zoom: number },
+): { x: number; y: number } {
+  const [nudge, setNudge] = useState<ViewportNudge | null>(null)
+  useEffect(() => onViewportNudge(setNudge), [onViewportNudge])
+
+  if (!nudge || nudge.zoom !== payload.zoom) return ZERO
+  const x = nudge.pan.x - payload.pan.x
+  const y = nudge.pan.y - payload.pan.y
+  if (x === 0 && y === 0) return ZERO
+  return { x, y }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1678,6 +1678,18 @@ export interface ToolbarElectronAPI {
   repoDisconnect: (id: string) => Promise<void>
 }
 
+/**
+ * The authoritative viewport, pushed to the overlay renderers immediately on a
+ * pan/zoom — ahead of the debounced `layout-update` rebuild. The canvas scene
+ * layers translate by (livePan − payloadPan) so selection chrome and entity
+ * bodies track the natively-positioned page views during a pan instead of
+ * waiting for the next full rebuild. See #257.
+ */
+export interface ViewportNudge {
+  pan: { x: number; y: number }
+  zoom: number
+}
+
 export interface CanvasBgElectronAPI {
   canvasZoom: (deltaY: number, mouseX: number, mouseY: number) => void
   canvasPan: (deltaX: number, deltaY: number) => void
@@ -1901,6 +1913,7 @@ export interface CanvasBgElectronAPI {
    *  connected repo, or null if connection fails. */
   repoConnect: (absolutePath: string) => Promise<unknown>
   onLayoutUpdate: (callback: (data: LayoutUpdateData) => void) => () => void
+  onViewportNudge: (callback: (data: ViewportNudge) => void) => () => void
   onFixProgressUpdate: (
     callback: (data: LayoutUpdateData['fixProgress']) => void,
   ) => () => void


### PR DESCRIPTION
Implements **Option A** from #257 — the live pan transform, the analysis's "most promising" direction. #257's quick fix (#260, merged) only did Option C (build the layout payload once instead of twice); the *growing* lag was never addressed until now.

## Problem
Page selection borders and entity bodies are React overlays pinned to absolute screen coordinates baked into the `layout-update` payload, so they can't move until a fresh payload arrives. Producing that payload rebuilds the whole scene (maps every entity, O(groups × entities) group scan, full sort) on every pan tick — past the frame budget the chrome trails the natively-positioned page WebContentsViews, and the gap grows with entity count.

## Fix
Decouple chrome movement from the rebuild. Main pushes the authoritative viewport to the overlay renderers immediately on every pan/zoom via a new `viewport-nudge` channel, ahead of the debounced layout pass. The canvas-bg and above-view scene layers translate by `(livePan − payloadPan)` so chrome tracks the page views during the gesture; the next `layout-update` reconciles the offset back to zero.

- Pan-only: zoom rescales rather than translates, so it yields to the payload.
- The above-view scene moves as one layer (pan is disabled during focus, the only state with viewport-pinned chrome).
- Pan stays main-authoritative — the local transform is a transient visual offset, reconciled away on every payload.

This removes the dependency on payload timing, so chrome lag no longer grows with entity count.

## Scope / follow-up
The full scene rebuild still runs per pan tick — A just takes it off the critical path. Making the pan-only build cheap (caching the scene/group scan) is **Option B**, filed as a separate follow-up.

## Verification
- `pnpm typecheck` clean
- `pnpm test:unit` — 723/723 pass
- `pnpm test:smoke` — 168 pass (1 unrelated env failure: page-screenshot needs a display surface this CI session lacks)
- Manual 20-page pan repro: _pending reviewer eyeball_

Closes #257.

---
_Generated by [Claude Code](https://claude.ai/code)_