### PR TITLE
perf: canvas pan/zoom frame hitches + live selection chrome (#257, #265)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,7 @@ Conventions:
 ## Entity geometry
 
 - **Entity rect** — the full bounding rect of an entity, body + chrome as one layout unit ([ADR 0002](./docs/adr/0002-canvas-anchored-overlay-ui.md)). Pan / zoom / drag / resize operate on this rect.
+- **Camera** — the renderer-owned `{ x, y, zoom }` viewport transform. Canvas-space DOM (borders, entity bodies, edges, selection chrome) rides one `translate/scale` container per renderer; pan/zoom are GPU-composited, not per-entity screen coords rebuilt in main. Native pages (`WebContentsView`s) can't ride the transform, so main follows the camera to reposition them (`setBounds`) and re-emulate on zoom-*settle*. Proposed migration in [ADR 0023](./docs/adr/0023-renderer-owned-camera-gpu-panzoom.md).
 - **Body sub-rect** — the part of the entity rect that holds the entity's content (the live document for a page, the image for a file, etc.). Resize handles and edge anchors attach here.
 - **Chrome slot** — the part of the entity rect reserved for canvas-anchored overlay UI. Per-kind, runtime-derived, **not persisted** in the `.canvas` schema.
 

--- a/docs/adr/0023-renderer-owned-camera-gpu-panzoom.md
+++ b/docs/adr/0023-renderer-owned-camera-gpu-panzoom.md
@@ -1,9 +1,21 @@
 # ADR 0023 — Renderer-owned camera and GPU-composited pan/zoom
 
-**Status:** Proposed
+**Status:** Rejected — attempted then abandoned 2026-07-01 (see Postmortem below)
 **Date:** 2026-06-30
 **Related:** [ADR 0014 — Canvas stack order](./0014-canvas-stack-order.md) (the layering constraint this ADR must preserve), [ADR 0002 — Canvas-anchored overlay UI](./0002-canvas-anchored-overlay-ui.md), [ADR 0021 — Focus session](./0021-focus-session-as-first-class-concept.md), [ADR 0022 — Pages select-first / interact-second](./0022-pages-select-first-interact-second.md).
 **Origin:** Perf analysis on branch `claude/issue-265-perf-b-and-hud`, distilled from issues [#257](https://github.com/lklyne/specular/issues/257) (selection border lags during pan) and [#265](https://github.com/lklyne/specular/issues/265) (make `buildCanvasLayoutData` cheap for pan-only changes). Those two issues chipped at symptoms; this ADR names the root cause and the end-state architecture.
+
+## Postmortem — attempted and abandoned (2026-07-01)
+
+Phases 1–3 were built on branch `claude/feat-renderer-owned-camera` (step PRs #271/#275/#276) and abandoned before Phase 4 landed. Integration PR #277 was closed; the branch is kept as a record. **The design below is preserved unedited for the record — read it as the plan we tried, not current guidance.** What we learned:
+
+- **No felt improvement, worse measured cost.** After Phases 1–3, HUD frame/`build` stats during pan and zoom were *worse* than the pre-ADR baseline, and there was no perceptible smoothness gain from the migration. The two-substrate tax the ADR set out to remove did not shrink meaningfully in practice.
+- **Decision §5 rests on a false assumption.** §5 claims resizing a page's `WebContentsView` via `setBounds` lets "the view's existing raster scale (Chromium composites the view texture at the new size)." It does not. Content is pinned to the emulation `viewSize × scale` (`runtime-geometry.ts`), so a page does **not** scale during a zoom gesture — it snaps to the new scale only on the settle re-emulation. The "smooth approximate scale during the gesture" §5 promised never existed.
+- **The only ways to scale a live page during zoom both have known costs.** Per-tick `enableDeviceEmulation({ scale })` (the pre-Phase-3 behavior) scales the content but is the reflow cost Phase 3 removed; the snapshot-freeze in §6/Phase 5 is the real fix but is genuine work. `setBounds` alone — the cheap path this ADR bet on — is not an option. So Phase 5 was never optional for the "pages scale during zoom" goal, contrary to §6's "build only if profiling shows jank."
+
+**What we kept:** the #257/#265 perf work that predates the migration — live selection chrome during pan (#257), the perf HUD, chrome-layer memoization, and rAF-batched layout-update consumption (#265). Those helped and remain on `claude/issue-265-perf-b-and-hud`. Only the renderer-owned-camera refactor (Phases 1–4) was dropped.
+
+**If revisited:** start from the §5/§6 correction above — the live-page substrate is the hard part, and it needs the snapshot-freeze approach, not a `setBounds`/transform trick.
 
 ## Context
 

--- a/docs/adr/0023-renderer-owned-camera-gpu-panzoom.md
+++ b/docs/adr/0023-renderer-owned-camera-gpu-panzoom.md
@@ -1,0 +1,173 @@
+# ADR 0023 — Renderer-owned camera and GPU-composited pan/zoom
+
+**Status:** Proposed
+**Date:** 2026-06-30
+**Related:** [ADR 0014 — Canvas stack order](./0014-canvas-stack-order.md) (the layering constraint this ADR must preserve), [ADR 0002 — Canvas-anchored overlay UI](./0002-canvas-anchored-overlay-ui.md), [ADR 0021 — Focus session](./0021-focus-session-as-first-class-concept.md), [ADR 0022 — Pages select-first / interact-second](./0022-pages-select-first-interact-second.md).
+**Origin:** Perf analysis on branch `claude/issue-265-perf-b-and-hud`, distilled from issues [#257](https://github.com/lklyne/specular/issues/257) (selection border lags during pan) and [#265](https://github.com/lklyne/specular/issues/265) (make `buildCanvasLayoutData` cheap for pan-only changes). Those two issues chipped at symptoms; this ADR names the root cause and the end-state architecture.
+
+## Context
+
+Pan and zoom are the two motions a spatial canvas does most, and today both are more expensive than the pixels they move. The cause is architectural, not a hotspot: **the canvas is ~60% migrated to a camera-transform model, but inconsistently, so it pays for two positioning models at once.**
+
+### The two substrates
+
+The canvas composites two kinds of content that behave oppositely under pan/zoom:
+
+1. **Native `WebContentsView`s** (live pages, component previews) — OS-level layers positioned by main via `setBounds`, scaled via `enableDeviceEmulation({ scale: zoom })`. **They cannot ride a CSS transform** and cannot re-layout crisply at 60fps (each re-emulation is a full Chromium reflow). This is irreducible.
+2. **DOM overlay** (grid, page borders, device shells, group backgrounds, text/shape/file/drawing bodies, edges, selection chrome, guides, marquee, handles) — split across two renderer surfaces, `bgView` (below pages) and `aboveView` (above pages). **This content wants a single GPU `translate/scale` transform** — pan/zoom for free, like tldraw and Figma.
+
+### Why the DOM pays the pages' tax
+
+Because pan/zoom must go through main for the pages, and because most DOM layers are pinned to main-computed per-entity `screenX/screenY`, every pan/zoom tick incurs three costs the DOM does not need:
+
+- **Cost center 1 — full scene rebuild + serialize + 3× IPC.** `setPan` calls `markDirty('canvas')`; `setZoom` calls `markDirty('canvas', 'toolbar')` (`viewport-control.ts`). That flag gates `buildCanvasLayoutData`, which re-maps every entity to a scene entity (recomputing screen coords), builds an order-rank map, **sorts all entities + edges**, and structured-clones a payload carrying *every* entity, edge, annotation, presence cursor, and inspect-panel blob — sent to three webContents (`bgView`, `aboveView`, `cursorOverlayWindow`). The entity list is identical to the previous tick. Pure waste. (Note: `layout-dirty.ts` already documents that geometry — the per-page `setBounds` loop — runs *unconditionally*; the dirty flag gates only the IPC payload. So pan/zoom sets a flag whose sole job is to trigger work pan/zoom doesn't need.)
+- **Cost center 2 — renderer re-render.** `aboveView` has no rAF batching (`bgView` got it in #265; `aboveView` was missed): every payload → `setLayoutData` → full `App` re-render → `SelectionOutlineLayer` re-runs eight `.filter()` passes over the whole entity array (dependency is `layoutData.entities`, a fresh reference every tick, so the memos never hit). ~10–20 ms per payload at 20 pages.
+- **Cost center 3 — device-emulation reflow storm on zoom.** `pageEmulationKey` includes `zoom` (`layout-engine.ts`), so every zoom tick calls `enableDeviceEmulation` on every visible page *and* every component view — each a full Chromium reflow. There is no gesture-settle defer and no cheap visual scale during the gesture.
+
+So **pan** is expensive only because of cost centers 1 + 2. **Zoom** is expensive because of 1 + 2 + 3, and it has no live shimmer at all (`useScenePanOffset` returns zero offset when zoom changes, so the DOM waits for the heavy payload).
+
+### What is already correct (the half-migration)
+
+Two pieces of the target model already exist and are load-bearing evidence that it fits:
+
+- **Entity bodies already live in canvas space under one transform.** `ShapeViewportLayer`, `StickyViewportLayer`, `FileViewportLayer` render children at `canvasX/canvasY` inside a single `translate(canvasOrigin.x + pan.x, pan.y) scale(zoom)` container. This is the tldraw model, done right — for three of the layers.
+- **A lightweight viewport channel already exists.** `viewport-nudge` (`{ pan, zoom }`, tiny, sent immediately on every `setPan`/`setZoom`, ahead of the debounced payload) is the correctly-shaped message. #264 wired it to the chrome layer as a live-pan *patch* (`translate3d(panOffset)` on the outer container) so the border stops trailing — but it is pan-only, applied over the still-per-entity-`screenX` model, and the heavy payload still rebuilds and sends every tick beside it.
+
+### The constraint that cannot break: layering (ADR 0014)
+
+The two-surface split is not incidental — it is the *only* way to interleave DOM with native WCVs. `LAYER_STACK` (`layer-stack.ts`) pins the child-view order bottom→top: **`bgView` → pages + component WCVs → `aboveView` → devtools → toolbar.** A native WCV cannot sit inside a single renderer's DOM z-order, so "some chrome below the page, some above" *requires* two renderer views with the pages sandwiched between them. This banding (all-DOM-below < all-WCVs < all-DOM-above) is exactly what ADR 0014 §"Cross-surface visual stacking" records as architecturally fixed. **Every decision below preserves it: no content moves between renderers, and `LAYER_STACK` / `applyStack()` are untouched.**
+
+## Decision
+
+Adopt one consistent rule and migrate the remaining layers to it.
+
+> **A single camera, owned by the renderer, drives one GPU-composited transform per renderer over all canvas-space DOM. The heavy layout payload is viewport-independent — it flows only on real content change. Main is demoted to a follower for the native WCVs: it repositions them (`setBounds`) and re-emulates them once per zoom-*settle*, never per tick, and the DOM never waits on it.**
+
+This is the tldraw/Figma model, adapted to the one thing they lack — native WebContentsViews. The specific decisions:
+
+### 1. The renderer owns the camera
+
+Live `camera = { x, y, zoom }` is renderer state, updated synchronously from wheel/gesture input and applied to the scene transform in the same frame — **zero input→transform latency**. This removes even the one-IPC-hop lag the `viewport-nudge` carries today. Main stops being the pan/zoom authority for the *visual*; it becomes a consumer of the renderer's camera.
+
+Rejected: *keep main authoritative, just stop rebuilding* (the minimal version). It removes cost centers 1–2 but leaves one IPC hop of latency on every gesture — not Figma-parity. Adopted as the **Phase 1** stepping stone (main-authoritative, nudge-driven) because it de-risks the authority flip, but the end state is renderer-owned.
+
+### 2. One transform, all DOM in canvas space
+
+Every canvas-space layer in each renderer becomes a child of one `translate(x, y) scale(zoom)` container driven by the live camera:
+
+- `aboveView`: fold selection outlines, edges, guides, drawings, marquee, group bounds, and reorder dots into the same transformed container the entity bodies already use. The outer `translate3d(panOffset)` shimmer patch and the inner body transform **merge into one** — the patch *becomes* the primary transform.
+- `bgView`: grid, page borders, device shells, and group backgrounds under one transform.
+
+Per-entity screen-coordinate math in `SelectionOutlineLayer` (`span.screenX`), `EdgeLayer` (`screenX − originY`), `GuideOverlayLayer` (`x*zoom + pan.x`), and `DrawingsLayer` (per-point `canvasToScreen`) **deletes** — the transform does it on the GPU.
+
+**Screen-constant chrome exception.** Selection outlines, resize handles, and 1px borders must stay constant width in screen pixels, not scale with zoom. Standard fixes: SVG `vector-effect: non-scaling-stroke` (already used for shapes), counter-scale (`1/zoom`) on DOM handles, *or* keep selection chrome in a non-transformed overlay that projects entity bounds through the **live renderer camera** (how Figma/tldraw render selection UI). Either is fine; the invariant is that the projection source is the local camera, never a main round-trip.
+
+### 3. The layout payload is viewport-independent
+
+`setPan`/`setZoom` stop calling `markDirty('canvas')`. `buildCanvasLayoutData` no longer runs on pan/zoom, and `screenX/screenY/screenWidth/screenHeight` are removed from the entity payload and from the per-kind builders — entities ship canvas coordinates only. Anything main still needs in screen space (hit-test overlay rect, comment-hover bbox) computes on demand. The payload flows only on content/selection/order change; `aboveView` gets rAF batching and stable per-kind slices so even content payloads stop re-filtering the whole entity array.
+
+### 4. Main is a follower for the native views
+
+The renderer forwards absolute `{ pan, zoom }` to main, rAF-throttled and fire-and-forget — only so main can (a) position the WCVs via the existing unconditional `setBounds` loop and (b) persist viewport to the Y.Doc. Main does **not** echo the viewport back during a gesture, so there is no round-trip and no drift (main is a pure function of the forwarded camera). Programmatic camera moves (focus, zoom-to-fit, undo-to-tab) originate in main and *push* a target camera to the renderer, which animates its local camera via rAF; the existing `cameraTransitionStartedAt` field is the hand-off. This replaces the main-side `setInterval` camera tween in `viewport-control.ts` with a renderer rAF animation.
+
+### 5. Zoom-settle device emulation (no rasterization)
+
+A live WCV cannot re-layout crisply at 60fps. Without freezing to a bitmap, zoom has exactly one honest behavior for live pages, and it is the browser/Figma behavior: **smooth approximate scale during the gesture, one crisp re-raster on settle.**
+
+- **During an active zoom:** do not re-emulate. Track the zoomed rect via `setBounds` so the view's existing raster scales (Chromium composites the view texture at the new size). Slightly soft mid-gesture, geometrically correct.
+- **On settle** (~120–150 ms debounce after the last zoom tick): call `enableDeviceEmulation({ scale: finalZoom })` once. One reflow per gesture instead of one per 16 ms.
+- Same treatment for component views (the second emulation loop in `layout-engine.ts`).
+- Optionally re-raster DOM entity text crisp on the same settle (bump font-size once) so entity text and page content share one behavior: everything is a smooth scale during the gesture and re-rasters crisp together on settle.
+
+### 6. Rasterization freeze during gesture — deferred final step, only if needed
+
+The one way to make *live pages* GPU-smooth during a gesture (not just approximate-scaled) is to freeze them: at gesture-start, `capturePage()` each visible page into a DOM element that rides the camera transform, park the live WCV off-screen, and re-emulate + restore on settle. Then pan *and* zoom of the entire canvas — pages included — become 100% compositor operations with zero main work during the gesture, and cost becomes independent of page count.
+
+This is **explicitly deferred** (Phase 5, may never be built) because:
+
+- It re-introduces the ADR-0014 layering problem: a page snapshot must occupy the page z-band, which DOM cannot natively enter. Workable — snapshots ride `bgView`'s transformed container (above the border divs, below `aboveView` — the correct band), with live WCVs hidden for the gesture — but it is genuine coordination, not a free transform.
+- `capturePage()` is an async GPU readback (a few ms per page); at gesture-start across many pages it needs pre-warming/pipelining or it spikes.
+- Live content (video, animation) freezes for the gesture duration — imperceptible for arrange-gestures, but a real behavior change.
+
+Phases 1–4 already make the DOM fully GPU-composited and cut the native cost to one reflow per zoom-settle. Phase 5 is only warranted if profiling after Phase 4 still shows page-count-dependent jank during gestures. Recorded here so the option is designed, not discovered.
+
+## Consequences
+
+**Enables:**
+
+- Pan and zoom of all DOM become one compositor transform update — no rebuild, no sort, no serialize, no React re-render. Cost independent of entity count on the DOM side.
+- Zoom gets a live DOM shimmer (today it has none) and stops reflowing every native page per tick.
+- Zero input→transform latency (Phase 4) — Figma/tldraw-grade camera feel.
+- One coherent zoom behavior across substrates: smooth scale during the gesture, crisp re-raster on settle, for both pages and DOM entities.
+- Hit-testing and coordinate mapping read the live local camera instead of a lagged payload — more correct, not just faster.
+
+**Replaces:**
+
+- Per-entity main-computed `screenX/screenY` on DOM layers → canvas coordinates + one renderer transform.
+- The `translate3d(panOffset)` live-pan *patch* (#264) → the primary camera transform.
+- `useScenePanOffset` (pan-only nudge offset) → the renderer's own camera state (Phase 4) or a pan+zoom nudge (Phase 1).
+- The main-side `setInterval` camera tween → renderer rAF animation.
+- Per-tick `enableDeviceEmulation` → one emulation per zoom-settle.
+
+**Costs / tradeoffs:**
+
+- **The one visual concession of avoiding rasterization:** live pages are approximately scaled (slightly soft) *during* a zoom gesture and snap crisp on settle. This is the browser pinch-zoom / Figma-embedded-iframe behavior and is the correct tradeoff for a design tool. There is no third option — either soft-during-zoom (this ADR) or freeze-to-bitmap (Phase 5).
+- Renderer refactor of both `bgView` and `aboveView` scene layers (net deletion of coordinate math).
+- Authority flip (Phase 4) touches the focus/camera-animation machinery in `viewport-control.ts`; sequenced last and de-risked by Phases 1–3.
+- Screen-constant chrome needs explicit counter-scaling / camera-projection instead of falling out of main-computed screen coords.
+
+**Preserved (explicitly not changed):**
+
+- `LAYER_STACK`, `applyStack()`, and the `bgView` / WCV / `aboveView` banding (ADR 0014). `layoutAllViews()` still runs every pan/zoom tick (the `setBounds` loop must, to move the WCVs); only the payload build/send is removed. Z-order reconciliation is independent of the viewport and untouched.
+- All user-facing functionality — this is a rendering-path change, not a behavior change.
+
+**Out of scope:**
+
+- **Entity drag** carries the identical waste (`canvas-drag-*` → `requestLayout` → full rebuild per tick). The same principle applies (ship a minimal delta, move the entity live under the transform), and it falls out of this architecture cheaply, but it is a separate change.
+- Cross-surface visual stacking (ADR 0014 out-of-scope) — unchanged.
+- The `cursorOverlayWindow` presence-cursor rendering model beyond joining the viewport channel (Phase 1).
+
+## Migration plan
+
+Five slices, each an independently shippable PR (mapping to one AFK-local step each). Phases 1–3 deliver essentially all the felt smoothness; Phase 4 is Figma-parity; Phase 5 is the deferred rasterization escape hatch.
+
+**Phase 1 — De-dirty the viewport + batch the renderer (main stays authoritative).**
+The minimal high-leverage cut. Keep main as the pan/zoom authority, but:
+- `setPan`/`setZoom` stop calling `markDirty('canvas')`; `buildCanvasLayoutData` stops running on pan/zoom.
+- Extend `viewport-nudge` to carry and apply zoom (not just pan), and drive the *whole* scene transform from it in both renderers — including the layers currently pinned to `screenX` (temporarily projected renderer-side from the nudge).
+- rAF-batch `aboveView`'s `onLayoutUpdate` (match `bgView`, #265); hoist stable per-kind slices so `SelectionOutlineLayer` stops re-filtering the full array.
+- `cursorOverlayWindow` joins the `viewport-nudge` channel so cursors track pan without the heavy payload.
+- *Result:* pan and zoom stop rebuilding/serializing/re-rendering. Biggest single win; low risk (authority unchanged). Largely resolves #265. HUD `build`/`hitch` should drop sharply during pan.
+
+**Phase 2 — One transform, delete screen coordinates.**
+- Move every remaining `aboveView` and `bgView` layer into one canvas-space transform container (selection outlines, edges, guides, drawings, page chrome).
+- Delete `screenX/screenY/screenWidth/screenHeight` from the entity payload and the per-kind builders; entities ship canvas coords.
+- Implement screen-constant chrome (non-scaling stroke / counter-scale / camera projection).
+- Add GPU hygiene: `will-change: transform` on the scene containers so pan/zoom composite without paint (one compositor layer per renderer).
+- *Result:* the coordinate math deletes; zoom shimmers on the DOM; the payload is fully viewport-independent.
+
+**Phase 3 — Zoom-settle device emulation.**
+- `setBounds`-only during an active zoom; `enableDeviceEmulation` once on a ~120–150 ms settle debounce, for pages and component views.
+- Optional: re-raster DOM entity text crisp on the same settle.
+- Cull hysteresis so edge-hovering pages don't toggle bounds every pan tick.
+- *Result:* live pages stop reflowing per zoom tick; the worst zoom cost is gone. Orthogonal to 1–2.
+
+**Phase 4 — Renderer-owned camera (zero-latency).**
+- Move pan/zoom integration into the renderer; apply the transform in the input frame; forward absolute `{ pan, zoom }` to main rAF-throttled for `setBounds` + persist.
+- Main→renderer camera *push* for programmatic moves via `cameraTransitionStartedAt`; renderer rAF animation replaces the main `setInterval` tween.
+- Delete the two stacked 16 ms timers on the viewport path (the drag-IPC coalescer and the `requestLayout` viewport debounce).
+- Memoize the scene build so content-change payloads don't re-map + re-sort from scratch.
+- *Result:* zero input→transform latency; the true Figma/tldraw camera. De-risked by Phases 1–3.
+
+**Phase 5 — Rasterization freeze during gesture (deferred, build only if needed).**
+- Per decision §6. Snapshot visible pages into `bgView`'s transformed container at gesture-start, park live WCVs, re-emulate + restore on settle.
+- Gate on profiling: only if page-count-dependent gesture jank survives Phase 4.
+
+## Tests
+
+- **Unit:** camera → transform projection is exact (canvas↔screen round-trips within 0.5 px at representative zooms); screen-constant chrome holds constant screen width across zoom levels.
+- **Smoke:** during a pan of a ~20-page canvas, `buildCanvasLayoutData` does not run (instrument the build counter / `buildMs`) — the scene list is reused (the #265 acceptance criterion, now satisfied structurally).
+- **Smoke:** chrome, borders, selection outlines, edges, and entity bodies stay pixel-locked to their pages/entities through pan → zoom → entity edit → undo/redo (the #257 lag, now impossible — DOM and WCVs read the same camera).
+- **Smoke:** stack order (ADR 0014) is unaffected — two overlapping pages resolve clicks and paint correctly after the migration; `LAYER_STACK` order in `win.contentView.children` is unchanged by a pan/zoom.
+- **Smoke:** a programmatic camera move (focus / zoom-to-fit) animates and lands at the same final camera as before (Phase 4 authority flip is behavior-preserving).
+- **Perf (HUD-assisted, manual):** frame `hitch` during sustained pan and zoom on a 20-page canvas stays within budget; `build` is flat (not spiking) during movement.

--- a/src/main/runtime/layout-engine.ts
+++ b/src/main/runtime/layout-engine.ts
@@ -234,7 +234,9 @@ function layoutAllViews(): void {
     const bgWidth = Math.max(0, width - (devtoolsOpen ? devtoolsWidth : 0))
     layoutCache.lastBackgroundBoundsKey = setBoundsIfChanged(bgView, { x: 0, y: 0, width: bgWidth, height }, layoutCache.lastBackgroundBoundsKey)
     if (consumeDirty('canvas')) {
+      const buildStart = performance.now()
       const layoutData = buildCanvasLayoutData(pageOverlays, nextActiveSelection)
+      layoutData.buildMs = performance.now() - buildStart
       bgView.webContents.send('layout-update', layoutData)
       sendAnnotationLayoutUpdate(layoutData)
       bgView.webContents.send('component-tree-data', selectedComponentTreePayload())

--- a/src/main/runtime/viewport-control.ts
+++ b/src/main/runtime/viewport-control.ts
@@ -32,6 +32,7 @@ import {
   pageVisualBoundsForContentSize,
 } from './runtime-geometry'
 import { scheduleWorkspaceAutosave } from './workspace-autosave'
+import { broadcastViewportNudge } from './viewport-nudge'
 import { safeSend } from './safe-send'
 import { clampCanvasZoom } from '../../shared/zoom'
 import {
@@ -65,6 +66,7 @@ export function setZoom(value: number): void {
   if (nextZoom === zoom) return
   setZoomState(nextZoom)
   markDirty('canvas', 'toolbar')
+  broadcastViewportNudge()
   broadcastCanvasZoomToPages()
   if (!suppressCameraAutosave) scheduleWorkspaceAutosave()
 }
@@ -81,6 +83,7 @@ export function setPan(x: number, y: number): void {
   if (pan.x === x && pan.y === y) return
   setPanState({ x, y })
   markDirty('canvas')
+  broadcastViewportNudge()
   if (!suppressCameraAutosave) scheduleWorkspaceAutosave()
 }
 

--- a/src/main/runtime/viewport-nudge.ts
+++ b/src/main/runtime/viewport-nudge.ts
@@ -1,0 +1,20 @@
+import type { ViewportNudge } from '../../shared/types'
+import { aboveView, bgView } from './view-refs'
+import { pan, zoom } from './runtime-context'
+import { safeSend } from './safe-send'
+
+/**
+ * Push the authoritative viewport to the canvas overlay renderers immediately,
+ * bypassing the debounced layout pass. The canvas-bg and above-view scene
+ * layers translate by (livePan − payloadPan) so selection chrome and entity
+ * bodies track the natively-positioned page views during a pan, instead of
+ * trailing until the next full layout-update rebuild lands (which scales with
+ * entity count). The eventual layout-update reconciles the offset back to zero.
+ * See #257.
+ */
+export function broadcastViewportNudge(): void {
+  if (!bgView && !aboveView) return
+  const payload: ViewportNudge = { pan: { x: pan.x, y: pan.y }, zoom }
+  if (bgView) safeSend(bgView.webContents, 'viewport-nudge', payload)
+  if (aboveView) safeSend(aboveView.webContents, 'viewport-nudge', payload)
+}

--- a/src/preload/canvas-bg.ts
+++ b/src/preload/canvas-bg.ts
@@ -8,6 +8,7 @@ import type {
   LayoutUpdateData,
   SelectionOverlayPayload,
   ToolDefaultPatch,
+  ViewportNudge,
 } from '../shared/types'
 import type { BindingId } from '../shared/bindings'
 import type { CancelReason } from '../shared/interaction-types'
@@ -357,6 +358,11 @@ const api: CanvasBgElectronAPI = {
     const handler = (_event: Electron.IpcRendererEvent, data: LayoutUpdateData) => callback(data)
     ipcRenderer.on('layout-update', handler)
     return () => ipcRenderer.removeListener('layout-update', handler)
+  },
+  onViewportNudge: (callback) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: ViewportNudge) => callback(data)
+    ipcRenderer.on('viewport-nudge', handler)
+    return () => ipcRenderer.removeListener('viewport-nudge', handler)
   },
   onFixProgressUpdate: (callback) => {
     const handler = (_event: Electron.IpcRendererEvent, data: LayoutUpdateData['fixProgress']) =>

--- a/src/renderer/above-view/App.tsx
+++ b/src/renderer/above-view/App.tsx
@@ -80,6 +80,7 @@ import { useCanvasClipboard } from '../canvas-bg/useCanvasClipboard'
 import { buildAboveViewHandlers } from './binding-handlers'
 import { useReportTextEditing } from '../shared/hooks/useReportTextEditing'
 import { useRendererBindingHandlers } from '../shared/hooks/useRendererBindingHandlers'
+import { useScenePanOffset } from '../shared/hooks/useScenePanOffset'
 import { useTheme } from '../shared/hooks/useTheme'
 import { useViewportWheelAndMiddlePan } from '../shared/hooks/useViewportWheelAndMiddlePan'
 
@@ -407,6 +408,7 @@ export default function App({
   const threadInputRef = useRef<HTMLTextAreaElement>(null)
   const activeStrokeRef = useRef<{ pointerId: number; strokeId: string } | null>(null)
   const [layoutData, setLayoutData] = useState<LayoutUpdateData>(initialLayoutData)
+  const panOffset = useScenePanOffset(api.onViewportNudge, layoutData)
   const [fixProgress, setFixProgress] = useState<LayoutUpdateData['fixProgress']>(
     initialLayoutData.fixProgress,
   )
@@ -1319,6 +1321,15 @@ html:active, body:active, body *:active { cursor: grabbing !important; }`
       onPointerUp={handleOverlayPointerUp}
       onPointerCancel={handleOverlayPointerCancel}
     >
+      {/* Translate the whole canvas scene live with the pan gesture so selection
+          chrome and entity bodies track the natively-positioned page views
+          instead of trailing until the next layout-update rebuild (#257). Pan is
+          disabled during focus, where the only viewport-pinned chrome exists, so
+          every layer here is canvas-space and moves together. */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ transform: `translate3d(${panOffset.x}px, ${panOffset.y}px, 0)` }}
+      >
       {placementPreview && selectionOverlay?.variant !== 'place-shape' ? (
         <PlacementPreviewLayer
           isDark={isDark}
@@ -1591,6 +1602,7 @@ html:active, body:active, body *:active { cursor: grabbing !important; }`
           />
         </>
       ) : null}
+      </div>
     </div>
   )
 }

--- a/src/renderer/canvas-bg/App.tsx
+++ b/src/renderer/canvas-bg/App.tsx
@@ -17,6 +17,7 @@ import { PageBorderLayer } from './PageBorderLayer'
 import { SvgDeviceShellLayer } from './SvgDeviceShellLayer'
 import { useCanvasLayoutState } from './useCanvasLayoutState'
 import { useCanvasViewportGestures } from './useCanvasViewportGestures'
+import { useScenePanOffset } from '../shared/hooks/useScenePanOffset'
 
 const api = (window as unknown as { electronAPI: CanvasBgElectronAPI }).electronAPI
 
@@ -34,6 +35,11 @@ export default function App({
   const isDark = useTheme(initialTheme, api.onThemeChanged)
   useReportTextEditing(api.setTextEditing)
   const { layoutData, layoutRef, layoutTick } = useCanvasLayoutState({ api, initialLayoutData })
+  const panOffset = useScenePanOffset(api.onViewportNudge, layoutData)
+  const livePan = useMemo(
+    () => ({ x: layoutData.pan.x + panOffset.x, y: layoutData.pan.y + panOffset.y }),
+    [layoutData.pan.x, layoutData.pan.y, panOffset.x, panOffset.y],
+  )
 
   useCanvasViewportGestures({
     api,
@@ -81,27 +87,35 @@ export default function App({
         bgRef={bgRef}
         isDark={isDark}
         canvasOrigin={layoutData.canvasOrigin}
-        pan={layoutData.pan}
+        pan={livePan}
         zoom={layoutData.zoom}
       />
-      <GroupBackgroundLayer
-        groups={hideContext ? [] : (layoutData.groups ?? [])}
-        isDark={isDark}
-      />
-      <div className="pointer-events-none absolute inset-0">
-        <PageBorderLayer
-          pages={chromePages}
-          fileEntities={chromeFiles}
-        />
-        <DeviceShellLayer
-          pages={chromePages.filter((f) => !f.useSvgDeviceShell)}
-          fileEntities={chromeFiles}
+      {/* Translate the page chrome live with the pan gesture so borders and
+          device shells track the natively-positioned page views instead of
+          trailing until the next layout-update rebuild lands (#257). */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ transform: `translate3d(${panOffset.x}px, ${panOffset.y}px, 0)` }}
+      >
+        <GroupBackgroundLayer
+          groups={hideContext ? [] : (layoutData.groups ?? [])}
           isDark={isDark}
         />
-        <SvgDeviceShellLayer
-          pages={chromePages.filter((f) => f.useSvgDeviceShell)}
-          isDark={isDark}
-        />
+        <div className="pointer-events-none absolute inset-0">
+          <PageBorderLayer
+            pages={chromePages}
+            fileEntities={chromeFiles}
+          />
+          <DeviceShellLayer
+            pages={chromePages.filter((f) => !f.useSvgDeviceShell)}
+            fileEntities={chromeFiles}
+            isDark={isDark}
+          />
+          <SvgDeviceShellLayer
+            pages={chromePages.filter((f) => f.useSvgDeviceShell)}
+            isDark={isDark}
+          />
+        </div>
       </div>
 
       {/* Group selection popup migrated to above-view (ADR 0008 §1, step 5).

--- a/src/renderer/canvas-bg/App.tsx
+++ b/src/renderer/canvas-bg/App.tsx
@@ -14,6 +14,7 @@ import { CanvasDebugBadge, CanvasGridSurface } from './CanvasGridSurface'
 import { DeviceShellLayer } from './DeviceShellLayer'
 import { GroupBackgroundLayer } from './GroupBackgroundLayer'
 import { PageBorderLayer } from './PageBorderLayer'
+import { PerfHudOverlay } from './PerfHudOverlay'
 import { SvgDeviceShellLayer } from './SvgDeviceShellLayer'
 import { useCanvasLayoutState } from './useCanvasLayoutState'
 import { useCanvasViewportGestures } from './useCanvasViewportGestures'
@@ -83,6 +84,7 @@ export default function App({
         isDev={isDev}
         layoutTick={layoutTick}
       />
+      <PerfHudOverlay isDev={isDev} layoutData={layoutData} />
       <CanvasGridSurface
         bgRef={bgRef}
         isDark={isDark}

--- a/src/renderer/canvas-bg/App.tsx
+++ b/src/renderer/canvas-bg/App.tsx
@@ -71,6 +71,21 @@ export default function App({
     () => (hideContext ? [] : fileEntities),
     [fileEntities, hideContext],
   )
+  // Hoist per-layer slices so the memoized layers receive stable array refs and
+  // skip re-rendering on every pan/zoom nudge (props only change on a real
+  // layout-update). Inline .filter() in JSX would defeat React.memo (#265).
+  const deviceShellPages = useMemo(
+    () => chromePages.filter((f) => !f.useSvgDeviceShell),
+    [chromePages],
+  )
+  const svgDeviceShellPages = useMemo(
+    () => chromePages.filter((f) => f.useSvgDeviceShell),
+    [chromePages],
+  )
+  const chromeGroups = useMemo(
+    () => (hideContext ? [] : (layoutData.groups ?? [])),
+    [hideContext, layoutData.groups],
+  )
   return (
     <div
       className="relative h-screen w-screen overflow-hidden"
@@ -99,22 +114,19 @@ export default function App({
         className="pointer-events-none absolute inset-0"
         style={{ transform: `translate3d(${panOffset.x}px, ${panOffset.y}px, 0)` }}
       >
-        <GroupBackgroundLayer
-          groups={hideContext ? [] : (layoutData.groups ?? [])}
-          isDark={isDark}
-        />
+        <GroupBackgroundLayer groups={chromeGroups} isDark={isDark} />
         <div className="pointer-events-none absolute inset-0">
           <PageBorderLayer
             pages={chromePages}
             fileEntities={chromeFiles}
           />
           <DeviceShellLayer
-            pages={chromePages.filter((f) => !f.useSvgDeviceShell)}
+            pages={deviceShellPages}
             fileEntities={chromeFiles}
             isDark={isDark}
           />
           <SvgDeviceShellLayer
-            pages={chromePages.filter((f) => f.useSvgDeviceShell)}
+            pages={svgDeviceShellPages}
             isDark={isDark}
           />
         </div>

--- a/src/renderer/canvas-bg/CanvasGridSurface.tsx
+++ b/src/renderer/canvas-bg/CanvasGridSurface.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { PLAIN_TEXT_PLACEHOLDER } from '../../shared/constants'
 import type { TextEntityStyle } from '../../shared/types'
 import { resolveCanvasColor } from '../../shared/canvas-colors'
@@ -59,33 +59,43 @@ export function CanvasGridSurface({
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const gridStyle = useMemo(() => buildCanvasGridStyle(), [])
 
+  // Latest draw inputs, read by the resize-triggered redraw without re-binding
+  // the observer every pan tick (#265).
+  const drawInputs = useRef({ canvasOrigin, pan, zoom, isDark })
+  drawInputs.current = { canvasOrigin, pan, zoom, isDark }
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const { canvasOrigin: o, pan: p, zoom: z, isDark: dark } = drawInputs.current
+    drawCanvasGrid({
+      canvas,
+      color: dark ? '#78716c' : '#a8a29e',
+      canvasOrigin: o,
+      pan: p,
+      zoom: z,
+      isDark: dark,
+      devicePixelRatio: window.devicePixelRatio || 1,
+    })
+  }, [])
+
+  // Redraw when the viewport changes.
+  useEffect(() => {
+    draw()
+  }, [canvasOrigin, isDark, pan, zoom, draw])
+
+  // Bind resize listeners once — not on every pan.
   useEffect(() => {
     const surface = bgRef.current
-    const canvas = canvasRef.current
-    if (!surface || !canvas) return
-
-    const draw = () => {
-      drawCanvasGrid({
-        canvas,
-        color: isDark ? '#78716c' : '#a8a29e',
-        canvasOrigin,
-        pan,
-        zoom,
-        isDark,
-        devicePixelRatio: window.devicePixelRatio || 1,
-      })
-    }
-
-    draw()
+    if (!surface) return
     const resizeObserver = new ResizeObserver(draw)
     resizeObserver.observe(surface)
     window.addEventListener('resize', draw)
-
     return () => {
       resizeObserver.disconnect()
       window.removeEventListener('resize', draw)
     }
-  }, [bgRef, canvasOrigin, isDark, pan, zoom])
+  }, [bgRef, draw])
 
   return (
     <div

--- a/src/renderer/canvas-bg/DeviceShellLayer.tsx
+++ b/src/renderer/canvas-bg/DeviceShellLayer.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import type { CanvasScenePageEntity, CanvasSceneFileEntity } from '../../shared/types'
 import {
   CUSTOM_SHELL_CORNER_RADIUS,
@@ -23,7 +24,7 @@ interface DeviceShellItem {
   width: number
 }
 
-export function DeviceShellLayer({
+export const DeviceShellLayer = memo(function DeviceShellLayer({
   pages,
   fileEntities,
   isDark,
@@ -198,7 +199,7 @@ export function DeviceShellLayer({
       {framedFiles.map(renderItem)}
     </>
   )
-}
+})
 
 function pct(value: number, total: number): string {
   return `${((value / total) * 100).toFixed(4)}%`

--- a/src/renderer/canvas-bg/PageBorderLayer.tsx
+++ b/src/renderer/canvas-bg/PageBorderLayer.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { memo } from 'react'
 import type { CanvasScenePageEntity, CanvasSceneFileEntity } from '../../shared/types'
 import {
   CUSTOM_SHELL_CORNER_RADIUS,
@@ -24,7 +24,7 @@ type BorderItem = {
   width: number
 }
 
-export function PageBorderLayer({
+export const PageBorderLayer = memo(function PageBorderLayer({
   pages,
   fileEntities,
   offsetY = 0,
@@ -102,4 +102,4 @@ export function PageBorderLayer({
       })}
     </>
   )
-}
+})

--- a/src/renderer/canvas-bg/PerfHudOverlay.tsx
+++ b/src/renderer/canvas-bg/PerfHudOverlay.tsx
@@ -91,10 +91,22 @@ export function PerfHudOverlay({
   const buildMs = useRef<number[]>([])
   const lastFrameTs = useRef(0)
 
+  // Off by default; opt in per-machine with `localStorage.perfHud = '1'` in the
+  // canvas devtools console, then reload. Dev-only tool, dev-only switch — not
+  // worth the cross-window preference plumbing a UI toggle would need.
+  const [enabled] = useState(() => {
+    try {
+      return localStorage.getItem('perfHud') === '1'
+    } catch {
+      return false
+    }
+  })
+  const active = isDev && enabled
+
   // Sample every real frame into a ring buffer; never setState here — that
   // would re-render 120x/sec and pollute the very numbers we're measuring.
   useEffect(() => {
-    if (!isDev) return
+    if (!active) return
     let raf = 0
     const loop = (ts: number) => {
       if (lastFrameTs.current) pushCapped(frameMs.current, ts - lastFrameTs.current)
@@ -103,21 +115,21 @@ export function PerfHudOverlay({
     }
     raf = requestAnimationFrame(loop)
     return () => cancelAnimationFrame(raf)
-  }, [isDev])
+  }, [active])
 
   // Repaint the readout at a fixed 4Hz, decoupled from the frame loop.
   useEffect(() => {
-    if (!isDev) return
+    if (!active) return
     const id = setInterval(() => forceTick((n) => n + 1), 250)
     return () => clearInterval(id)
-  }, [isDev])
+  }, [active])
 
   // Record each layout build cost as its payload lands.
   useEffect(() => {
     if (layoutData.buildMs != null) pushCapped(buildMs.current, layoutData.buildMs)
   }, [layoutData])
 
-  if (!isDev) return null
+  if (!active) return null
 
   const frames = frameMs.current
   const recentFrames = frames.slice(-15)

--- a/src/renderer/canvas-bg/PerfHudOverlay.tsx
+++ b/src/renderer/canvas-bg/PerfHudOverlay.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useRef, useState } from 'react'
+import type { LayoutUpdateData } from '../../shared/types'
+
+// ~2s of frames at 120fps — long enough that a spike stays readable.
+const RING = 240
+const FRAME_BUDGET_MS = 1000 / 60
+
+function pushCapped(buf: number[], value: number): void {
+  buf.push(value)
+  if (buf.length > RING) buf.shift()
+}
+
+function maxOf(values: number[]): number {
+  let m = 0
+  for (const v of values) if (v > m) m = v
+  return m
+}
+
+function Spark({
+  values,
+  ceiling,
+  target,
+  width = 148,
+  height = 26,
+}: {
+  values: number[]
+  ceiling: number
+  target: number
+  width?: number
+  height?: number
+}) {
+  const hi = Math.max(ceiling, maxOf(values))
+  const step = width / (RING - 1)
+  const points = values
+    .map((v, i) => `${(i * step).toFixed(1)},${(height - (v / hi) * height).toFixed(1)}`)
+    .join(' ')
+  const targetY = height - (target / hi) * height
+  return (
+    <svg width={width} height={height} className="block text-zinc-400 dark:text-zinc-500">
+      <line
+        x1={0}
+        y1={targetY}
+        x2={width}
+        y2={targetY}
+        stroke="currentColor"
+        strokeOpacity={0.5}
+        strokeDasharray="2 2"
+      />
+      {values.length > 1 ? (
+        <polyline
+          points={points}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1}
+          className="text-zinc-700 dark:text-zinc-200"
+        />
+      ) : null}
+    </svg>
+  )
+}
+
+// A single slow frame is what reads as a hitch — colour by the worst recent
+// frame, not the average. Thresholds are display-agnostic: a >2-frame stall is
+// visible on any refresh rate.
+function hitchColor(worstFrameMs: number): string {
+  if (worstFrameMs <= FRAME_BUDGET_MS * 1.5) return 'text-emerald-600 dark:text-emerald-400'
+  if (worstFrameMs <= FRAME_BUDGET_MS * 3) return 'text-amber-500'
+  return 'text-red-500'
+}
+
+/**
+ * Dev-only heads-up display for canvas rendering cost. Left readout measures
+ * real renderer frame intervals (rAF); right readout charts the main-process
+ * `buildCanvasLayoutData` duration stamped onto each layout-update. Peaks are
+ * held over the sample window so a spike during pan/zoom stays readable, and
+ * the two columns discriminate the bottleneck: a build spike points at the
+ * O(entities) rebuild (#265 Option B), a frame spike with a flat build points
+ * at renderer churn instead. Click the pill to expand the sparklines. Never a
+ * pointer target except the collapsed pill.
+ */
+export function PerfHudOverlay({
+  isDev,
+  layoutData,
+}: {
+  isDev: boolean
+  layoutData: LayoutUpdateData
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const [, forceTick] = useState(0)
+  const frameMs = useRef<number[]>([])
+  const buildMs = useRef<number[]>([])
+  const lastFrameTs = useRef(0)
+
+  // Sample every real frame into a ring buffer; never setState here — that
+  // would re-render 120x/sec and pollute the very numbers we're measuring.
+  useEffect(() => {
+    if (!isDev) return
+    let raf = 0
+    const loop = (ts: number) => {
+      if (lastFrameTs.current) pushCapped(frameMs.current, ts - lastFrameTs.current)
+      lastFrameTs.current = ts
+      raf = requestAnimationFrame(loop)
+    }
+    raf = requestAnimationFrame(loop)
+    return () => cancelAnimationFrame(raf)
+  }, [isDev])
+
+  // Repaint the readout at a fixed 4Hz, decoupled from the frame loop.
+  useEffect(() => {
+    if (!isDev) return
+    const id = setInterval(() => forceTick((n) => n + 1), 250)
+    return () => clearInterval(id)
+  }, [isDev])
+
+  // Record each layout build cost as its payload lands.
+  useEffect(() => {
+    if (layoutData.buildMs != null) pushCapped(buildMs.current, layoutData.buildMs)
+  }, [layoutData])
+
+  if (!isDev) return null
+
+  const frames = frameMs.current
+  const recentFrames = frames.slice(-15)
+  const avgFrame = recentFrames.length
+    ? recentFrames.reduce((a, b) => a + b, 0) / recentFrames.length
+    : 0
+  const fps = avgFrame ? Math.round(1000 / avgFrame) : 0
+  const worstFrame = maxOf(frames) // held over the ~2s window
+
+  const builds = buildMs.current
+  const lastBuild = builds.length ? builds[builds.length - 1] : 0
+  const peakBuild = maxOf(builds)
+
+  return (
+    <div className="pointer-events-none absolute left-2 top-10 z-[71] select-none font-mono text-[10px] text-zinc-700 dark:text-zinc-200">
+      <div className="pointer-events-auto inline-block rounded border border-zinc-300/80 bg-white/90 shadow dark:border-zinc-600 dark:bg-zinc-900/90">
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 px-2 py-1"
+          onClick={() => setExpanded((e) => !e)}
+        >
+          <span>{fps} fps</span>
+          <span className="text-zinc-400">·</span>
+          {/* Worst frame in the window — the number that tracks felt jitter. */}
+          <span className={hitchColor(worstFrame)}>hitch {worstFrame.toFixed(0)}ms</span>
+        </button>
+        {expanded ? (
+          <div className="border-t border-zinc-200 px-2 pb-2 pt-1 dark:border-zinc-700">
+            <div className="flex justify-between gap-3">
+              <span>frame</span>
+              <span className={hitchColor(worstFrame)}>peak {worstFrame.toFixed(1)}ms</span>
+            </div>
+            <Spark values={frames} ceiling={FRAME_BUDGET_MS * 2} target={FRAME_BUDGET_MS} />
+            <div className="mt-1 flex justify-between gap-3">
+              <span>build</span>
+              <span>
+                {lastBuild.toFixed(1)} · peak {peakBuild.toFixed(1)}ms
+              </span>
+            </div>
+            <Spark values={builds} ceiling={FRAME_BUDGET_MS} target={FRAME_BUDGET_MS} />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/canvas-bg/SvgDeviceShellLayer.tsx
+++ b/src/renderer/canvas-bg/SvgDeviceShellLayer.tsx
@@ -18,6 +18,7 @@
  * the right details panel, currently commented out).
  */
 
+import { memo } from 'react'
 import type { CanvasScenePageEntity } from '../../shared/types'
 import {
   DEVICE_CATALOG,
@@ -25,7 +26,7 @@ import {
 } from '../../shared/device-catalog'
 import { squirclePath } from './squirclePath'
 
-export function SvgDeviceShellLayer({
+export const SvgDeviceShellLayer = memo(function SvgDeviceShellLayer({
   pages,
   isDark,
 }: {
@@ -188,4 +189,4 @@ export function SvgDeviceShellLayer({
       })}
     </>
   )
-}
+})

--- a/src/renderer/canvas-bg/useCanvasLayoutState.ts
+++ b/src/renderer/canvas-bg/useCanvasLayoutState.ts
@@ -13,12 +13,28 @@ export function useCanvasLayoutState({
   const [layoutTick, setLayoutTick] = useState(0)
 
   useEffect(() => {
+    // During a fast zoom the main process emits a payload per tick, faster than
+    // one per frame. Keep the ref current synchronously (gesture logic reads it
+    // on every pointer event) but coalesce the React render to one per animation
+    // frame, so a burst of payloads collapses into a single re-render (#265).
+    let pending: LayoutUpdateData | null = null
+    let raf = 0
+    const flush = () => {
+      raf = 0
+      if (!pending) return
+      setLayoutData(pending)
+      setLayoutTick((current) => current + 1)
+      pending = null
+    }
     const cleanup = api.onLayoutUpdate((data) => {
       layoutRef.current = data
-      setLayoutData(data)
-      setLayoutTick((current) => current + 1)
+      pending = data
+      if (!raf) raf = requestAnimationFrame(flush)
     })
-    return cleanup
+    return () => {
+      cleanup()
+      if (raf) cancelAnimationFrame(raf)
+    }
   }, [api])
 
   return {

--- a/src/renderer/shared/hooks/useScenePanOffset.ts
+++ b/src/renderer/shared/hooks/useScenePanOffset.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+import type { ViewportNudge } from '../../../shared/types'
+
+const ZERO = { x: 0, y: 0 }
+
+/**
+ * Live screen-space offset to apply to the canvas scene so it tracks a pan
+ * before the debounced `layout-update` catches up. Main pushes a viewport
+ * nudge on every pan/zoom; the offset is `livePan − payloadPan`, which
+ * self-reconciles to zero as soon as a fresh layout-update lands with the
+ * matching pan.
+ *
+ * Pan-only: a zoom change rescales the scene rather than translating it, so
+ * when the nudge's zoom differs from the payload we yield no offset and let the
+ * next layout-update reposition. Zoom gestures are comparatively rare and the
+ * payload lands within a couple of frames. See #257.
+ */
+export function useScenePanOffset(
+  onViewportNudge: (cb: (nudge: ViewportNudge) => void) => () => void,
+  payload: { pan: { x: number; y: number }; zoom: number },
+): { x: number; y: number } {
+  const [nudge, setNudge] = useState<ViewportNudge | null>(null)
+  useEffect(() => onViewportNudge(setNudge), [onViewportNudge])
+
+  if (!nudge || nudge.zoom !== payload.zoom) return ZERO
+  const x = nudge.pan.x - payload.pan.x
+  const y = nudge.pan.y - payload.pan.y
+  if (x === 0 && y === 0) return ZERO
+  return { x, y }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1678,6 +1678,18 @@ export interface ToolbarElectronAPI {
   repoDisconnect: (id: string) => Promise<void>
 }
 
+/**
+ * The authoritative viewport, pushed to the overlay renderers immediately on a
+ * pan/zoom — ahead of the debounced `layout-update` rebuild. The canvas scene
+ * layers translate by (livePan − payloadPan) so selection chrome and entity
+ * bodies track the natively-positioned page views during a pan instead of
+ * waiting for the next full rebuild. See #257.
+ */
+export interface ViewportNudge {
+  pan: { x: number; y: number }
+  zoom: number
+}
+
 export interface CanvasBgElectronAPI {
   canvasZoom: (deltaY: number, mouseX: number, mouseY: number) => void
   canvasPan: (deltaX: number, deltaY: number) => void
@@ -1901,6 +1913,7 @@ export interface CanvasBgElectronAPI {
    *  connected repo, or null if connection fails. */
   repoConnect: (absolutePath: string) => Promise<unknown>
   onLayoutUpdate: (callback: (data: LayoutUpdateData) => void) => () => void
+  onViewportNudge: (callback: (data: ViewportNudge) => void) => () => void
   onFixProgressUpdate: (
     callback: (data: LayoutUpdateData['fixProgress']) => void,
   ) => () => void

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -429,6 +429,13 @@ export type PersistedCanvasEntity =
 // --- Layout Update Data ---
 
 export interface LayoutUpdateData {
+  /**
+   * Wall-clock milliseconds `buildCanvasLayoutData` took to produce this
+   * payload, stamped by the layout pass. Diagnostic only — feeds the canvas
+   * perf HUD so the O(entities) rebuild cost is visible during pan/zoom. See
+   * #257 / #265.
+   */
+  buildMs?: number
   windowWidth: number
   zoom: number
   pan: { x: number; y: number }


### PR DESCRIPTION
## What this lands

The canvas pan/zoom perf work from #257/#265 that measurably helped, plus the record of a follow-on refactor that didn't:

- **Live selection chrome during pan (#257)** — selection borders/handles track their entities without trailing.
- **Kill pan/zoom frame hitches (#265)** — rAF-batched layout-update consumption, chrome-layer memoization, and a stop to grid-observer churn.
- **Dev perf HUD (#265)** — canvas frame-interval + `buildCanvasLayoutData` sparklines. Now **off by default** (see below).
- **ADR 0023 — rejected, with postmortem.** The renderer-owned-camera / GPU pan/zoom migration this HUD was built to guide was attempted on `claude/feat-renderer-owned-camera` and abandoned.

## ADR 0023 outcome

Phases 1–3 shipped to `claude/feat-renderer-owned-camera` (PRs #271/#275/#276) and were abandoned before Phase 4. Integration PR #277 is closed; that branch is kept as a record. Reasons, captured in the ADR postmortem:

- Worse measured frame/`build` cost after the migration, with no perceptible smoothness gain.
- Decision §5's load-bearing assumption was false: resizing a page's `WebContentsView` via `setBounds` does **not** stretch its raster, so live pages never scaled during a zoom gesture — they snapped on the settle re-emulation. Live scaling needs per-tick `enableDeviceEmulation` (the reflow cost Phase 3 removed) or the snapshot-freeze (§6/Phase 5), never the cheap `setBounds` trick the ADR bet on.

The ADR body is preserved unedited with a "read as the plan we tried, not current guidance" banner.

## Perf HUD gating

Off unless `localStorage.perfHud === '1'` (per machine, reload to apply). A UI checkbox in the debug window would need the full cross-window preference plumbing (`cursorSplineViz` pattern: shared type + `preferences.ts` + preload on both bridges + both renderers) — not worth it for a dev-only readout that's already invisible in production.

## Manual test

1. `pnpm dev`, open a canvas with several live pages.
2. Pan/zoom — selection chrome and borders stay pinned to their entities, no trailing (#257).
3. Perf HUD is **not** visible by default. In the canvas devtools console: `localStorage.perfHud = '1'`, reload → the `fps · hitch` pill appears top-left; click to expand frame/build sparklines. Remove the key + reload → gone.
4. `docs/adr/0023-renderer-owned-camera-gpu-panzoom.md` shows **Status: Rejected** with the postmortem up top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
