### PR TITLE
Collapse viewport layers, overlay-offset math, and preload subscribe boilerplate

### DIFF
--- a/src/preload/canvas-bg.ts
+++ b/src/preload/canvas-bg.ts
@@ -2,16 +2,19 @@ import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import type {
   AnnotationBboxSubscription,
   AnnotationCreateRequest,
+  AnnotationElementSelectionPayload,
   AnnotationLiveBboxUpdate,
   CanvasBgElectronAPI,
   EdgeSide,
   LayoutUpdateData,
   SelectionOverlayPayload,
   ToolDefaultPatch,
+  WorkspaceBounds,
 } from '../shared/types'
 import type { BindingId } from '../shared/bindings'
 import type { CancelReason } from '../shared/interaction-types'
 import type { CanvasGuidesPayload } from '../shared/canvas-guides'
+import { makeThemeSubscriber, sub } from './ipc-subscribe'
 
 function installSelectionOverlayBridge(): void {
   if (location.href !== 'about:blank') return
@@ -68,14 +71,7 @@ const api: CanvasBgElectronAPI = {
     ipcRenderer.send('canvas-zoom', { deltaY, mouseX, mouseY }),
   canvasPan: (deltaX, deltaY) => ipcRenderer.send('canvas-pan', { deltaX, deltaY }),
   setSelectionOverlayRect: (overlay) => ipcRenderer.send('canvas-selection-overlay', overlay),
-  onSelectionOverlayChanged: (callback) => {
-    const handler = (
-      _event: Electron.IpcRendererEvent,
-      overlay: import('../shared/types').SelectionOverlayPayload | null,
-    ) => callback(overlay)
-    ipcRenderer.on('canvas-selection-overlay', handler)
-    return () => ipcRenderer.removeListener('canvas-selection-overlay', handler)
-  },
+  onSelectionOverlayChanged: sub<SelectionOverlayPayload | null>('canvas-selection-overlay'),
   canvasSelectInRect: (rect, modifiers) =>
     ipcRenderer.send('canvas-select-in-rect', { ...rect, modifiers }),
   canvasDeselect: (modifiers) => ipcRenderer.send('page-deselect', { modifiers }),
@@ -243,29 +239,12 @@ const api: CanvasBgElectronAPI = {
     ipcRenderer.send('annotation-open-thread', { annotationId }),
   setCommentOverlayActive: (active: boolean) =>
     ipcRenderer.send('comment-overlay-set-active', active),
-  onCaptureMode: (callback: (active: boolean) => void) => {
-    const handler = (_event: Electron.IpcRendererEvent, active: boolean) => callback(active)
-    ipcRenderer.on('capture-mode', handler)
-    return () => ipcRenderer.removeListener('capture-mode', handler)
-  },
-  onAnnotateElementSelected: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: Parameters<typeof callback>[0]) =>
-      callback(data)
-    ipcRenderer.on('annotate-element-selected', handler)
-    return () => ipcRenderer.removeListener('annotate-element-selected', handler)
-  },
-  onRegionSelectCommitted: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: Parameters<typeof callback>[0]) =>
-      callback(data)
-    ipcRenderer.on('region-select-committed', handler)
-    return () => ipcRenderer.removeListener('region-select-committed', handler)
-  },
-  onCommentCanvasPointCommitted: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: Parameters<typeof callback>[0]) =>
-      callback(data)
-    ipcRenderer.on('comment-canvas-point-committed', handler)
-    return () => ipcRenderer.removeListener('comment-canvas-point-committed', handler)
-  },
+  onCaptureMode: sub<boolean>('capture-mode'),
+  onAnnotateElementSelected: sub<AnnotationElementSelectionPayload>('annotate-element-selected'),
+  onRegionSelectCommitted: sub<{ canvasRect: WorkspaceBounds }>('region-select-committed'),
+  onCommentCanvasPointCommitted: sub<{ canvasX: number; canvasY: number }>(
+    'comment-canvas-point-committed',
+  ),
   setCommentToolPointerState: (state) =>
     ipcRenderer.send(
       'comment-tool-pointer-state',
@@ -282,20 +261,10 @@ const api: CanvasBgElectronAPI = {
     subscriptions: AnnotationBboxSubscription[],
   ) =>
     ipcRenderer.send('comment-tool-bbox-subscriptions', { pageId, subscriptions }),
-  onAnnotationLiveBbox: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, update: AnnotationLiveBboxUpdate) =>
-      callback(update)
-    ipcRenderer.on('annotation-live-bbox', handler)
-    return () => ipcRenderer.removeListener('annotation-live-bbox', handler)
-  },
+  onAnnotationLiveBbox: sub<AnnotationLiveBboxUpdate>('annotation-live-bbox'),
   createRegionAnnotation: (canvasRect, text) =>
     ipcRenderer.send('canvas-create-region-annotation', { canvasRect, text }),
-  onAnnotationThreadOpen: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: Parameters<typeof callback>[0]) =>
-      callback(data)
-    ipcRenderer.on('annotation-thread-open', handler)
-    return () => ipcRenderer.removeListener('annotation-thread-open', handler)
-  },
+  onAnnotationThreadOpen: sub<{ annotationId: string }>('annotation-thread-open'),
   beginEdgeDrag: (fromEntityId: string, fromSide: EdgeSide) =>
     ipcRenderer.send('canvas-edge-drag-begin', { fromEntityId, fromSide }),
   updateEdgeDragTarget: (targetEntityId: string | null, targetSide: EdgeSide | null) =>
@@ -323,29 +292,13 @@ const api: CanvasBgElectronAPI = {
     ipcRenderer.send('canvas-forward-wheel', { pageId, payload }),
   forwardPointerToPage: (pageId, payload) =>
     ipcRenderer.send('canvas-forward-pointer', { pageId, payload }),
-  onPageCursorChange: (callback) => {
-    const handler = (
-      _event: Electron.IpcRendererEvent,
-      data: { type: string | null },
-    ) => callback(data)
-    ipcRenderer.on('aboveview-cursor-update', handler)
-    return () => ipcRenderer.removeListener('aboveview-cursor-update', handler)
-  },
+  onPageCursorChange: sub<{ type: string | null }>('aboveview-cursor-update'),
   setTextEditing: (active: boolean) =>
     ipcRenderer.send('canvas-set-text-editing', { active }),
   setAnnotationState: (hasOpenThread: boolean, hasPendingAnnotation: boolean) =>
     ipcRenderer.send('canvas-set-annotation-state', { hasOpenThread, hasPending: hasPendingAnnotation }),
-  onBindingFire: (callback: (id: BindingId) => void) => {
-    const handler = (_event: Electron.IpcRendererEvent, id: BindingId) => callback(id)
-    ipcRenderer.on('binding-fire', handler)
-    return () => ipcRenderer.removeListener('binding-fire', handler)
-  },
-  onCanvasGuides: (callback: (payload: CanvasGuidesPayload) => void) => {
-    const handler = (_event: Electron.IpcRendererEvent, payload: CanvasGuidesPayload) =>
-      callback(payload)
-    ipcRenderer.on('canvas-guides', handler)
-    return () => ipcRenderer.removeListener('canvas-guides', handler)
-  },
+  onBindingFire: sub<BindingId>('binding-fire'),
+  onCanvasGuides: sub<CanvasGuidesPayload>('canvas-guides'),
   writeNoteFile: (filePath: string, content: string) =>
     ipcRenderer.invoke('write-note-file', { filePath, content }),
   morphTextFile: (entityId: string, direction: 'text-to-file' | 'file-to-text') =>
@@ -353,23 +306,9 @@ const api: CanvasBgElectronAPI = {
   getInitialData: () => ipcRenderer.invoke('get-canvas-layout-bootstrap'),
   repoConnect: (absolutePath: string) =>
     ipcRenderer.invoke('repo-connect', { absolutePath }),
-  onLayoutUpdate: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: LayoutUpdateData) => callback(data)
-    ipcRenderer.on('layout-update', handler)
-    return () => ipcRenderer.removeListener('layout-update', handler)
-  },
-  onFixProgressUpdate: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: LayoutUpdateData['fixProgress']) =>
-      callback(data)
-    ipcRenderer.on('fix-progress-update', handler)
-    return () => ipcRenderer.removeListener('fix-progress-update', handler)
-  },
-  onThemeChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: { isDark: boolean }) =>
-      callback(data)
-    ipcRenderer.on('theme-changed', handler)
-    return () => ipcRenderer.removeListener('theme-changed', handler)
-  },
+  onLayoutUpdate: sub<LayoutUpdateData>('layout-update'),
+  onFixProgressUpdate: sub<LayoutUpdateData['fixProgress']>('fix-progress-update'),
+  onThemeChanged: makeThemeSubscriber(),
 }
 
 contextBridge.exposeInMainWorld('electronAPI', api)

--- a/src/preload/debug.ts
+++ b/src/preload/debug.ts
@@ -3,47 +3,23 @@ import type {
   CursorMotionParams,
   DebugElectronAPI,
   PresenceDebugEntry,
-  ThemeData,
 } from '../shared/types'
+import { makeThemeSubscriber, sub } from './ipc-subscribe'
 
 const api: DebugElectronAPI = {
   getInitialData: () => ipcRenderer.invoke('debug:get-initial-data'),
   updateCursorMotion: (params) =>
     ipcRenderer.send('debug:update-cursor-motion', params),
   resetCursorMotion: () => ipcRenderer.send('debug:reset-cursor-motion'),
-  onCursorMotionChanged: (callback) => {
-    const handler = (
-      _event: Electron.IpcRendererEvent,
-      params: CursorMotionParams,
-    ) => callback(params)
-    ipcRenderer.on('cursor-motion-changed', handler)
-    return () => ipcRenderer.removeListener('cursor-motion-changed', handler)
-  },
+  onCursorMotionChanged: sub<CursorMotionParams>('cursor-motion-changed'),
   updateCursorSplineViz: (on) =>
     ipcRenderer.send('debug:update-cursor-spline-viz', on),
-  onCursorSplineVizChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, on: boolean) =>
-      callback(on)
-    ipcRenderer.on('cursor-spline-viz-changed', handler)
-    return () => ipcRenderer.removeListener('cursor-spline-viz-changed', handler)
-  },
+  onCursorSplineVizChanged: sub<boolean>('cursor-spline-viz-changed'),
   updateCursorTuning: (params) =>
     ipcRenderer.send('debug:update-cursor-tuning', params),
   resetCursorTuning: () => ipcRenderer.send('debug:reset-cursor-tuning'),
-  onPresenceTimelineAppend: (callback) => {
-    const handler = (
-      _event: Electron.IpcRendererEvent,
-      entry: PresenceDebugEntry,
-    ) => callback(entry)
-    ipcRenderer.on('presence-timeline-append', handler)
-    return () => ipcRenderer.removeListener('presence-timeline-append', handler)
-  },
-  onThemeChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: ThemeData) =>
-      callback(data)
-    ipcRenderer.on('theme-changed', handler)
-    return () => ipcRenderer.removeListener('theme-changed', handler)
-  },
+  onPresenceTimelineAppend: sub<PresenceDebugEntry>('presence-timeline-append'),
+  onThemeChanged: makeThemeSubscriber(),
 }
 
 contextBridge.exposeInMainWorld('electronAPI', api)

--- a/src/preload/devtools-resize-handle.ts
+++ b/src/preload/devtools-resize-handle.ts
@@ -1,17 +1,13 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import type { DevtoolsResizeHandleElectronAPI } from '../shared/types'
+import { makeThemeSubscriber } from './ipc-subscribe'
 
 const api: DevtoolsResizeHandleElectronAPI = {
   devtoolsResizeStart: (screenX) => ipcRenderer.send('devtools-resize-start', { screenX }),
   devtoolsResizeMove: (screenX) => ipcRenderer.send('devtools-resize-move', { screenX }),
   devtoolsResizeEnd: () => ipcRenderer.send('devtools-resize-end'),
   getInitialData: () => ipcRenderer.invoke('get-theme-bootstrap'),
-  onThemeChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: { isDark: boolean }) =>
-      callback(data)
-    ipcRenderer.on('theme-changed', handler)
-    return () => ipcRenderer.removeListener('theme-changed', handler)
-  },
+  onThemeChanged: makeThemeSubscriber(),
 }
 
 contextBridge.exposeInMainWorld('electronAPI', api)

--- a/src/preload/ipc-subscribe.ts
+++ b/src/preload/ipc-subscribe.ts
@@ -1,0 +1,19 @@
+import { ipcRenderer } from 'electron'
+import type { ThemeData } from '../shared/types'
+
+/**
+ * Builds an `onX(callback) => unsubscribe` bridge method for a single IPC
+ * channel — the boilerplate every preload's subscribe-style API repeats.
+ */
+export function sub<T>(channel: string): (callback: (data: T) => void) => () => void {
+  return (callback) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: T) => callback(data)
+    ipcRenderer.on(channel, handler)
+    return () => ipcRenderer.removeListener(channel, handler)
+  }
+}
+
+/** Every preload bridge exposes `onThemeChanged` on the same `theme-changed` channel. */
+export function makeThemeSubscriber(): (callback: (data: ThemeData) => void) => () => void {
+  return sub<ThemeData>('theme-changed')
+}

--- a/src/preload/left-sidebar.ts
+++ b/src/preload/left-sidebar.ts
@@ -3,8 +3,8 @@ import type {
   CanvasEntityKind,
   LeftSidebarData,
   LeftSidebarElectronAPI,
-  ThemeData,
 } from '../shared/types'
+import { makeThemeSubscriber, sub } from './ipc-subscribe'
 
 const api: LeftSidebarElectronAPI = {
   revealPage: (pageId) => ipcRenderer.send('canvas-reveal-page', { pageId }),
@@ -38,16 +38,8 @@ const api: LeftSidebarElectronAPI = {
   deletePage: (pageId) => ipcRenderer.send('canvas-delete-page', { pageId }),
   setTextEditing: (active) => ipcRenderer.send('canvas-set-text-editing', { active }),
   getInitialData: () => ipcRenderer.invoke('get-left-sidebar-bootstrap'),
-  onThemeChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: ThemeData) => callback(data)
-    ipcRenderer.on('theme-changed', handler)
-    return () => ipcRenderer.removeListener('theme-changed', handler)
-  },
-  onSidebarData: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: LeftSidebarData) => callback(data)
-    ipcRenderer.on('left-sidebar-data', handler)
-    return () => ipcRenderer.removeListener('left-sidebar-data', handler)
-  },
+  onThemeChanged: makeThemeSubscriber(),
+  onSidebarData: sub<LeftSidebarData>('left-sidebar-data'),
 }
 
 contextBridge.exposeInMainWorld('electronAPI', api)

--- a/src/preload/onboarding.ts
+++ b/src/preload/onboarding.ts
@@ -1,24 +1,14 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import type { OnboardingElectronAPI } from '../shared/types'
+import type { OnboardingElectronAPI, OnboardingProgressEvent } from '../shared/types'
+import { makeThemeSubscriber, sub } from './ipc-subscribe'
 
 const api: OnboardingElectronAPI = {
   getInitialData: () => ipcRenderer.invoke('onboarding:get-initial-data'),
   install: (selections) => ipcRenderer.invoke('onboarding:install', selections),
   complete: () => ipcRenderer.send('onboarding:complete'),
   dismiss: () => ipcRenderer.send('onboarding:dismiss'),
-  onProgress: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, payload: unknown) => {
-      callback(payload as Parameters<typeof callback>[0])
-    }
-    ipcRenderer.on('onboarding:progress', handler)
-    return () => ipcRenderer.removeListener('onboarding:progress', handler)
-  },
-  onThemeChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: { isDark: boolean }) =>
-      callback(data)
-    ipcRenderer.on('theme-changed', handler)
-    return () => ipcRenderer.removeListener('theme-changed', handler)
-  },
+  onProgress: sub<OnboardingProgressEvent>('onboarding:progress'),
+  onThemeChanged: makeThemeSubscriber(),
 }
 
 contextBridge.exposeInMainWorld('electronAPI', api)

--- a/src/preload/right-details-panel.ts
+++ b/src/preload/right-details-panel.ts
@@ -3,8 +3,8 @@ import type {
   AnnotationCreateRequest,
   DevtoolsPanelData,
   DevtoolsPanelElectronAPI,
-  ThemeData,
 } from '../shared/types'
+import { makeThemeSubscriber, sub } from './ipc-subscribe'
 
 const api: DevtoolsPanelElectronAPI = {
   setTool: (tool) => ipcRenderer.send('toolbar-set-tool', tool),
@@ -91,16 +91,8 @@ const api: DevtoolsPanelElectronAPI = {
   openBrowserDevTools: () => ipcRenderer.send('right-details-panel-open-browser-devtools'),
   closeBrowserDevTools: () => ipcRenderer.send('right-details-panel-dismiss-browser-devtools'),
   getInitialData: () => ipcRenderer.invoke('get-theme-bootstrap'),
-  onThemeChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: ThemeData) => callback(data)
-    ipcRenderer.on('theme-changed', handler)
-    return () => ipcRenderer.removeListener('theme-changed', handler)
-  },
-  onPanelData: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: DevtoolsPanelData) => callback(data)
-    ipcRenderer.on('right-details-panel-data', handler)
-    return () => ipcRenderer.removeListener('right-details-panel-data', handler)
-  },
+  onThemeChanged: makeThemeSubscriber(),
+  onPanelData: sub<DevtoolsPanelData>('right-details-panel-data'),
 }
 
 contextBridge.exposeInMainWorld('electronAPI', api)

--- a/src/preload/settings.ts
+++ b/src/preload/settings.ts
@@ -2,8 +2,10 @@ import { contextBridge, ipcRenderer } from 'electron'
 import type {
   ConnectedRepo,
   FixConfig,
+  OnboardingProgressEvent,
   SettingsElectronAPI,
 } from '../shared/types'
+import { makeThemeSubscriber, sub } from './ipc-subscribe'
 
 const api: SettingsElectronAPI = {
   getInitialData: () => ipcRenderer.invoke('settings:get-initial-data'),
@@ -18,31 +20,10 @@ const api: SettingsElectronAPI = {
   repoBindOrigin: (repoId, origin) =>
     ipcRenderer.invoke('repo-bind-origin', { repoId, origin }),
   close: () => ipcRenderer.send('settings:close'),
-  onSkillProgress: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, payload: unknown) => {
-      callback(payload as Parameters<typeof callback>[0])
-    }
-    ipcRenderer.on('settings:skill-progress', handler)
-    return () => ipcRenderer.removeListener('settings:skill-progress', handler)
-  },
-  onFixConfigChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, payload: FixConfig) =>
-      callback(payload)
-    ipcRenderer.on('settings:fix-config-changed', handler)
-    return () => ipcRenderer.removeListener('settings:fix-config-changed', handler)
-  },
-  onConnectedReposChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, payload: ConnectedRepo[]) =>
-      callback(payload)
-    ipcRenderer.on('repo-changed', handler)
-    return () => ipcRenderer.removeListener('repo-changed', handler)
-  },
-  onThemeChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: { isDark: boolean }) =>
-      callback(data)
-    ipcRenderer.on('theme-changed', handler)
-    return () => ipcRenderer.removeListener('theme-changed', handler)
-  },
+  onSkillProgress: sub<OnboardingProgressEvent>('settings:skill-progress'),
+  onFixConfigChanged: sub<FixConfig>('settings:fix-config-changed'),
+  onConnectedReposChanged: sub<ConnectedRepo[]>('repo-changed'),
+  onThemeChanged: makeThemeSubscriber(),
 }
 
 contextBridge.exposeInMainWorld('electronAPI', api)

--- a/src/preload/toolbar.ts
+++ b/src/preload/toolbar.ts
@@ -4,6 +4,7 @@ import type {
   ToolbarElectronAPI,
   ToolbarSelectionData,
 } from '../shared/types'
+import { makeThemeSubscriber, sub } from './ipc-subscribe'
 
 const api: ToolbarElectronAPI = {
   zoomIn: () => ipcRenderer.send('zoom-in'),
@@ -23,44 +24,13 @@ const api: ToolbarElectronAPI = {
   dropdownOpen: () => ipcRenderer.send('toolbar-dropdown-open'),
   dropdownClose: () => ipcRenderer.send('toolbar-dropdown-close'),
   setTextEditing: (active) => ipcRenderer.send('canvas-set-text-editing', { active }),
-  onZoomChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, value: number) => callback(value)
-    ipcRenderer.on('zoom-changed', handler)
-    return () => ipcRenderer.removeListener('zoom-changed', handler)
-  },
-  onSelectionChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: ToolbarSelectionData) =>
-      callback(data)
-    ipcRenderer.on('toolbar-selection-changed', handler)
-    return () => ipcRenderer.removeListener('toolbar-selection-changed', handler)
-  },
-  onLeftSidebarChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, open: boolean) => callback(open)
-    ipcRenderer.on('left-sidebar-changed', handler)
-    return () => ipcRenderer.removeListener('left-sidebar-changed', handler)
-  },
-  onDevtoolsChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, open: boolean) => callback(open)
-    ipcRenderer.on('devtools-changed', handler)
-    return () => ipcRenderer.removeListener('devtools-changed', handler)
-  },
-  onThemeChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: { isDark: boolean }) =>
-      callback(data)
-    ipcRenderer.on('theme-changed', handler)
-    return () => ipcRenderer.removeListener('theme-changed', handler)
-  },
-  onAgentPresenceChanged: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, cursors: AgentPresenceCursor[]) =>
-      callback(cursors)
-    ipcRenderer.on('agent-presence-changed', handler)
-    return () => ipcRenderer.removeListener('agent-presence-changed', handler)
-  },
-  onFocusAddressBar: (callback) => {
-    const handler = () => callback()
-    ipcRenderer.on('focus-address-bar', handler)
-    return () => ipcRenderer.removeListener('focus-address-bar', handler)
-  },
+  onZoomChanged: sub<number>('zoom-changed'),
+  onSelectionChanged: sub<ToolbarSelectionData>('toolbar-selection-changed'),
+  onLeftSidebarChanged: sub<boolean>('left-sidebar-changed'),
+  onDevtoolsChanged: sub<boolean>('devtools-changed'),
+  onThemeChanged: makeThemeSubscriber(),
+  onAgentPresenceChanged: sub<AgentPresenceCursor[]>('agent-presence-changed'),
+  onFocusAddressBar: sub<void>('focus-address-bar'),
   repoConnectViaPicker: () => ipcRenderer.invoke('repo-connect-via-picker'),
   repoDisconnect: (id) => ipcRenderer.invoke('repo-disconnect', { id }),
 }

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -17,8 +17,10 @@ import {
   canvasToScreenX,
   canvasToScreenY,
   canScrollWheelTarget,
+  clientYToWindowY,
   DRAG_THRESHOLD,
   isOverlayUiTarget,
+  isPointerInPageContent,
   normalizeRect,
   screenPointToCanvasPoint,
   screenRectToCanvasRect,
@@ -805,7 +807,7 @@ export default function App({
   const hitTestHoverTarget = useCallback(
     (clientX: number, clientY: number) => {
       const layout = layoutRef.current
-      const windowY = clientY + layout.canvasOrigin.y
+      const windowY = clientYToWindowY(clientY, layout)
       for (let i = layout.entities.length - 1; i >= 0; i--) {
         const entity = layout.entities[i]
         if (entity.kind === 'group' || entity.kind === 'drawing') continue
@@ -848,7 +850,7 @@ export default function App({
       if (pendingPlacement) {
         setPlacementCursor({
           clientX: event.clientX,
-          clientY: event.clientY + layoutRef.current.canvasOrigin.y,
+          clientY: clientYToWindowY(event.clientY, layoutRef.current),
         })
       }
       // During placement the placeholder owns the cursor; page hover would flicker.
@@ -925,7 +927,7 @@ export default function App({
 
       const startX = event.clientX
       const startY = event.clientY
-      const startWindowY = startY + layout.canvasOrigin.y
+      const startWindowY = clientYToWindowY(startY, layout)
       const startCanvas = screenPointToCanvasPoint(startX, startWindowY, layout)
       const placementAtStart = layout.pendingPlacement
       let crossedThreshold = false
@@ -946,7 +948,7 @@ export default function App({
         const current = layoutRef.current
         const endCanvas = screenPointToCanvasPoint(
           ev.clientX,
-          ev.clientY + current.canvasOrigin.y,
+          clientYToWindowY(ev.clientY, current),
           current,
         )
         const square = squareConstrainedRect(
@@ -1002,7 +1004,7 @@ export default function App({
             api.setSelectionOverlayRect(null)
             const endCanvas = screenPointToCanvasPoint(
               ev.clientX,
-              ev.clientY + current.canvasOrigin.y,
+              clientYToWindowY(ev.clientY, current),
               current,
             )
             const square = squareConstrainedRect(
@@ -1046,7 +1048,7 @@ export default function App({
             draft.clearDraft()
             return
           }
-          api.commitCommentClickAt(ev.clientX, ev.clientY + current.canvasOrigin.y)
+          api.commitCommentClickAt(ev.clientX, clientYToWindowY(ev.clientY, current))
         }
       }
 
@@ -1096,16 +1098,11 @@ export default function App({
           entity.kind === 'page' && entity.id === pageId,
       )
       if (!page) return false
-      const windowY = event.clientY + layout.canvasOrigin.y
+      const windowY = clientYToWindowY(event.clientY, layout)
       // In focus presentation the camera is locked on the page, so any wheel
       // scrolls it — skip the cursor-over-body check used for selected pages.
-      if (!focusedPageId) {
-        const x0 = page.contentScreenX ?? page.screenX
-        const y0 = page.contentScreenY ?? page.screenY
-        const x1 = x0 + (page.contentScreenWidth ?? page.screenWidth)
-        const y1 = y0 + (page.contentScreenHeight ?? page.screenHeight)
-        if (event.clientX < x0 || event.clientX > x1) return false
-        if (windowY < y0 || windowY > y1) return false
+      if (!focusedPageId && !isPointerInPageContent(event.clientX, windowY, page)) {
+        return false
       }
       api.forwardWheelToPage(pageId, {
         windowX: event.clientX,
@@ -1195,13 +1192,8 @@ export default function App({
           entity.kind === 'page' && entity.id === pageId,
       )
       if (!page) return resetCursor()
-      const windowY = event.clientY + layout.canvasOrigin.y
-      const x0 = page.contentScreenX ?? page.screenX
-      const y0 = page.contentScreenY ?? page.screenY
-      const x1 = x0 + (page.contentScreenWidth ?? page.screenWidth)
-      const y1 = y0 + (page.contentScreenHeight ?? page.screenHeight)
-      if (event.clientX < x0 || event.clientX > x1) return resetCursor()
-      if (windowY < y0 || windowY > y1) return resetCursor()
+      const windowY = clientYToWindowY(event.clientY, layout)
+      if (!isPointerInPageContent(event.clientX, windowY, page)) return resetCursor()
       cursorIsForwarded = true
       api.forwardPointerToPage(pageId, {
         kind: 'move',

--- a/src/renderer/above-view/CanvasViewportLayer.tsx
+++ b/src/renderer/above-view/CanvasViewportLayer.tsx
@@ -1,0 +1,29 @@
+/**
+ * Wraps aboveView body/bounds layers in a viewport transform so they live in
+ * canvas-coordinate space. AboveView's WCV origin already sits at
+ * `canvasOrigin.y` (the toolbar inset), so the translate omits that axis —
+ * only `canvasOrigin.x` and `pan` apply.
+ */
+export function CanvasViewportLayer({
+  canvasOrigin,
+  pan,
+  zoom,
+  children,
+}: {
+  canvasOrigin: { x: number; y: number }
+  pan: { x: number; y: number }
+  zoom: number
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      className="pointer-events-none absolute left-0 top-0 origin-top-left"
+      style={{
+        ['--canvas-zoom' as string]: zoom,
+        transform: `translate(${canvasOrigin.x + pan.x}px, ${pan.y}px) scale(${zoom})`,
+      }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/renderer/above-view/FileBodyLayer.tsx
+++ b/src/renderer/above-view/FileBodyLayer.tsx
@@ -18,37 +18,7 @@ import {
   RendererSwitch,
 } from '../canvas-bg/entity-renderers/RendererSwitch'
 import { getFileApi } from '../canvas-bg/entity-renderers/filePathToSrc'
-
-/**
- * Wraps the file cards in a viewport transform so they live in
- * canvas-coordinate space. AboveView's WCV origin already sits at
- * `canvasOrigin.y` (the toolbar inset), so the translate omits that axis
- * — only `canvasOrigin.x` and `pan` apply. Matches `StickyViewportLayer`
- * and `ShapeViewportLayer`.
- */
-function FileViewportLayer({
-  canvasOrigin,
-  pan,
-  zoom,
-  children,
-}: {
-  canvasOrigin: { x: number; y: number }
-  pan: { x: number; y: number }
-  zoom: number
-  children: React.ReactNode
-}) {
-  return (
-    <div
-      className="pointer-events-none absolute left-0 top-0 origin-top-left"
-      style={{
-        ['--canvas-zoom' as string]: zoom,
-        transform: `translate(${canvasOrigin.x + pan.x}px, ${pan.y}px) scale(${zoom})`,
-      }}
-    >
-      {children}
-    </div>
-  )
-}
+import { CanvasViewportLayer } from './CanvasViewportLayer'
 
 function FileShell({
   id,
@@ -261,7 +231,7 @@ export function FileBodyLayer({
 }) {
   if (!entities.length) return null
   return (
-    <FileViewportLayer canvasOrigin={canvasOrigin} pan={pan} zoom={zoom}>
+    <CanvasViewportLayer canvasOrigin={canvasOrigin} pan={pan} zoom={zoom}>
       {entities.map((entity) => (
         <MemoFileBodyCard
           key={entity.id}
@@ -273,6 +243,6 @@ export function FileBodyLayer({
           onTextEditingChange={onTextEditingChange}
         />
       ))}
-    </FileViewportLayer>
+    </CanvasViewportLayer>
   )
 }

--- a/src/renderer/above-view/GroupBoundsLayer.tsx
+++ b/src/renderer/above-view/GroupBoundsLayer.tsx
@@ -10,36 +10,7 @@
 import { memo } from 'react'
 import type { CanvasSceneGroupEntity } from '../../shared/types'
 import { groupSurfaceStyle } from '../shared/groupSurfaceStyle'
-
-/**
- * Wraps the group-bound rectangles in a viewport transform so they live in
- * canvas-coordinate space. AboveView's WCV origin already sits at
- * `canvasOrigin.y` (the toolbar inset), so the translate omits that axis
- * — only `canvasOrigin.x` and `pan` apply. Matches `StickyViewportLayer`.
- */
-function GroupViewportLayer({
-  canvasOrigin,
-  pan,
-  zoom,
-  children,
-}: {
-  canvasOrigin: { x: number; y: number }
-  pan: { x: number; y: number }
-  zoom: number
-  children: React.ReactNode
-}) {
-  return (
-    <div
-      className="pointer-events-none absolute left-0 top-0 origin-top-left"
-      style={{
-        ['--canvas-zoom' as string]: zoom,
-        transform: `translate(${canvasOrigin.x + pan.x}px, ${pan.y}px) scale(${zoom})`,
-      }}
-    >
-      {children}
-    </div>
-  )
-}
+import { CanvasViewportLayer } from './CanvasViewportLayer'
 
 export const GroupBoundsLayer = memo(function GroupBoundsLayer({
   groups,
@@ -58,7 +29,7 @@ export const GroupBoundsLayer = memo(function GroupBoundsLayer({
   const inverseScale = 1 / zoom
 
   return (
-    <GroupViewportLayer canvasOrigin={canvasOrigin} pan={pan} zoom={zoom}>
+    <CanvasViewportLayer canvasOrigin={canvasOrigin} pan={pan} zoom={zoom}>
       {groups.map((group) => (
         <GroupBoundsItem
           key={group.id}
@@ -67,7 +38,7 @@ export const GroupBoundsLayer = memo(function GroupBoundsLayer({
           inverseScale={inverseScale}
         />
       ))}
-    </GroupViewportLayer>
+    </CanvasViewportLayer>
   )
 })
 

--- a/src/renderer/above-view/ShapeBodyLayer.tsx
+++ b/src/renderer/above-view/ShapeBodyLayer.tsx
@@ -12,42 +12,13 @@
 import { memo, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { CanvasSceneShapeEntity } from '../../shared/types'
 import { lightenHex, resolveCanvasColor } from '../../shared/canvas-colors'
+import { CanvasViewportLayer } from './CanvasViewportLayer'
 
 const DEFAULT_STROKE_WIDTH = 2
 /** ADR 0013 §2 — shapes without textSize render their label at this size. */
 const DEFAULT_TEXT_SIZE = 14
 const FILL_LIGHTEN = 0.5
 const NEUTRAL_SLATE = '#6b7280'
-
-/**
- * Wraps the shape cards in a viewport transform so they live in
- * canvas-coordinate space. AboveView's WCV origin already sits at
- * `canvasOrigin.y` (the toolbar inset), so the translate omits that axis
- * — only `canvasOrigin.x` and `pan` apply. Matches `StickyViewportLayer`.
- */
-function ShapeViewportLayer({
-  canvasOrigin,
-  pan,
-  zoom,
-  children,
-}: {
-  canvasOrigin: { x: number; y: number }
-  pan: { x: number; y: number }
-  zoom: number
-  children: React.ReactNode
-}) {
-  return (
-    <div
-      className="pointer-events-none absolute left-0 top-0 origin-top-left"
-      style={{
-        ['--canvas-zoom' as string]: zoom,
-        transform: `translate(${canvasOrigin.x + pan.x}px, ${pan.y}px) scale(${zoom})`,
-      }}
-    >
-      {children}
-    </div>
-  )
-}
 
 function ShapeText({
   text,
@@ -397,7 +368,7 @@ export function ShapeBodyLayer({
 }) {
   if (!entities.length) return null
   return (
-    <ShapeViewportLayer canvasOrigin={canvasOrigin} pan={pan} zoom={zoom}>
+    <CanvasViewportLayer canvasOrigin={canvasOrigin} pan={pan} zoom={zoom}>
       {entities.map((shape) => (
         <ShapeCard
           key={shape.id}
@@ -409,6 +380,6 @@ export function ShapeBodyLayer({
           onCommitEdit={onCommitEdit}
         />
       ))}
-    </ShapeViewportLayer>
+    </CanvasViewportLayer>
   )
 }

--- a/src/renderer/above-view/StickyBodyLayer.tsx
+++ b/src/renderer/above-view/StickyBodyLayer.tsx
@@ -28,41 +28,12 @@ import { resolveCanvasColor } from '../../shared/canvas-colors'
 import { MarkdownEditor } from '../shared/MarkdownEditor'
 import { remarkLineBreaks } from '../shared/remark-line-breaks'
 import { lineHeightForTextSize } from './TextSizeDropdown'
+import { CanvasViewportLayer } from './CanvasViewportLayer'
 
 const PLAIN_MIN_WIDTH = 64
 const PLAIN_MIN_HEIGHT = 18
 /** ADR 0013 §2 — entities without textSize render at this size ("Small"). */
 const DEFAULT_TEXT_SIZE = 14
-
-/**
- * Wraps the sticky body cards in a viewport transform so they live in
- * canvas-coordinate space. AboveView's WCV origin already sits at
- * `canvasOrigin.y` (the toolbar inset), so the translate omits that axis
- * — only `canvasOrigin.x` and `pan` apply.
- */
-function StickyViewportLayer({
-  canvasOrigin,
-  pan,
-  zoom,
-  children,
-}: {
-  canvasOrigin: { x: number; y: number }
-  pan: { x: number; y: number }
-  zoom: number
-  children: React.ReactNode
-}) {
-  return (
-    <div
-      className="pointer-events-none absolute left-0 top-0 origin-top-left"
-      style={{
-        ['--canvas-zoom' as string]: zoom,
-        transform: `translate(${canvasOrigin.x + pan.x}px, ${pan.y}px) scale(${zoom})`,
-      }}
-    >
-      {children}
-    </div>
-  )
-}
 
 function StickyShell({
   id,
@@ -384,7 +355,7 @@ export function StickyBodyLayer({
 }) {
   if (!entities.length) return null
   return (
-    <StickyViewportLayer canvasOrigin={canvasOrigin} pan={pan} zoom={zoom}>
+    <CanvasViewportLayer canvasOrigin={canvasOrigin} pan={pan} zoom={zoom}>
       {entities.map((note) => (
         <MemoStickyCard
           key={note.id}
@@ -397,6 +368,6 @@ export function StickyBodyLayer({
           onCommitEdit={onCommitEdit}
         />
       ))}
-    </StickyViewportLayer>
+    </CanvasViewportLayer>
   )
 }

--- a/src/renderer/above-view/useAnnotationDrawingGestures.ts
+++ b/src/renderer/above-view/useAnnotationDrawingGestures.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react'
 import type { CanvasBgElectronAPI, LayoutUpdateData } from '../../shared/types'
-import { isOverlayUiTarget, screenPointToCanvasPoint } from '../../shared/gesture-utils'
+import { clientYToWindowY, isOverlayUiTarget, screenPointToCanvasPoint } from '../../shared/gesture-utils'
 import { drawingBounds, snapPointTo45Degrees, type DrawingSession } from './annotationMath'
 
 export function useAnnotationDrawingGestures({
@@ -79,7 +79,7 @@ export function useAnnotationDrawingGestures({
         const strokeId = `stroke_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
         const startPoint = screenPointToCanvasPoint(
           event.clientX,
-          event.clientY + layoutRef.current.canvasOrigin.y,
+          clientYToWindowY(event.clientY, layoutRef.current),
           layoutRef.current,
         )
         activeStrokeRef.current = { pointerId: event.pointerId, strokeId }
@@ -154,7 +154,7 @@ export function useAnnotationDrawingGestures({
       if (event.pointerId !== activeStroke.pointerId) return
       const pointerPoint = screenPointToCanvasPoint(
         event.clientX,
-        event.clientY + layoutRef.current.canvasOrigin.y,
+        clientYToWindowY(event.clientY, layoutRef.current),
         layoutRef.current,
       )
       const current = sessionRef.current

--- a/src/renderer/above-view/useCanvasPointerRouter.ts
+++ b/src/renderer/above-view/useCanvasPointerRouter.ts
@@ -52,6 +52,7 @@ import {
 } from '../../shared/multi-resize-accumulator'
 import {
   entitiesOverlappingRect,
+  clientYToWindowY,
   DRAG_THRESHOLD,
   isOverlayUiTarget,
   isTypingTarget,
@@ -219,7 +220,7 @@ export function useCanvasPointerRouter(options: UseCanvasPointerRouterOptions): 
 
       // aboveView's WCV starts at canvasOrigin.y; scene entities use
       // window-relative screenY, so add the offset before hit-testing.
-      const windowY = event.clientY + layout.canvasOrigin.y
+      const windowY = clientYToWindowY(event.clientY, layout)
       const inputs = layoutToHitInputs(layout)
       const target = hitTest(inputs, { x: event.clientX, y: windowY })
 
@@ -296,7 +297,7 @@ export function useCanvasPointerRouter(options: UseCanvasPointerRouterOptions): 
       if (isTypingTarget(event.target)) return
       if (event.button !== 0) return
       const layout = layoutRef.current
-      const windowY = event.clientY + layout.canvasOrigin.y
+      const windowY = clientYToWindowY(event.clientY, layout)
       const target = hitTest(layoutToHitInputs(layout), { x: event.clientX, y: windowY })
       const action = routePointerDoubleClick(target)
       switch (action.kind) {
@@ -818,7 +819,7 @@ function runEdgeDrag(
   const pointerId = event.pointerId
   const releasePointer = capturePointer(event)
   const layout = layoutRef.current
-  const windowY = event.clientY + layout.canvasOrigin.y
+  const windowY = clientYToWindowY(event.clientY, layout)
   const entityMap = new Map<string, CanvasSceneEntity>()
   for (const e of layout.entities) entityMap.set(e.id, e)
   let state = beginEdgeDragState(
@@ -845,7 +846,7 @@ function runEdgeDrag(
     const cur = layoutRef.current
     const snapMap = new Map<string, CanvasSceneEntity>()
     for (const e of cur.entities) snapMap.set(e.id, e)
-    const winY = ev.clientY + cur.canvasOrigin.y
+    const winY = clientYToWindowY(ev.clientY, cur)
     state = updateEdgeDragCursor(state, ev.clientX, winY, snapMap, cur.zoom ?? 1)
     setEdgeDragState(state)
     const snapKey = state.kind !== 'idle' && state.snap
@@ -1006,7 +1007,7 @@ function runForwardPointer(
   const releasePointer = capturePointer(event)
   const { entityId, button } = action
   let lastWindowX = event.clientX
-  let lastWindowY = event.clientY + layoutRef.current.canvasOrigin.y
+  let lastWindowY = clientYToWindowY(event.clientY, layoutRef.current)
   api.forwardPointerToPage(entityId, {
     kind: 'down',
     windowX: lastWindowX,
@@ -1034,7 +1035,7 @@ function runForwardPointer(
   const onMove = (ev: PointerEvent) => {
     if (ev.pointerId !== pointerId) return
     lastWindowX = ev.clientX
-    lastWindowY = ev.clientY + layoutRef.current.canvasOrigin.y
+    lastWindowY = clientYToWindowY(ev.clientY, layoutRef.current)
     api.forwardPointerToPage(entityId, {
       kind: 'move',
       windowX: lastWindowX,
@@ -1048,7 +1049,7 @@ function runForwardPointer(
   }
   const sendUp = (ev: PointerEvent | null) => {
     const winX = ev ? ev.clientX : lastWindowX
-    const winY = ev ? ev.clientY + layoutRef.current.canvasOrigin.y : lastWindowY
+    const winY = ev ? clientYToWindowY(ev.clientY, layoutRef.current) : lastWindowY
     api.forwardPointerToPage(entityId, {
       kind: 'up',
       windowX: winX,
@@ -1129,7 +1130,7 @@ function runReorderDrag(
   const startLayout = layoutRef.current
   const grab = screenPointToCanvasPoint(
     event.clientX,
-    event.clientY + startLayout.canvasOrigin.y,
+    clientYToWindowY(event.clientY, startLayout),
     startLayout,
   )
 
@@ -1152,7 +1153,7 @@ function runReorderDrag(
   const onMove = (ev: PointerEvent) => {
     if (ev.pointerId !== pointerId) return
     const layout = layoutRef.current
-    const point = screenPointToCanvasPoint(ev.clientX, ev.clientY + layout.canvasOrigin.y, layout)
+    const point = screenPointToCanvasPoint(ev.clientX, clientYToWindowY(ev.clientY, layout), layout)
     api.reorderDragMove(point.x, point.y)
     setReorderGhost({ dx: point.x - grab.x, dy: point.y - grab.y })
   }

--- a/src/renderer/above-view/useCommentToolPointerBroadcast.ts
+++ b/src/renderer/above-view/useCommentToolPointerBroadcast.ts
@@ -14,6 +14,7 @@
 
 import { useCallback, useEffect, useRef } from 'react'
 import type { CanvasBgElectronAPI, LayoutUpdateData } from '../../shared/types'
+import { clientYToWindowY } from '../../shared/coords'
 
 type PointerStateApi = Pick<CanvasBgElectronAPI, 'setCommentToolPointerState'>
 
@@ -101,7 +102,7 @@ export function useCommentToolPointerBroadcast({
       const layout = layoutRef.current
       const pointer = {
         windowX: event.clientX,
-        windowY: event.clientY + layout.canvasOrigin.y,
+        windowY: clientYToWindowY(event.clientY, layout),
       }
       lastPointerRef.current = pointer
       send(pointer, currentRegion())

--- a/src/shared/coords.ts
+++ b/src/shared/coords.ts
@@ -45,3 +45,52 @@ export function screenRectToCanvasRect(
 export function toOverlayY(layout: LayoutUpdateData, value: number): number {
   return value - layout.canvasOrigin.y
 }
+
+/**
+ * aboveView's WCV origin sits at `canvasOrigin.y` below the toolbar, so a
+ * pointer event's `clientY` (relative to the overlay) must add that offset
+ * to land in window space, where scene entities' `screenY` lives.
+ */
+export function clientYToWindowY(clientY: number, layout: LayoutUpdateData): number {
+  return clientY + layout.canvasOrigin.y
+}
+
+export interface ScreenContentBounds {
+  screenX: number
+  screenY: number
+  screenWidth: number
+  screenHeight: number
+  contentScreenX?: number
+  contentScreenY?: number
+  contentScreenWidth?: number
+  contentScreenHeight?: number
+}
+
+/**
+ * A page/file entity's outer `screen*` bounds include device-shell chrome;
+ * `contentScreen*` (when present) is the inner web-viewport rect. Falls back
+ * to the outer bounds when there's no shell.
+ */
+export function pageContentBounds(page: ScreenContentBounds): ScreenRect {
+  return {
+    left: page.contentScreenX ?? page.screenX,
+    top: page.contentScreenY ?? page.screenY,
+    width: page.contentScreenWidth ?? page.screenWidth,
+    height: page.contentScreenHeight ?? page.screenHeight,
+  }
+}
+
+/** Whether a window-space point (`clientX`, `windowY`) falls inside a page's content rect. */
+export function isPointerInPageContent(
+  clientX: number,
+  windowY: number,
+  page: ScreenContentBounds,
+): boolean {
+  const bounds = pageContentBounds(page)
+  return (
+    clientX >= bounds.left &&
+    clientX <= bounds.left + bounds.width &&
+    windowY >= bounds.top &&
+    windowY <= bounds.top + bounds.height
+  )
+}

--- a/src/shared/gesture-utils.ts
+++ b/src/shared/gesture-utils.ts
@@ -7,6 +7,9 @@ export const DRAG_THRESHOLD = 4
 export {
   canvasToScreenX,
   canvasToScreenY,
+  clientYToWindowY,
+  isPointerInPageContent,
+  pageContentBounds,
   screenPointToCanvasPoint,
   screenRectToCanvasRect,
   toOverlayY,

--- a/tests/unit/coords.test.ts
+++ b/tests/unit/coords.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   canvasToScreenPoint,
+  clientYToWindowY,
+  isPointerInPageContent,
+  pageContentBounds,
   screenPointToCanvasPoint,
   screenRectToCanvasRect,
 } from '../../src/shared/coords'
@@ -44,5 +47,37 @@ describe('coords', () => {
     expect(canvasRect.y).toBeCloseTo(tl.y, 6)
     expect(canvasRect.width).toBeCloseTo(rect.width / L.zoom, 6)
     expect(canvasRect.height).toBeCloseTo(rect.height / L.zoom, 6)
+  })
+
+  it('adds canvasOrigin.y to overlay-relative clientY to land in window space', () => {
+    const L = layout()
+    expect(clientYToWindowY(200, L)).toBe(200 + L.canvasOrigin.y)
+  })
+
+  it('falls back to outer screen bounds when a page has no content* bounds', () => {
+    const page = { screenX: 10, screenY: 20, screenWidth: 300, screenHeight: 200 }
+    expect(pageContentBounds(page)).toEqual({ left: 10, top: 20, width: 300, height: 200 })
+  })
+
+  it('prefers content* bounds over outer screen bounds when present', () => {
+    const page = {
+      screenX: 0,
+      screenY: 0,
+      screenWidth: 400,
+      screenHeight: 300,
+      contentScreenX: 10,
+      contentScreenY: 40,
+      contentScreenWidth: 380,
+      contentScreenHeight: 260,
+    }
+    expect(pageContentBounds(page)).toEqual({ left: 10, top: 40, width: 380, height: 260 })
+  })
+
+  it('isPointerInPageContent matches inclusive membership against the content rect', () => {
+    const page = { screenX: 0, screenY: 0, screenWidth: 100, screenHeight: 50 }
+    expect(isPointerInPageContent(0, 0, page)).toBe(true)
+    expect(isPointerInPageContent(100, 50, page)).toBe(true)
+    expect(isPointerInPageContent(101, 25, page)).toBe(false)
+    expect(isPointerInPageContent(50, 51, page)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- `StickyViewportLayer` / `ShapeViewportLayer` / `FileViewportLayer` / `GroupViewportLayer` were byte-identical except for the name — collapsed onto one shared `CanvasViewportLayer` (`src/renderer/above-view/CanvasViewportLayer.tsx`), used by all four.
- Added `clientYToWindowY(clientY, layout)` and `pageContentBounds(page)` / `isPointerInPageContent(clientX, windowY, page)` to `src/shared/coords.ts`, replacing ~17 inlined `event.clientY + layout.canvasOrigin.y` occurrences across `App.tsx`, `useCanvasPointerRouter.ts`, `useCommentToolPointerBroadcast.ts`, and `useAnnotationDrawingGestures.ts`, plus two duplicated page-content-bounds membership checks in `App.tsx` (wheel routing + cursor forwarding).
- Added a `sub<T>(channel)` + `makeThemeSubscriber()` factory (`src/preload/ipc-subscribe.ts`) that builds an `onX(callback) => unsubscribe` bridge method for a channel, replacing the repeated boilerplate across all 8 preload bridges (including 8x identical `onThemeChanged`).

No behavior change — net ~150 LOC removed across preload + above-view, plus a small unit test for the new coords helpers.

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm lint` green (no new warnings/errors)
- [x] `pnpm test:unit` green — 702 passed (4 pre-existing failures are an Electron-binary-download environment limitation in this sandbox, unrelated to this change; confirmed identical failures on `main` via `git stash`)
- [x] Added `tests/unit/coords.test.ts` coverage for `clientYToWindowY`, `pageContentBounds`, `isPointerInPageContent`

Closes #221


---
_Generated by [Claude Code](https://claude.ai/code/session_018s8pniX9e3ZwoyjRLKv8Tv)_