### PR TITLE
Prevent native browser selection on inline images

### DIFF
--- a/src/renderer/canvas-bg/entity-renderers/ImageInlineRenderer.tsx
+++ b/src/renderer/canvas-bg/entity-renderers/ImageInlineRenderer.tsx
@@ -13,6 +13,10 @@ export function ImageInlineRenderer({ entity }: { entity: CanvasSceneFileEntity 
         height: '100%',
         objectFit: entity.objectFit ?? 'contain',
         pointerEvents: 'none',
+        // Defer selection to Specular's own selection system; the native
+        // browser selection can otherwise leave images in a stuck highlighted state.
+        userSelect: 'none',
+        WebkitUserSelect: 'none',
       }}
     />
   )


### PR DESCRIPTION
## Summary
Disable native browser text selection on inline image entities to prevent images from becoming stuck in a highlighted state when users interact with them on the canvas.

## Changes
- Added `userSelect: 'none'` and `WebkitUserSelect: 'none'` CSS properties to the `<img>` element in `ImageInlineRenderer`
- This defers selection behavior to Specular's own selection system instead of allowing the browser's default selection mechanism

## Implementation details
The change prevents a UX issue where images could remain visually highlighted after interaction. By disabling native browser selection, we ensure that image selection is handled consistently through Specular's canvas selection system rather than the browser's default text/element selection behavior.

https://claude.ai/code/session_01YB8yWMhQeiZorh5YZ9sWgW