### PR TITLE
[codex] Fix pnpm dev setup and skills wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@9.5.0",
+  "packageManager": "pnpm@11.9.0",
   "scripts": {
     "dev": "pnpm fetch:agent-browser && pnpm build:mcp-helper && pnpm build:cli && electron-forge start",
     "dev:restart": "bash scripts/dev-restart.sh",
@@ -80,16 +80,5 @@
     "typescript-eslint": "^8.58.2",
     "vite": "^7.3.1",
     "vitest": "^4.1.1"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "electron",
-      "esbuild",
-      "macos-alias",
-      "fs-xattr"
-    ],
-    "overrides": {
-      "@electron/notarize": "^3.1.1"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,14 @@
 packages:
   - '.'
   - 'packages/*'
+
+nodeLinker: hoisted
+
+overrides:
+  '@electron/notarize': ^3.1.1
+
+allowBuilds:
+  electron: true
+  esbuild: true
+  macos-alias: true
+  fs-xattr: true

--- a/scripts/dev-restart.sh
+++ b/scripts/dev-restart.sh
@@ -4,11 +4,11 @@
 #
 # Usage:
 #   pnpm dev:restart          — kill + restart in a new Terminal tab
-#   pnpm dev:restart:debug    — same, but with custom CDP port (default 9229 is always on)
+#   pnpm dev:restart:debug    — same, but with custom CDP port (default 9333 is always on)
 set -euo pipefail
 
-PROJECT_DIR="/Users/lyleklyne/Developer/web-canvas"
-CDP_PORT=9229
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CDP_PORT=9333
 APP_CONTROL_PORT=29979
 
 # ── Kill existing Specular processes ──────────────────────────────
@@ -21,8 +21,8 @@ pkill -9 -f "electron-forge start" 2>/dev/null || true
 
 # Kill orphaned Vite dev servers and node processes from the project directory.
 # These survive pkill -9 of the parent forge process.
-pgrep -f "node.*vite.*web-canvas" | xargs kill -9 2>/dev/null || true
-pgrep -f "node.*electron-forge.*web-canvas" | xargs kill -9 2>/dev/null || true
+pgrep -f "node.*vite.*${PROJECT_DIR}" | xargs kill -9 2>/dev/null || true
+pgrep -f "node.*electron-forge.*${PROJECT_DIR}" | xargs kill -9 2>/dev/null || true
 
 # Wait for CDP port to close
 for i in {1..10}; do

--- a/src/main/cdp-proxy.ts
+++ b/src/main/cdp-proxy.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
 import { webContents } from 'electron'
 import { WebSocket, type RawData } from 'ws'
+import { DEFAULT_REMOTE_DEBUGGING_PORT } from '../shared/constants'
 import type { UiSelection } from '../shared/types'
 import { activeSessions } from './presence-manager'
 import {
@@ -17,7 +18,10 @@ import { findPageById } from './runtime/runtime-context'
 
 export const APP_CONTROL_HOST = '127.0.0.1'
 const CDP_PROXY_TTL_MS = 5 * 60_000
-const REMOTE_DEBUGGING_PORT = Number.parseInt(process.env.SPECULAR_REMOTE_DEBUGGING_PORT ?? '9229', 10)
+const REMOTE_DEBUGGING_PORT = Number.parseInt(
+  process.env.SPECULAR_REMOTE_DEBUGGING_PORT ?? String(DEFAULT_REMOTE_DEBUGGING_PORT),
+  10,
+)
 const CDP_PROXY_LOG_DEBUG = process.env.SPECULAR_DEBUG_CDP_PROXY === '1'
 const CDP_PROXY_TIMING_DEBUG = process.env.SPECULAR_DEBUG_CDP_PROXY_TIMING === '1'
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,5 @@
 import { app, crashReporter, net, nativeTheme, protocol } from 'electron'
-import { DEFAULT_PAGES } from '../shared/constants'
+import { DEFAULT_PAGES, DEFAULT_REMOTE_DEBUGGING_PORT } from '../shared/constants'
 import { logCrash } from './crash-log'
 import {
   flushWorkspaceAutosaveSync,
@@ -81,7 +81,7 @@ app.on('render-process-gone', (_e, wc, details) => {
 })
 app.on('child-process-gone', (_e, details) => logCrash('child-process-gone', details))
 
-const remoteDebuggingPort = process.env.SPECULAR_REMOTE_DEBUGGING_PORT ?? '9229'
+const remoteDebuggingPort = process.env.SPECULAR_REMOTE_DEBUGGING_PORT ?? String(DEFAULT_REMOTE_DEBUGGING_PORT)
 app.commandLine.appendSwitch('remote-debugging-port', remoteDebuggingPort)
 app.commandLine.appendSwitch('remote-debugging-address', '127.0.0.1')
 app.commandLine.appendSwitch('enable-unsafe-webgpu')

--- a/src/renderer/onboarding/App.tsx
+++ b/src/renderer/onboarding/App.tsx
@@ -2,12 +2,16 @@ import { useCallback, useEffect, useMemo, useReducer, useState } from 'react'
 import type {
   OnboardingBootstrapData,
   OnboardingComponentId,
-  OnboardingComponentStatus,
   OnboardingElectronAPI,
   OnboardingProgressEvent,
   OnboardingStatusSnapshot,
 } from '../../shared/types'
 import { SkillInstaller, type InstallerRowSnapshot, type RowProgress } from '../shared/SkillInstaller'
+import {
+  defaultSelected,
+  hasInstallableSelection,
+  installableSelections,
+} from './onboardingSelection'
 
 type RowProgressMap = Record<OnboardingComponentId, { progress: RowProgress; detail?: string }>
 
@@ -34,16 +38,6 @@ function progressReducer(state: RowProgressMap, action: ProgressAction): RowProg
     case 'error':
       return { ...state, [action.id]: { progress: 'error', detail: action.detail } }
   }
-}
-
-function defaultSelected(status: OnboardingComponentStatus): boolean {
-  return status.kind !== 'installed'
-}
-
-function anyInstallable(
-  selections: Record<OnboardingComponentId, boolean>,
-): boolean {
-  return Object.values(selections).some(Boolean)
 }
 
 function allInstalledOrSkipped(
@@ -143,16 +137,17 @@ function SetupScreen({
   )
 
   const handleInstall = useCallback(async () => {
-    if (installing || !anyInstallable(selections)) return
+    const selectionsToInstall = installableSelections(status, selections)
+    if (installing || !hasInstallableSelection(status, selections)) return
     setInstalling(true)
     dispatchProgress({ kind: 'reset' })
     try {
-      const next = await api.install(selections)
+      const next = await api.install(selectionsToInstall)
       setStatus(next)
     } finally {
       setInstalling(false)
     }
-  }, [api, installing, selections])
+  }, [api, installing, status, selections])
 
   const isSettingsMode = initialData.mode === 'settings'
   const canFinish = allInstalledOrSkipped(status, progress)
@@ -218,7 +213,7 @@ function SetupScreen({
         <button
           type="button"
           className="rounded-[6px] bg-[var(--surface-toolbar-foreground)] px-4 py-[6px] text-[12px] font-medium text-[var(--surface-panel)] shadow-sm enabled:hover:opacity-90 disabled:opacity-50"
-          disabled={installing || (!canFinish && !anyInstallable(selections))}
+          disabled={installing || (!canFinish && !hasInstallableSelection(status, selections))}
           onClick={primaryAction}
         >
           {primaryLabel}

--- a/src/renderer/onboarding/App.tsx
+++ b/src/renderer/onboarding/App.tsx
@@ -76,7 +76,7 @@ function WelcomeScreen({ onContinue, onSkip }: { onContinue: () => void; onSkip:
         </button>
         <button
           type="button"
-          className="rounded-[6px] bg-emerald-600 px-4 py-[6px] text-[12px] font-medium text-white shadow-sm hover:bg-emerald-500"
+          className="rounded-[6px] bg-[var(--surface-toolbar-foreground)] px-4 py-[6px] text-[12px] font-medium text-[var(--surface-panel)] shadow-sm hover:opacity-90"
           onClick={onContinue}
         >
           Get started
@@ -149,23 +149,22 @@ function SetupScreen({
     try {
       const next = await api.install(selections)
       setStatus(next)
-      if (allInstalledOrSkipped(next, INITIAL_PROGRESS)) {
-        api.complete()
-      }
     } finally {
       setInstalling(false)
     }
   }, [api, installing, selections])
 
+  const isSettingsMode = initialData.mode === 'settings'
   const canFinish = allInstalledOrSkipped(status, progress)
   const primaryLabel = canFinish
-    ? 'Continue'
+    ? isSettingsMode
+      ? 'Done'
+      : 'Get started'
     : installing
       ? 'Installing\u2026'
       : 'Install selected'
 
   const primaryAction = canFinish ? () => api.complete() : handleInstall
-  const isSettingsMode = initialData.mode === 'settings'
 
   return (
     <div className="flex h-full flex-col">
@@ -218,7 +217,7 @@ function SetupScreen({
         </button>
         <button
           type="button"
-          className="rounded-[6px] bg-emerald-600 px-4 py-[6px] text-[12px] font-medium text-white shadow-sm enabled:hover:bg-emerald-500 disabled:opacity-50"
+          className="rounded-[6px] bg-[var(--surface-toolbar-foreground)] px-4 py-[6px] text-[12px] font-medium text-[var(--surface-panel)] shadow-sm enabled:hover:opacity-90 disabled:opacity-50"
           disabled={installing || (!canFinish && !anyInstallable(selections))}
           onClick={primaryAction}
         >

--- a/src/renderer/onboarding/onboardingSelection.ts
+++ b/src/renderer/onboarding/onboardingSelection.ts
@@ -1,0 +1,30 @@
+import type {
+  OnboardingComponentId,
+  OnboardingComponentStatus,
+  OnboardingStatusSnapshot,
+} from '../../shared/types'
+
+const ONBOARDING_COMPONENT_IDS: OnboardingComponentId[] = ['cli', 'skill', 'agentBrowser']
+
+export function defaultSelected(_status: OnboardingComponentStatus): boolean {
+  return true
+}
+
+export function installableSelections(
+  status: OnboardingStatusSnapshot,
+  selections: Record<OnboardingComponentId, boolean>,
+): Record<OnboardingComponentId, boolean> {
+  return Object.fromEntries(
+    ONBOARDING_COMPONENT_IDS.map((id) => [
+      id,
+      selections[id] && status[id].kind !== 'installed',
+    ]),
+  ) as Record<OnboardingComponentId, boolean>
+}
+
+export function hasInstallableSelection(
+  status: OnboardingStatusSnapshot,
+  selections: Record<OnboardingComponentId, boolean>,
+): boolean {
+  return Object.values(installableSelections(status, selections)).some(Boolean)
+}

--- a/src/renderer/settings/FixConfigPane.tsx
+++ b/src/renderer/settings/FixConfigPane.tsx
@@ -70,7 +70,7 @@ export function FixConfigPane({
             type="button"
             disabled={!dirty}
             onClick={() => api.setFixConfig({ model, permissions })}
-            className="rounded-[6px] bg-emerald-600 px-4 py-[6px] text-[12px] font-medium text-white shadow-sm enabled:hover:bg-emerald-500 disabled:opacity-50"
+            className="rounded-[6px] bg-[var(--surface-toolbar-foreground)] px-4 py-[6px] text-[12px] font-medium text-[var(--surface-panel)] shadow-sm enabled:hover:opacity-90 disabled:opacity-50"
           >
             Save
           </button>

--- a/src/renderer/settings/SkillsPane.tsx
+++ b/src/renderer/settings/SkillsPane.tsx
@@ -115,7 +115,7 @@ export function SkillsPane({
             <label
               key={row.id}
               title={title}
-              className={`flex items-start gap-3 rounded-[8px] border border-[var(--surface-popover-border)] bg-[var(--surface-popover-subtle)] px-4 py-3 select-none ${
+              className={`flex items-start gap-3 rounded-[8px] border border-[var(--surface-card-border)] bg-[var(--surface-card)] px-4 py-3 select-none ${
                 disabled ? 'cursor-not-allowed' : 'cursor-pointer'
               }`}
             >
@@ -149,7 +149,7 @@ export function SkillsPane({
                   disabled={disabled}
                   checked={installed}
                   onCheckedChange={(checked) => handleToggle(row.id, checked)}
-                  className="relative inline-flex h-[18px] w-[32px] shrink-0 cursor-pointer items-center rounded-full border border-[var(--surface-popover-border)] bg-[var(--surface-input)] transition-colors data-[checked]:border-transparent data-[checked]:bg-[var(--surface-toolbar-foreground)] data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
+                  className="relative inline-flex h-[18px] w-[32px] shrink-0 cursor-pointer items-center rounded-full border border-[var(--surface-switch-track-border)] bg-[var(--surface-switch-track)] transition-colors data-[checked]:border-[var(--surface-switch-track-checked-border)] data-[checked]:bg-[var(--surface-switch-track-checked)] data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
                 >
                   <Switch.Thumb className="block h-[14px] w-[14px] translate-x-[1px] rounded-full bg-white shadow-sm transition-transform data-[checked]:translate-x-[15px]" />
                 </Switch.Root>

--- a/src/renderer/settings/SkillsPane.tsx
+++ b/src/renderer/settings/SkillsPane.tsx
@@ -149,7 +149,7 @@ export function SkillsPane({
                   disabled={disabled}
                   checked={installed}
                   onCheckedChange={(checked) => handleToggle(row.id, checked)}
-                  className="relative inline-flex h-[18px] w-[32px] shrink-0 cursor-pointer items-center rounded-full border border-[var(--surface-popover-border)] bg-[var(--surface-input)] transition-colors data-[checked]:border-transparent data-[checked]:bg-emerald-500 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
+                  className="relative inline-flex h-[18px] w-[32px] shrink-0 cursor-pointer items-center rounded-full border border-[var(--surface-popover-border)] bg-[var(--surface-input)] transition-colors data-[checked]:border-transparent data-[checked]:bg-[var(--surface-toolbar-foreground)] data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
                 >
                   <Switch.Thumb className="block h-[14px] w-[14px] translate-x-[1px] rounded-full bg-white shadow-sm transition-transform data-[checked]:translate-x-[15px]" />
                 </Switch.Root>

--- a/src/renderer/shared/SkillInstaller.tsx
+++ b/src/renderer/shared/SkillInstaller.tsx
@@ -52,9 +52,8 @@ function Root({
 
 function rowBaseClass(progress: RowProgress): string {
   const base =
-    'flex items-start gap-3 rounded-[8px] border border-[var(--surface-popover-border)] bg-[var(--surface-popover-subtle)] px-4 py-3 text-left cursor-pointer select-none'
+    'flex items-start gap-3 rounded-[8px] border border-[var(--surface-card-border)] bg-[var(--surface-card)] px-4 py-3 text-left cursor-pointer select-none'
   if (progress === 'installing') return `${base} opacity-90 cursor-not-allowed`
-  if (progress === 'success') return `${base} border-[var(--surface-toolbar-foreground)]/40`
   if (progress === 'error') return `${base} border-red-500/50`
   return base
 }
@@ -88,7 +87,7 @@ function Row({
           disabled={snapshot.progress === 'installing'}
           checked={snapshot.selected}
           onCheckedChange={(checked) => setSelected(id, checked)}
-          className="relative inline-flex h-[18px] w-[32px] shrink-0 cursor-pointer items-center rounded-full border border-[var(--surface-popover-border)] bg-[var(--surface-input)] transition-colors data-[checked]:border-transparent data-[checked]:bg-[var(--surface-toolbar-foreground)] data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
+          className="relative inline-flex h-[18px] w-[32px] shrink-0 cursor-pointer items-center rounded-full border border-[var(--surface-switch-track-border)] bg-[var(--surface-switch-track)] transition-colors data-[checked]:border-[var(--surface-switch-track-checked-border)] data-[checked]:bg-[var(--surface-switch-track-checked)] data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
         >
           <Switch.Thumb className="block h-[14px] w-[14px] translate-x-[1px] rounded-full bg-white shadow-sm transition-transform data-[checked]:translate-x-[15px]" />
         </Switch.Root>

--- a/src/renderer/shared/SkillInstaller.tsx
+++ b/src/renderer/shared/SkillInstaller.tsx
@@ -54,7 +54,7 @@ function rowBaseClass(progress: RowProgress): string {
   const base =
     'flex items-start gap-3 rounded-[8px] border border-[var(--surface-popover-border)] bg-[var(--surface-popover-subtle)] px-4 py-3 text-left cursor-pointer select-none'
   if (progress === 'installing') return `${base} opacity-90 cursor-not-allowed`
-  if (progress === 'success') return `${base} border-emerald-500/40`
+  if (progress === 'success') return `${base} border-[var(--surface-toolbar-foreground)]/40`
   if (progress === 'error') return `${base} border-red-500/50`
   return base
 }
@@ -88,7 +88,7 @@ function Row({
           disabled={snapshot.progress === 'installing'}
           checked={snapshot.selected}
           onCheckedChange={(checked) => setSelected(id, checked)}
-          className="relative inline-flex h-[18px] w-[32px] shrink-0 cursor-pointer items-center rounded-full border border-[var(--surface-popover-border)] bg-[var(--surface-input)] transition-colors data-[checked]:border-transparent data-[checked]:bg-emerald-500 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
+          className="relative inline-flex h-[18px] w-[32px] shrink-0 cursor-pointer items-center rounded-full border border-[var(--surface-popover-border)] bg-[var(--surface-input)] transition-colors data-[checked]:border-transparent data-[checked]:bg-[var(--surface-toolbar-foreground)] data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
         >
           <Switch.Thumb className="block h-[14px] w-[14px] translate-x-[1px] rounded-full bg-white shadow-sm transition-transform data-[checked]:translate-x-[15px]" />
         </Switch.Root>
@@ -108,7 +108,7 @@ function StatusBadge({ snapshot }: { snapshot: InstallerRowSnapshot }) {
   }
   if (snapshot.progress === 'success' || snapshot.status.kind === 'installed') {
     return (
-      <span className="flex shrink-0 items-center gap-1 text-[11px] font-medium text-emerald-600 dark:text-emerald-400">
+      <span className="flex shrink-0 items-center gap-1 text-[11px] font-medium text-[var(--surface-toolbar-foreground)]">
         <Check size={12} strokeWidth={3} />
         Installed
       </span>

--- a/src/renderer/shared/surfaceTheme.css
+++ b/src/renderer/shared/surfaceTheme.css
@@ -12,10 +12,16 @@
   --surface-popover: var(--color-stone-200);
   --surface-popover-subtle: var(--color-stone-100);
   --surface-popover-border: var(--color-stone-200);
+  --surface-card: var(--surface-popover-subtle);
+  --surface-card-border: var(--surface-input-border);
   --surface-popup: var(--color-stone-50);
   --surface-popup-border: var(--surface-chrome-border);
   --surface-input: var(--color-stone-50);
   --surface-input-border: var(--color-stone-300);
+  --surface-switch-track: var(--surface-input);
+  --surface-switch-track-border: var(--surface-input-border);
+  --surface-switch-track-checked: var(--surface-toolbar-foreground);
+  --surface-switch-track-checked-border: var(--surface-toolbar-foreground);
   --surface-device: var(--color-stone-300);
   --surface-device-border: var(--color-stone-400);
 }
@@ -34,10 +40,16 @@
   --surface-popover: var(--color-stone-800);
   --surface-popover-subtle: var(--color-stone-900);
   --surface-popover-border: var(--color-stone-600);
+  --surface-card: color-mix(in srgb, var(--color-stone-800) 68%, var(--color-stone-900) 32%);
+  --surface-card-border: color-mix(in srgb, var(--color-stone-700) 58%, transparent);
   --surface-popup: color-mix(in srgb, var(--surface-panel) 45%, var(--color-stone-700) 55%);
   --surface-popup-border: var(--surface-chrome-border);
   --surface-input: color-mix(in srgb, var(--color-stone-900) 90%, transparent);
   --surface-input-border: color-mix(in srgb, var(--color-stone-700) 80%, transparent);
+  --surface-switch-track: var(--surface-input);
+  --surface-switch-track-border: var(--surface-input-border);
+  --surface-switch-track-checked: var(--surface-input);
+  --surface-switch-track-checked-border: var(--surface-input-border);
   --surface-device: var(--color-stone-800);
   --surface-device-border: var(--color-stone-600);
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -14,6 +14,7 @@ export const CLUSTER_OUTER_MARGIN = 80
 export const PLACEMENT_SCAN_STEP = GRID_SIZE
 export const ANCHOR_OFFSET_X = 80
 export const ANCHOR_OFFSET_Y = 0
+export const DEFAULT_REMOTE_DEBUGGING_PORT = 9333
 export const APP_CONTROL_PORT = 29979
 export const APP_CONTROL_VERSION = '1'
 export const APP_CONTROL_DISCOVERY_FILE = 'specular-mcp.json'

--- a/tests/unit/onboarding-selection.test.ts
+++ b/tests/unit/onboarding-selection.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import type { OnboardingComponentId, OnboardingStatusSnapshot } from '../../src/shared/types'
+import {
+  defaultSelected,
+  hasInstallableSelection,
+  installableSelections,
+} from '../../src/renderer/onboarding/onboardingSelection'
+
+const baseStatus: OnboardingStatusSnapshot = {
+  cli: { kind: 'missing' },
+  skill: { kind: 'missing' },
+  agentBrowser: { kind: 'missing' },
+  claudeDirExists: true,
+}
+
+function selections(value: boolean): Record<OnboardingComponentId, boolean> {
+  return { cli: value, skill: value, agentBrowser: value }
+}
+
+describe('onboarding selection helpers', () => {
+  it('defaults installed rows to visually selected', () => {
+    expect(defaultSelected({ kind: 'installed' })).toBe(true)
+  })
+
+  it('does not submit already-installed rows for installation', () => {
+    const status: OnboardingStatusSnapshot = {
+      ...baseStatus,
+      cli: { kind: 'installed' },
+      skill: { kind: 'outdated', detail: 'New bundled version available.' },
+    }
+
+    expect(installableSelections(status, selections(true))).toEqual({
+      cli: false,
+      skill: true,
+      agentBrowser: true,
+    })
+  })
+
+  it('ignores checked installed rows when deciding if install can run', () => {
+    const status: OnboardingStatusSnapshot = {
+      cli: { kind: 'installed' },
+      skill: { kind: 'installed' },
+      agentBrowser: { kind: 'installed' },
+      claudeDirExists: true,
+    }
+
+    expect(hasInstallableSelection(status, selections(true))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Move pnpm 11 project settings into `pnpm-workspace.yaml` so Forge sees the hoisted linker and renderer dependency resolution works again.
- Change Specular's default Electron remote debugging port from `9229` to `9333`, keep the CDP proxy in sync through a shared constant, and fix `dev:restart`'s stale project path.
- Soften setup/settings skill card backgrounds and borders in dark mode, keep installed-card borders stable after install, and restore already-installed rows to toggled-on in the setup wizard.
- Add unit coverage for onboarding selection behavior so installed rows show enabled without being submitted for reinstall.

## Validation

- `pnpm dev` launches successfully.
- `pnpm vitest run --config vitest.unit.config.ts tests/unit/onboarding-selection.test.ts`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm test:smoke` was run; CDP proxy coverage passed, but one existing screenshot smoke test failed locally with `Current display surface not available for capture`, which appears tied to display capture availability rather than this change.
